### PR TITLE
Add satoshidata.ai to ecosystem — Bitcoin chain intelligence API

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/satoshidata/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/satoshidata/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "satoshidata.ai",
+  "description": "Bitcoin wallet intelligence API with 33M+ labeled addresses. Trust scores, entity labels, and network analytics via x402-gated micropayments on Lightning Network. No API key, no signup \u2014 agents pay per request.",
+  "logoUrl": "/logos/satoshidata.svg",
+  "websiteUrl": "https://satoshidata.ai",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/satoshidata.svg
+++ b/typescript/site/public/logos/satoshidata.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="blue-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2563EB"/>
+      <stop offset="100%" stop-color="#4D94FF"/>
+    </linearGradient>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="#000" flood-opacity="0.25"/>
+    </filter>
+  </defs>
+  <rect x="18" y="28" width="72" height="72" rx="16" fill="#B8C4D0" opacity="0.6"/>
+  <rect x="110" y="100" width="72" height="72" rx="16" fill="#B8C4D0" opacity="0.6"/>
+  <rect x="48" y="48" width="104" height="104" rx="22" fill="url(#blue-grad)" filter="url(#shadow)"/>
+  <rect x="62" y="50" width="76" height="2.5" rx="1.2" fill="#fff" opacity="0.15"/>
+  <text x="100" y="122" font-family="Inter, -apple-system, sans-serif" font-size="62" font-weight="800" fill="#fff" text-anchor="middle" letter-spacing="-1">AI</text>
+</svg>


### PR DESCRIPTION
## satoshidata.ai — Bitcoin Chain Intelligence API

**Category:** Services/Endpoints

**Website:** https://satoshidata.ai

**Description:**
Bitcoin chain intelligence API with pay-per-call endpoints via x402 on Base mainnet. Address attribution from 33M+ labeled addresses, trust scoring, transaction verification, and Bitcoin timestamping. No API key required — agents pay directly in USDC.

**x402 Endpoints (USDC on Base):**
| Endpoint | Price | Description |
|---|---|---|
| `GET /v1/wallets/{address}/summary` | $0.01 | Chain intelligence summary — entity labels, balance, evidence |
| `GET /v1/wallets/{address}/detail` | $0.01 | Detailed label evidence breakdown |
| `POST /v1/tx/verify` | $0.01 | Payment verification with amount/confirmation checks |

**Free Endpoints (no auth):**
| Endpoint | Description |
|---|---|
| `GET /v1/wallets/{address}/trust-safety` | Trust score, entity labels, risk flags |
| `GET /v1/network/summary` | Block height, fees, mempool, price |
| `GET /v1/price` | BTC price snapshot |
| `GET /v1/fees/recommended` | Fee-rate recommendations |
| `GET /v1/mempool/stats` | Mempool state |
| `GET /v1/tx/{txid}/status` | Transaction confirmation status |

**x402 Integration:**
- Network: Base mainnet (`eip155:8453`)
- Scheme: `exact`
- Asset: USDC
- Facilitator: Coinbase Developer Platform (CDP)
- All paid endpoints return proper `402 Payment Required` with x402 headers

**Also available as:**
- MCP server: `https://satoshidata.ai/mcp/` (Streamable HTTP)
- Lightning (L402): native 21-sat per-call pricing
- API key bridge: $4.99/month

**Machine discovery:**
- OpenAPI: https://satoshidata.ai/openapi.json
- Agent card: https://satoshidata.ai/.well-known/agent-card.json
- MCP card: https://satoshidata.ai/.well-known/mcp.json
- Capabilities: https://satoshidata.ai/v1/capabilities
- llms.txt: https://satoshidata.ai/llms.txt

**Changes:**
- Added `satoshidata.ai` entry to ecosystem partners data