### PR TITLE
Add WalletIQ to ecosystem (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/walletiq/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/walletiq/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "WalletIQ",
+  "description": "Wallet intelligence API for EVM addresses. One call returns a full wallet profile: age, activity score, DeFi protocols, risk score, and on-chain labels. Pay $0.005/lookup via x402 in USDC on Base — no API key, no signup.",
+  "logoUrl": "/logos/walletiq.svg",
+  "websiteUrl": "https://walletiq.dev",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/walletiq.svg
+++ b/typescript/site/public/logos/walletiq.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="32" fill="#0f172a"/>
+  <text x="100" y="88" font-family="monospace,sans-serif" font-size="52" font-weight="bold" fill="#38bdf8" text-anchor="middle">W</text>
+  <text x="100" y="138" font-family="monospace,sans-serif" font-size="22" font-weight="600" fill="#94a3b8" text-anchor="middle" letter-spacing="2">IQ</text>
+  <circle cx="100" cy="155" r="4" fill="#38bdf8" opacity="0.6"/>
+</svg>


### PR DESCRIPTION
## WalletIQ — Wallet Intelligence API

**Category:** Services/Endpoints

**Website:** https://walletiq.dev

**Description:**
Wallet intelligence API for EVM addresses. One call returns a full wallet profile: age, activity score, DeFi protocols, risk score, and on-chain labels. Pay $0.005/lookup via x402 in USDC on Base — no API key, no signup.

**x402 Integration:**
- Endpoint: `GET /api/v1/x402/profile/{address}`
- Price: $0.005 USDC per lookup
- Network: Base mainnet (`eip155:8453`) + Avalanche C-Chain (`eip155:43114`)
- Scheme: `exact` (x402 v2)
- Facilitators: AutoIncentive (Base) + PayAI (Avalanche)
- No API key required — agents pay directly on-chain

**Changes:**
- `typescript/site/app/ecosystem/partners-data/walletiq/metadata.json`
- `typescript/site/public/logos/walletiq.svg`
