### PR TITLE
[codex] isolate hook failures and harden facilitator settlement flows

### DIFF
--- a/go/.changes/unreleased/fixed-20260403-crypto-rand.yaml
+++ b/go/.changes/unreleased/fixed-20260403-crypto-rand.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: Switched SVM facilitator fee-payer selection to crypto/rand and safely handle empty signer pools when generating extra metadata
+time: 2026-04-03T12:00:00-07:00

--- a/go/mechanisms/svm/exact/facilitator/duplicate_tx_test.go
+++ b/go/mechanisms/svm/exact/facilitator/duplicate_tx_test.go
@@ -1,10 +1,13 @@
 package facilitator
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	x402 "github.com/coinbase/x402/go"
 	"github.com/coinbase/x402/go/mechanisms/svm"
+	solana "github.com/gagliardetto/solana-go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -85,4 +88,45 @@ func TestDuplicateSettlementCache(t *testing.T) {
 		assert.Same(t, cache, scheme.settlementCache,
 			"scheme should hold the exact cache instance that was injected")
 	})
+}
+
+func TestGetExtraReturnsManagedFeePayer(t *testing.T) {
+	addresses := []solana.PublicKey{
+		solana.MustPublicKeyFromBase58(svm.MemoProgramAddress),
+		solana.MustPublicKeyFromBase58(svm.LighthouseProgramAddress),
+	}
+	scheme := NewExactSvmScheme(mockFacilitatorSvmSigner{addresses: addresses})
+
+	extra := scheme.GetExtra(x402.Network("solana:mainnet"))
+
+	feePayer, ok := extra["feePayer"].(string)
+	if !ok {
+		t.Fatalf("expected feePayer string, got %T", extra["feePayer"])
+	}
+
+	assert.Contains(t, []string{addresses[0].String(), addresses[1].String()}, feePayer)
+}
+
+type mockFacilitatorSvmSigner struct {
+	addresses []solana.PublicKey
+}
+
+func (m mockFacilitatorSvmSigner) GetAddresses(context.Context, string) []solana.PublicKey {
+	return m.addresses
+}
+
+func (mockFacilitatorSvmSigner) SignTransaction(context.Context, *solana.Transaction, solana.PublicKey, string) error {
+	return nil
+}
+
+func (mockFacilitatorSvmSigner) SimulateTransaction(context.Context, *solana.Transaction, string) error {
+	return nil
+}
+
+func (mockFacilitatorSvmSigner) SendTransaction(context.Context, *solana.Transaction, string) (solana.Signature, error) {
+	return solana.Signature{}, nil
+}
+
+func (mockFacilitatorSvmSigner) ConfirmTransaction(context.Context, solana.Signature, string) error {
+	return nil
 }

--- a/go/mechanisms/svm/exact/facilitator/scheme.go
+++ b/go/mechanisms/svm/exact/facilitator/scheme.go
@@ -2,9 +2,10 @@ package facilitator
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"strconv"
 
 	solana "github.com/gagliardetto/solana-go"
@@ -53,13 +54,29 @@ func (f *ExactSvmScheme) CaipFamily() string {
 // Random selection distributes load across multiple signers.
 func (f *ExactSvmScheme) GetExtra(network x402.Network) map[string]interface{} {
 	addresses := f.signer.GetAddresses(context.Background(), string(network))
+	if len(addresses) == 0 {
+		return map[string]interface{}{}
+	}
 
 	// Randomly select from available addresses to distribute load
-	randomIndex := rand.Intn(len(addresses))
+	randomIndex := randomAddressIndex(len(addresses))
 
 	return map[string]interface{}{
 		"feePayer": addresses[randomIndex].String(),
 	}
+}
+
+func randomAddressIndex(addressCount int) int {
+	if addressCount <= 1 {
+		return 0
+	}
+
+	randomValue, err := rand.Int(rand.Reader, big.NewInt(int64(addressCount)))
+	if err != nil {
+		return 0
+	}
+
+	return int(randomValue.Int64())
 }
 
 // GetSigners returns signer addresses used by this facilitator.

--- a/go/mechanisms/svm/exact/v1/facilitator/duplicate_tx_test.go
+++ b/go/mechanisms/svm/exact/v1/facilitator/duplicate_tx_test.go
@@ -1,10 +1,13 @@
 package facilitator
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	x402 "github.com/coinbase/x402/go"
 	"github.com/coinbase/x402/go/mechanisms/svm"
+	solana "github.com/gagliardetto/solana-go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -113,4 +116,45 @@ func TestDuplicateSettlementCacheV1(t *testing.T) {
 		assert.True(t, cache.IsDuplicate("new-2"), "fresh entry should still be cached")
 		assert.True(t, cache.IsDuplicate("new-3"), "fresh entry should still be cached")
 	})
+}
+
+func TestGetExtraReturnsManagedFeePayerV1(t *testing.T) {
+	addresses := []solana.PublicKey{
+		solana.MustPublicKeyFromBase58(svm.MemoProgramAddress),
+		solana.MustPublicKeyFromBase58(svm.LighthouseProgramAddress),
+	}
+	scheme := NewExactSvmSchemeV1(mockFacilitatorSvmSignerV1{addresses: addresses})
+
+	extra := scheme.GetExtra(x402.Network("solana:mainnet"))
+
+	feePayer, ok := extra["feePayer"].(string)
+	if !ok {
+		t.Fatalf("expected feePayer string, got %T", extra["feePayer"])
+	}
+
+	assert.Contains(t, []string{addresses[0].String(), addresses[1].String()}, feePayer)
+}
+
+type mockFacilitatorSvmSignerV1 struct {
+	addresses []solana.PublicKey
+}
+
+func (m mockFacilitatorSvmSignerV1) GetAddresses(context.Context, string) []solana.PublicKey {
+	return m.addresses
+}
+
+func (mockFacilitatorSvmSignerV1) SignTransaction(context.Context, *solana.Transaction, solana.PublicKey, string) error {
+	return nil
+}
+
+func (mockFacilitatorSvmSignerV1) SimulateTransaction(context.Context, *solana.Transaction, string) error {
+	return nil
+}
+
+func (mockFacilitatorSvmSignerV1) SendTransaction(context.Context, *solana.Transaction, string) (solana.Signature, error) {
+	return solana.Signature{}, nil
+}
+
+func (mockFacilitatorSvmSignerV1) ConfirmTransaction(context.Context, solana.Signature, string) error {
+	return nil
 }

--- a/go/mechanisms/svm/exact/v1/facilitator/scheme.go
+++ b/go/mechanisms/svm/exact/v1/facilitator/scheme.go
@@ -2,10 +2,11 @@ package facilitator
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"strconv"
 
 	solana "github.com/gagliardetto/solana-go"
@@ -54,13 +55,29 @@ func (f *ExactSvmSchemeV1) CaipFamily() string {
 // Random selection distributes load across multiple signers.
 func (f *ExactSvmSchemeV1) GetExtra(network x402.Network) map[string]interface{} {
 	addresses := f.signer.GetAddresses(context.Background(), string(network))
+	if len(addresses) == 0 {
+		return map[string]interface{}{}
+	}
 
 	// Randomly select from available addresses to distribute load
-	randomIndex := rand.Intn(len(addresses))
+	randomIndex := randomAddressIndex(len(addresses))
 
 	return map[string]interface{}{
 		"feePayer": addresses[randomIndex].String(),
 	}
+}
+
+func randomAddressIndex(addressCount int) int {
+	if addressCount <= 1 {
+		return 0
+	}
+
+	randomValue, err := rand.Int(rand.Reader, big.NewInt(int64(addressCount)))
+	if err != nil {
+		return 0
+	}
+
+	return int(randomValue.Int64())
 }
 
 // GetSigners returns signer addresses used by this facilitator.

--- a/python/x402/changelog.d/1846.bugfix.md
+++ b/python/x402/changelog.d/1846.bugfix.md
@@ -1,0 +1,1 @@
+Made FacilitatorWeb3Signer gas limits configurable with a signer-wide default and optional per-transaction override.

--- a/python/x402/mechanisms/evm/signer.py
+++ b/python/x402/mechanisms/evm/signer.py
@@ -109,6 +109,7 @@ class FacilitatorEvmSigner(Protocol):
         abi: list[dict[str, Any]],
         function_name: str,
         *args: Any,
+        gas: int | None = None,
     ) -> str:
         """Execute a smart contract transaction.
 
@@ -117,18 +118,20 @@ class FacilitatorEvmSigner(Protocol):
             abi: Contract ABI.
             function_name: Function to call.
             *args: Function arguments.
+            gas: Optional per-call gas limit override.
 
         Returns:
             Transaction hash.
         """
         ...
 
-    def send_transaction(self, to: str, data: bytes) -> str:
+    def send_transaction(self, to: str, data: bytes, *, gas: int | None = None) -> str:
         """Send raw transaction.
 
         Args:
             to: Recipient address.
             data: Transaction data.
+            gas: Optional per-call gas limit override.
 
         Returns:
             Transaction hash.

--- a/python/x402/mechanisms/evm/signers.py
+++ b/python/x402/mechanisms/evm/signers.py
@@ -258,17 +258,20 @@ class FacilitatorWeb3Signer:
         address: The signer's checksummed Ethereum address.
     """
 
+    DEFAULT_GAS_LIMIT = 300_000
+
     def __init__(
         self,
         private_key: str,
         rpc_url: str,
+        gas_limit: int = DEFAULT_GAS_LIMIT,
     ) -> None:
         """Initialize signer with private key and RPC connection.
 
         Args:
             private_key: Hex private key with or without 0x prefix.
             rpc_url: Ethereum RPC endpoint URL.
-
+            gas_limit: Default gas limit to use for settlement transactions.
         """
         # Normalize private key format
         if not private_key.startswith("0x"):
@@ -282,6 +285,7 @@ class FacilitatorWeb3Signer:
 
         # Cache chain ID
         self._chain_id: int | None = None
+        self._gas_limit = gas_limit
 
     @property
     def address(self) -> str:
@@ -453,6 +457,7 @@ class FacilitatorWeb3Signer:
         abi: list[dict[str, Any]],
         function_name: str,
         *args: Any,
+        gas: int | None = None,
     ) -> str:
         """Execute a smart contract transaction.
 
@@ -461,6 +466,7 @@ class FacilitatorWeb3Signer:
             abi: Contract ABI.
             function_name: Function to call.
             *args: Function arguments.
+            gas: Optional per-call gas limit override.
 
         Returns:
             Transaction hash.
@@ -476,7 +482,7 @@ class FacilitatorWeb3Signer:
             {
                 "from": self._account.address,
                 "nonce": self._w3.eth.get_transaction_count(self._account.address),
-                "gas": 300000,
+                "gas": gas if gas is not None else self._gas_limit,
                 "gasPrice": self._w3.eth.gas_price,
             }
         )
@@ -487,12 +493,13 @@ class FacilitatorWeb3Signer:
 
         return tx_hash.hex()
 
-    def send_transaction(self, to: str, data: bytes) -> str:
+    def send_transaction(self, to: str, data: bytes, *, gas: int | None = None) -> str:
         """Send a raw transaction.
 
         Args:
             to: Recipient address.
             data: Transaction data.
+            gas: Optional per-call gas limit override.
 
         Returns:
             Transaction hash.
@@ -502,7 +509,7 @@ class FacilitatorWeb3Signer:
             "to": Web3.to_checksum_address(to),
             "data": data,
             "nonce": self._w3.eth.get_transaction_count(self._account.address),
-            "gas": 300000,
+            "gas": gas if gas is not None else self._gas_limit,
             "gasPrice": self._w3.eth.gas_price,
         }
 

--- a/python/x402/tests/unit/mechanisms/evm/test_facilitator.py
+++ b/python/x402/tests/unit/mechanisms/evm/test_facilitator.py
@@ -227,11 +227,18 @@ class MockFacilitatorSigner:
     ) -> bool:
         return self.typed_data_valid
 
-    def write_contract(self, address: str, abi: list[dict], function_name: str, *args) -> str:
+    def write_contract(
+        self,
+        address: str,
+        abi: list[dict],
+        function_name: str,
+        *args,
+        gas: int | None = None,
+    ) -> str:
         self.write_calls += 1
         return "0x" + "34" * 32
 
-    def send_transaction(self, to: str, data: bytes) -> str:
+    def send_transaction(self, to: str, data: bytes, *, gas: int | None = None) -> str:
         self.send_calls += 1
         return self.deploy_tx_hash
 

--- a/python/x402/tests/unit/mechanisms/evm/test_permit2.py
+++ b/python/x402/tests/unit/mechanisms/evm/test_permit2.py
@@ -152,11 +152,18 @@ class MockFacilitatorSigner:
     def verify_typed_data(self, *args: Any, **kwargs: Any) -> bool:
         return self._sig_valid
 
-    def write_contract(self, address: str, abi: list[dict], function_name: str, *args) -> str:
+    def write_contract(
+        self,
+        address: str,
+        abi: list[dict],
+        function_name: str,
+        *args,
+        gas: int | None = None,
+    ) -> str:
         self.write_calls.append((address, function_name, args))
         return "0x" + "ab" * 32
 
-    def send_transaction(self, to: str, data: bytes) -> str:
+    def send_transaction(self, to: str, data: bytes, *, gas: int | None = None) -> str:
         return "0x" + "cd" * 32
 
     def wait_for_transaction_receipt(self, tx_hash: str) -> TransactionReceipt:

--- a/python/x402/tests/unit/mechanisms/evm/test_signer.py
+++ b/python/x402/tests/unit/mechanisms/evm/test_signer.py
@@ -1,5 +1,7 @@
 """Tests for EVM signer implementations."""
 
+from types import SimpleNamespace
+
 import pytest
 
 try:
@@ -8,6 +10,68 @@ except ImportError:
     pytest.skip("EVM signers require eth_account", allow_module_level=True)
 
 from x402.mechanisms.evm.signers import EthAccountSigner, FacilitatorWeb3Signer
+
+
+class _FakeBuiltTx:
+    def __init__(self, raw_transaction: bytes):
+        self.raw_transaction = raw_transaction
+
+
+class _FakeContractCall:
+    def __init__(self, sink: dict):
+        self._sink = sink
+
+    def build_transaction(self, tx: dict) -> dict:
+        self._sink["tx"] = tx
+        return tx
+
+
+class _FakeContractFunctions:
+    def __init__(self, sink: dict):
+        self._sink = sink
+
+    def __getattr__(self, _name: str):
+        def caller(*args):
+            self._sink["args"] = args
+            return _FakeContractCall(self._sink)
+
+        return caller
+
+
+class _FakeContract:
+    def __init__(self, sink: dict):
+        self.functions = _FakeContractFunctions(sink)
+
+
+class _FakeEth:
+    def __init__(self, contract_sink: dict | None = None):
+        self.contract_sink = contract_sink
+        self.gas_price = 123456
+        self.sent_raw_transaction: bytes | None = None
+
+    def contract(self, address: str, abi: list[dict]):
+        if self.contract_sink is None:
+            raise AssertionError("contract() should not be called in this test")
+        self.contract_sink["address"] = address
+        self.contract_sink["abi"] = abi
+        return _FakeContract(self.contract_sink)
+
+    def get_transaction_count(self, _address: str) -> int:
+        return 7
+
+    def send_raw_transaction(self, raw_transaction: bytes) -> bytes:
+        self.sent_raw_transaction = raw_transaction
+        return bytes.fromhex("12" * 32)
+
+
+class _FakeSignerAccount:
+    def __init__(self, address: str):
+        self.address = address
+        self.signed_txs: list[dict] = []
+
+    def sign_transaction(self, tx: dict) -> _FakeBuiltTx:
+        self.signed_txs.append(tx)
+        return _FakeBuiltTx(b"signed")
 
 
 class TestEthAccountSigner:
@@ -152,6 +216,89 @@ class TestFacilitatorWeb3Signer:
         assert callable(signer.get_balance)
         assert callable(signer.get_chain_id)
         assert callable(signer.get_code)
+
+    def test_write_contract_should_use_configured_default_gas_limit(self):
+        account = Account.create()
+        signer = FacilitatorWeb3Signer(
+            private_key=account.key.hex(),
+            rpc_url="https://sepolia.base.org",
+            gas_limit=450000,
+        )
+        contract_sink: dict = {}
+        fake_eth = _FakeEth(contract_sink)
+        fake_account = _FakeSignerAccount(account.address)
+        signer._w3 = SimpleNamespace(eth=fake_eth)
+        signer._account = fake_account
+
+        signer.write_contract(
+            "0x1234567890123456789012345678901234567890",
+            [],
+            "transferWithAuthorization",
+            "arg1",
+        )
+
+        assert contract_sink["tx"]["gas"] == 450000
+        assert fake_account.signed_txs[0]["gas"] == 450000
+
+    def test_write_contract_should_allow_per_call_gas_override(self):
+        account = Account.create()
+        signer = FacilitatorWeb3Signer(
+            private_key=account.key.hex(),
+            rpc_url="https://sepolia.base.org",
+            gas_limit=450000,
+        )
+        contract_sink: dict = {}
+        fake_eth = _FakeEth(contract_sink)
+        fake_account = _FakeSignerAccount(account.address)
+        signer._w3 = SimpleNamespace(eth=fake_eth)
+        signer._account = fake_account
+
+        signer.write_contract(
+            "0x1234567890123456789012345678901234567890",
+            [],
+            "transferWithAuthorization",
+            "arg1",
+            gas=510000,
+        )
+
+        assert contract_sink["tx"]["gas"] == 510000
+        assert fake_account.signed_txs[0]["gas"] == 510000
+
+    def test_send_transaction_should_use_configured_default_gas_limit(self):
+        account = Account.create()
+        signer = FacilitatorWeb3Signer(
+            private_key=account.key.hex(),
+            rpc_url="https://sepolia.base.org",
+            gas_limit=450000,
+        )
+        fake_eth = _FakeEth()
+        fake_account = _FakeSignerAccount(account.address)
+        signer._w3 = SimpleNamespace(eth=fake_eth)
+        signer._account = fake_account
+
+        signer.send_transaction("0x1234567890123456789012345678901234567890", b"\x01\x02")
+
+        assert fake_account.signed_txs[0]["gas"] == 450000
+
+    def test_send_transaction_should_allow_per_call_gas_override(self):
+        account = Account.create()
+        signer = FacilitatorWeb3Signer(
+            private_key=account.key.hex(),
+            rpc_url="https://sepolia.base.org",
+            gas_limit=450000,
+        )
+        fake_eth = _FakeEth()
+        fake_account = _FakeSignerAccount(account.address)
+        signer._w3 = SimpleNamespace(eth=fake_eth)
+        signer._account = fake_account
+
+        signer.send_transaction(
+            "0x1234567890123456789012345678901234567890",
+            b"\x01\x02",
+            gas=510000,
+        )
+
+        assert fake_account.signed_txs[0]["gas"] == 510000
 
 
 class TestSignerProtocols:

--- a/typescript/.changeset/hook-error-isolation.md
+++ b/typescript/.changeset/hook-error-isolation.md
@@ -1,0 +1,5 @@
+---
+'@x402/core': patch
+---
+
+Isolate facilitator and resource-server lifecycle hook failures so verification and settlement responses still complete when optional hooks throw.

--- a/typescript/packages/core/src/facilitator/x402Facilitator.ts
+++ b/typescript/packages/core/src/facilitator/x402Facilitator.ts
@@ -291,11 +291,19 @@ export class x402Facilitator {
 
     // Execute beforeVerify hooks
     for (const hook of this.beforeVerifyHooks) {
-      const result = await hook(context);
-      if (result && "abort" in result && result.abort) {
+      try {
+        const result = await hook(context);
+        if (result && "abort" in result && result.abort) {
+          return {
+            isValid: false,
+            invalidReason: result.reason,
+          };
+        }
+      } catch (error) {
+        console.error("Error in facilitator beforeVerify hook:", error);
         return {
           isValid: false,
-          invalidReason: result.reason,
+          invalidReason: "before_verify_hook_error",
         };
       }
     }
@@ -348,17 +356,25 @@ export class x402Facilitator {
 
         // Execute onVerifyFailure hooks
         for (const hook of this.onVerifyFailureHooks) {
-          const result = await hook(failureContext);
-          if (result && "recovered" in result && result.recovered) {
-            // If recovered, execute afterVerify hooks with recovered result
-            const recoveredContext: FacilitatorVerifyResultContext = {
-              ...context,
-              result: result.result,
-            };
-            for (const hook of this.afterVerifyHooks) {
-              await hook(recoveredContext);
+          try {
+            const result = await hook(failureContext);
+            if (result && "recovered" in result && result.recovered) {
+              // If recovered, execute afterVerify hooks with recovered result
+              const recoveredContext: FacilitatorVerifyResultContext = {
+                ...context,
+                result: result.result,
+              };
+              for (const afterHook of this.afterVerifyHooks) {
+                try {
+                  await afterHook(recoveredContext);
+                } catch (afterHookError) {
+                  console.error("Error in facilitator afterVerify hook:", afterHookError);
+                }
+              }
+              return result.result;
             }
-            return result.result;
+          } catch (hookError) {
+            console.error("Error in facilitator onVerifyFailure hook:", hookError);
           }
         }
 
@@ -372,7 +388,11 @@ export class x402Facilitator {
       };
 
       for (const hook of this.afterVerifyHooks) {
-        await hook(resultContext);
+        try {
+          await hook(resultContext);
+        } catch (hookError) {
+          console.error("Error in facilitator afterVerify hook:", hookError);
+        }
       }
 
       return verifyResult;
@@ -384,9 +404,13 @@ export class x402Facilitator {
 
       // Execute onVerifyFailure hooks
       for (const hook of this.onVerifyFailureHooks) {
-        const result = await hook(failureContext);
-        if (result && "recovered" in result && result.recovered) {
-          return result.result;
+        try {
+          const result = await hook(failureContext);
+          if (result && "recovered" in result && result.recovered) {
+            return result.result;
+          }
+        } catch (hookError) {
+          console.error("Error in facilitator onVerifyFailure hook:", hookError);
         }
       }
 
@@ -412,9 +436,19 @@ export class x402Facilitator {
 
     // Execute beforeSettle hooks
     for (const hook of this.beforeSettleHooks) {
-      const result = await hook(context);
-      if (result && "abort" in result && result.abort) {
-        throw new Error(`Settlement aborted: ${result.reason}`);
+      try {
+        const result = await hook(context);
+        if (result && "abort" in result && result.abort) {
+          throw new Error(`Settlement aborted: ${result.reason}`);
+        }
+      } catch (error) {
+        if (error instanceof Error && error.message.startsWith("Settlement aborted:")) {
+          throw error;
+        }
+        console.error("Error in facilitator beforeSettle hook:", error);
+        throw new Error(
+          `before_settle_hook_error: ${error instanceof Error ? error.message : "Unknown error"}`,
+        );
       }
     }
 
@@ -464,7 +498,11 @@ export class x402Facilitator {
       };
 
       for (const hook of this.afterSettleHooks) {
-        await hook(resultContext);
+        try {
+          await hook(resultContext);
+        } catch (hookError) {
+          console.error("Error in facilitator afterSettle hook:", hookError);
+        }
       }
 
       return settleResult;
@@ -476,9 +514,13 @@ export class x402Facilitator {
 
       // Execute onSettleFailure hooks
       for (const hook of this.onSettleFailureHooks) {
-        const result = await hook(failureContext);
-        if (result && "recovered" in result && result.recovered) {
-          return result.result;
+        try {
+          const result = await hook(failureContext);
+          if (result && "recovered" in result && result.recovered) {
+            return result.result;
+          }
+        } catch (hookError) {
+          console.error("Error in facilitator onSettleFailure hook:", hookError);
         }
       }
 

--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -744,7 +744,11 @@ export class x402ResourceServer {
       };
 
       for (const hook of this.afterVerifyHooks) {
-        await hook(resultContext);
+        try {
+          await hook(resultContext);
+        } catch (hookError) {
+          console.error("Error in afterVerify hook:", hookError);
+        }
       }
 
       return verifyResult;
@@ -756,9 +760,13 @@ export class x402ResourceServer {
 
       // Execute onVerifyFailure hooks
       for (const hook of this.onVerifyFailureHooks) {
-        const result = await hook(failureContext);
-        if (result && "recovered" in result && result.recovered) {
-          return result.result;
+        try {
+          const result = await hook(failureContext);
+          if (result && "recovered" in result && result.recovered) {
+            return result.result;
+          }
+        } catch (hookError) {
+          console.error("Error in onVerifyFailure hook:", hookError);
         }
       }
 
@@ -875,7 +883,11 @@ export class x402ResourceServer {
       };
 
       for (const hook of this.afterSettleHooks) {
-        await hook(resultContext);
+        try {
+          await hook(resultContext);
+        } catch (hookError) {
+          console.error("Error in afterSettle hook:", hookError);
+        }
       }
 
       // Let declared extensions add data to settlement response
@@ -910,9 +922,13 @@ export class x402ResourceServer {
 
       // Execute onSettleFailure hooks
       for (const hook of this.onSettleFailureHooks) {
-        const result = await hook(failureContext);
-        if (result && "recovered" in result && result.recovered) {
-          return result.result;
+        try {
+          const result = await hook(failureContext);
+          if (result && "recovered" in result && result.recovered) {
+            return result.result;
+          }
+        } catch (hookError) {
+          console.error("Error in onSettleFailure hook:", hookError);
         }
       }
 

--- a/typescript/packages/core/test/unit/facilitator/x402Facilitator.hookErrorIsolation.test.ts
+++ b/typescript/packages/core/test/unit/facilitator/x402Facilitator.hookErrorIsolation.test.ts
@@ -1,0 +1,416 @@
+import { describe, it, expect, vi } from "vitest";
+import { x402Facilitator } from "../../../src/facilitator/x402Facilitator";
+import {
+  PaymentPayload,
+  PaymentRequirements,
+  VerifyResponse,
+  SettleResponse,
+} from "../../../src/types";
+import { SchemeNetworkFacilitator } from "../../../src/types/mechanisms";
+
+// Mock scheme facilitator
+class MockSchemeFacilitator implements SchemeNetworkFacilitator {
+  readonly scheme = "exact";
+
+  constructor(
+    private verifyFn?: (
+      payload: PaymentPayload,
+      requirements: PaymentRequirements,
+    ) => Promise<VerifyResponse>,
+    private settleFn?: (
+      payload: PaymentPayload,
+      requirements: PaymentRequirements,
+    ) => Promise<SettleResponse>,
+  ) {}
+
+  getExtra(_: string): Record<string, unknown> | undefined {
+    return undefined;
+  }
+
+  async verify(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<VerifyResponse> {
+    if (this.verifyFn) {
+      return this.verifyFn(payload, requirements);
+    }
+    return { isValid: true, payer: "0xMockPayer" };
+  }
+
+  async settle(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<SettleResponse> {
+    if (this.settleFn) {
+      return this.settleFn(payload, requirements);
+    }
+    return { success: true, transaction: "0xMockTx", network: requirements.network };
+  }
+}
+
+const buildPaymentPayload = (): PaymentPayload => ({
+  x402Version: 2,
+  payload: {},
+  accepted: {
+    scheme: "exact",
+    network: "eip155:8453",
+    asset: "0xUSDC",
+    amount: "1000000",
+    payTo: "0xRecipient",
+    maxTimeoutSeconds: 300,
+    extra: {},
+  },
+  resource: {
+    url: "https://example.com/resource",
+    description: "Test resource",
+    mimeType: "application/json",
+  },
+});
+
+const buildPaymentRequirements = (): PaymentRequirements => ({
+  scheme: "exact",
+  network: "eip155:8453",
+  asset: "0xUSDC",
+  amount: "1000000",
+  payTo: "0xRecipient",
+  maxTimeoutSeconds: 300,
+  extra: {},
+});
+
+describe("x402Facilitator - Hook Error Isolation", () => {
+  describe("beforeVerify error isolation", () => {
+    it("should catch and isolate errors from beforeVerify hooks", async () => {
+      const facilitator = new x402Facilitator();
+      facilitator.register("eip155:8453", new MockSchemeFacilitator());
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      facilitator.onBeforeVerify(async () => {
+        throw new Error("beforeVerify hook crashed");
+      });
+
+      const result = await facilitator.verify(buildPaymentPayload(), buildPaymentRequirements());
+
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toBe("before_verify_hook_error");
+      expect(consoleSpy).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
+    it("should still allow abort to work after error isolation", async () => {
+      const facilitator = new x402Facilitator();
+      facilitator.register("eip155:8453", new MockSchemeFacilitator());
+
+      facilitator.onBeforeVerify(async () => {
+        return { abort: true, reason: "Blocked by policy" };
+      });
+
+      const result = await facilitator.verify(buildPaymentPayload(), buildPaymentRequirements());
+
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toBe("Blocked by policy");
+    });
+  });
+
+  describe("afterVerify error isolation", () => {
+    it("should return successful result even if afterVerify hook throws", async () => {
+      const facilitator = new x402Facilitator();
+      facilitator.register("eip155:8453", new MockSchemeFacilitator());
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      facilitator.onAfterVerify(async () => {
+        throw new Error("afterVerify hook crashed");
+      });
+
+      const result = await facilitator.verify(buildPaymentPayload(), buildPaymentRequirements());
+
+      expect(result.isValid).toBe(true);
+      expect(consoleSpy).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
+    it("should continue executing remaining afterVerify hooks after one throws", async () => {
+      const facilitator = new x402Facilitator();
+      facilitator.register("eip155:8453", new MockSchemeFacilitator());
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      let secondHookCalled = false;
+
+      facilitator
+        .onAfterVerify(async () => {
+          throw new Error("First hook throws");
+        })
+        .onAfterVerify(async () => {
+          secondHookCalled = true;
+        });
+
+      const result = await facilitator.verify(buildPaymentPayload(), buildPaymentRequirements());
+
+      expect(result.isValid).toBe(true);
+      expect(secondHookCalled).toBe(true);
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("onVerifyFailure error isolation", () => {
+    it("should propagate original error even if onVerifyFailure hook throws", async () => {
+      const facilitator = new x402Facilitator();
+
+      const mockScheme = new MockSchemeFacilitator(async () => {
+        throw new Error("Original verification error");
+      });
+      facilitator.register("eip155:8453", mockScheme);
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      facilitator.onVerifyFailure(async () => {
+        throw new Error("Failure hook also crashed");
+      });
+
+      await expect(
+        facilitator.verify(buildPaymentPayload(), buildPaymentRequirements()),
+      ).rejects.toThrow("Original verification error");
+
+      expect(consoleSpy).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
+    it("should still allow recovery even with error isolation", async () => {
+      const facilitator = new x402Facilitator();
+
+      const mockScheme = new MockSchemeFacilitator(async () => {
+        throw new Error("Verification failed");
+      });
+      facilitator.register("eip155:8453", mockScheme);
+
+      facilitator.onVerifyFailure(async () => {
+        return {
+          recovered: true,
+          result: { isValid: true, payer: "0xRecovered" },
+        };
+      });
+
+      const result = await facilitator.verify(buildPaymentPayload(), buildPaymentRequirements());
+
+      expect(result.isValid).toBe(true);
+      expect(result.payer).toBe("0xRecovered");
+    });
+
+    it("should try subsequent failure hooks if first one throws", async () => {
+      const facilitator = new x402Facilitator();
+
+      const mockScheme = new MockSchemeFacilitator(async () => {
+        throw new Error("Verification failed");
+      });
+      facilitator.register("eip155:8453", mockScheme);
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      facilitator
+        .onVerifyFailure(async () => {
+          throw new Error("First failure hook crashes");
+        })
+        .onVerifyFailure(async () => {
+          return {
+            recovered: true,
+            result: { isValid: true, payer: "0xRecoveredBySecondHook" },
+          };
+        });
+
+      const result = await facilitator.verify(buildPaymentPayload(), buildPaymentRequirements());
+
+      expect(result.isValid).toBe(true);
+      expect(result.payer).toBe("0xRecoveredBySecondHook");
+
+      consoleSpy.mockRestore();
+    });
+
+    it("should isolate errors in onVerifyFailure for isValid:false path", async () => {
+      const facilitator = new x402Facilitator();
+
+      const mockScheme = new MockSchemeFacilitator(async () => {
+        return { isValid: false, invalidReason: "Payment expired" };
+      });
+      facilitator.register("eip155:8453", mockScheme);
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      facilitator.onVerifyFailure(async () => {
+        throw new Error("Failure hook crashed on isValid:false");
+      });
+
+      const result = await facilitator.verify(buildPaymentPayload(), buildPaymentRequirements());
+
+      // Should still return the original failed result, not crash
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toBe("Payment expired");
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("beforeSettle error isolation", () => {
+    it("should catch and wrap errors from beforeSettle hooks", async () => {
+      const facilitator = new x402Facilitator();
+      facilitator.register("eip155:8453", new MockSchemeFacilitator());
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      facilitator.onBeforeSettle(async () => {
+        throw new Error("beforeSettle hook crashed");
+      });
+
+      await expect(
+        facilitator.settle(buildPaymentPayload(), buildPaymentRequirements()),
+      ).rejects.toThrow("before_settle_hook_error");
+
+      consoleSpy.mockRestore();
+    });
+
+    it("should re-throw abort errors as-is", async () => {
+      const facilitator = new x402Facilitator();
+      facilitator.register("eip155:8453", new MockSchemeFacilitator());
+
+      facilitator.onBeforeSettle(async () => {
+        return { abort: true, reason: "Gas too high" };
+      });
+
+      await expect(
+        facilitator.settle(buildPaymentPayload(), buildPaymentRequirements()),
+      ).rejects.toThrow("Settlement aborted: Gas too high");
+    });
+  });
+
+  describe("afterSettle error isolation", () => {
+    it("should return successful settlement even if afterSettle hook throws", async () => {
+      const facilitator = new x402Facilitator();
+      facilitator.register("eip155:8453", new MockSchemeFacilitator());
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      facilitator.onAfterSettle(async () => {
+        throw new Error("afterSettle hook crashed (e.g. external API call failed)");
+      });
+
+      const result = await facilitator.settle(buildPaymentPayload(), buildPaymentRequirements());
+
+      // Settlement succeeded on-chain — result must be returned despite hook error
+      expect(result.success).toBe(true);
+      expect(result.transaction).toBe("0xMockTx");
+      expect(consoleSpy).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
+    it("should continue executing remaining afterSettle hooks after one throws", async () => {
+      const facilitator = new x402Facilitator();
+      facilitator.register("eip155:8453", new MockSchemeFacilitator());
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      let secondHookCalled = false;
+
+      facilitator
+        .onAfterSettle(async () => {
+          throw new Error("First afterSettle hook throws");
+        })
+        .onAfterSettle(async () => {
+          secondHookCalled = true;
+        });
+
+      const result = await facilitator.settle(buildPaymentPayload(), buildPaymentRequirements());
+
+      expect(result.success).toBe(true);
+      expect(secondHookCalled).toBe(true);
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("onSettleFailure error isolation", () => {
+    it("should propagate original error even if onSettleFailure hook throws", async () => {
+      const facilitator = new x402Facilitator();
+
+      const mockScheme = new MockSchemeFacilitator(undefined, async () => {
+        throw new Error("Original settlement error");
+      });
+      facilitator.register("eip155:8453", mockScheme);
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      facilitator.onSettleFailure(async () => {
+        throw new Error("Failure hook also crashed");
+      });
+
+      await expect(
+        facilitator.settle(buildPaymentPayload(), buildPaymentRequirements()),
+      ).rejects.toThrow("Original settlement error");
+
+      expect(consoleSpy).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
+    it("should still allow recovery even with error isolation", async () => {
+      const facilitator = new x402Facilitator();
+
+      const mockScheme = new MockSchemeFacilitator(undefined, async () => {
+        throw new Error("Settlement failed");
+      });
+      facilitator.register("eip155:8453", mockScheme);
+
+      facilitator.onSettleFailure(async () => {
+        return {
+          recovered: true,
+          result: {
+            success: true,
+            transaction: "0xRecoveredTx",
+            network: "eip155:8453",
+          },
+        };
+      });
+
+      const result = await facilitator.settle(buildPaymentPayload(), buildPaymentRequirements());
+
+      expect(result.success).toBe(true);
+      expect(result.transaction).toBe("0xRecoveredTx");
+    });
+
+    it("should try subsequent failure hooks if first one throws", async () => {
+      const facilitator = new x402Facilitator();
+
+      const mockScheme = new MockSchemeFacilitator(undefined, async () => {
+        throw new Error("Settlement failed");
+      });
+      facilitator.register("eip155:8453", mockScheme);
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      facilitator
+        .onSettleFailure(async () => {
+          throw new Error("First failure hook crashes");
+        })
+        .onSettleFailure(async () => {
+          return {
+            recovered: true,
+            result: {
+              success: true,
+              transaction: "0xRecoveredBySecondHook",
+              network: "eip155:8453",
+            },
+          };
+        });
+
+      const result = await facilitator.settle(buildPaymentPayload(), buildPaymentRequirements());
+
+      expect(result.success).toBe(true);
+      expect(result.transaction).toBe("0xRecoveredBySecondHook");
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/typescript/packages/core/test/unit/server/x402ResourceServer.hookErrorIsolation.test.ts
+++ b/typescript/packages/core/test/unit/server/x402ResourceServer.hookErrorIsolation.test.ts
@@ -20,7 +20,11 @@ describe("x402ResourceServer - Hook Error Isolation", () => {
         kinds: [{ x402Version: 2, scheme: "test-scheme", network: "test:network" as Network }],
       }),
       buildVerifyResponse({ isValid: true }),
-      buildSettleResponse({ success: true, transaction: "0xSettledTx", network: "test:network" as Network }),
+      buildSettleResponse({
+        success: true,
+        transaction: "0xSettledTx",
+        network: "test:network" as Network,
+      }),
     );
 
     server = new x402ResourceServer(mockFacilitator);
@@ -35,16 +39,10 @@ describe("x402ResourceServer - Hook Error Isolation", () => {
         throw new Error("afterVerify hook crashed");
       });
 
-      const result = await server.verifyPayment(
-        buildPaymentPayload(),
-        buildPaymentRequirements(),
-      );
+      const result = await server.verifyPayment(buildPaymentPayload(), buildPaymentRequirements());
 
       expect(result.isValid).toBe(true);
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Error in afterVerify hook:",
-        expect.any(Error),
-      );
+      expect(consoleSpy).toHaveBeenCalledWith("Error in afterVerify hook:", expect.any(Error));
 
       consoleSpy.mockRestore();
     });
@@ -61,10 +59,7 @@ describe("x402ResourceServer - Hook Error Isolation", () => {
           secondHookCalled = true;
         });
 
-      const result = await server.verifyPayment(
-        buildPaymentPayload(),
-        buildPaymentRequirements(),
-      );
+      const result = await server.verifyPayment(buildPaymentPayload(), buildPaymentRequirements());
 
       expect(result.isValid).toBe(true);
       expect(secondHookCalled).toBe(true);
@@ -87,10 +82,7 @@ describe("x402ResourceServer - Hook Error Isolation", () => {
         server.verifyPayment(buildPaymentPayload(), buildPaymentRequirements()),
       ).rejects.toThrow("Original verification error");
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Error in onVerifyFailure hook:",
-        expect.any(Error),
-      );
+      expect(consoleSpy).toHaveBeenCalledWith("Error in onVerifyFailure hook:", expect.any(Error));
 
       consoleSpy.mockRestore();
     });
@@ -105,10 +97,7 @@ describe("x402ResourceServer - Hook Error Isolation", () => {
         };
       });
 
-      const result = await server.verifyPayment(
-        buildPaymentPayload(),
-        buildPaymentRequirements(),
-      );
+      const result = await server.verifyPayment(buildPaymentPayload(), buildPaymentRequirements());
 
       expect(result.isValid).toBe(true);
       expect(result.payer).toBe("0xRecovered");
@@ -130,10 +119,7 @@ describe("x402ResourceServer - Hook Error Isolation", () => {
           };
         });
 
-      const result = await server.verifyPayment(
-        buildPaymentPayload(),
-        buildPaymentRequirements(),
-      );
+      const result = await server.verifyPayment(buildPaymentPayload(), buildPaymentRequirements());
 
       expect(result.isValid).toBe(true);
       expect(result.payer).toBe("0xRecoveredBySecond");
@@ -150,18 +136,12 @@ describe("x402ResourceServer - Hook Error Isolation", () => {
         throw new Error("afterSettle hook crashed (e.g. external API failed)");
       });
 
-      const result = await server.settlePayment(
-        buildPaymentPayload(),
-        buildPaymentRequirements(),
-      );
+      const result = await server.settlePayment(buildPaymentPayload(), buildPaymentRequirements());
 
       // Settlement succeeded — must return result despite hook error
       expect(result.success).toBe(true);
       expect(result.transaction).toBe("0xSettledTx");
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Error in afterSettle hook:",
-        expect.any(Error),
-      );
+      expect(consoleSpy).toHaveBeenCalledWith("Error in afterSettle hook:", expect.any(Error));
 
       consoleSpy.mockRestore();
     });
@@ -178,10 +158,7 @@ describe("x402ResourceServer - Hook Error Isolation", () => {
           secondHookCalled = true;
         });
 
-      const result = await server.settlePayment(
-        buildPaymentPayload(),
-        buildPaymentRequirements(),
-      );
+      const result = await server.settlePayment(buildPaymentPayload(), buildPaymentRequirements());
 
       expect(result.success).toBe(true);
       expect(secondHookCalled).toBe(true);
@@ -204,10 +181,7 @@ describe("x402ResourceServer - Hook Error Isolation", () => {
         server.settlePayment(buildPaymentPayload(), buildPaymentRequirements()),
       ).rejects.toThrow("Original settlement error");
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Error in onSettleFailure hook:",
-        expect.any(Error),
-      );
+      expect(consoleSpy).toHaveBeenCalledWith("Error in onSettleFailure hook:", expect.any(Error));
 
       consoleSpy.mockRestore();
     });
@@ -226,10 +200,7 @@ describe("x402ResourceServer - Hook Error Isolation", () => {
         };
       });
 
-      const result = await server.settlePayment(
-        buildPaymentPayload(),
-        buildPaymentRequirements(),
-      );
+      const result = await server.settlePayment(buildPaymentPayload(), buildPaymentRequirements());
 
       expect(result.success).toBe(true);
       expect(result.transaction).toBe("0xRecoveredTx");
@@ -255,10 +226,7 @@ describe("x402ResourceServer - Hook Error Isolation", () => {
           };
         });
 
-      const result = await server.settlePayment(
-        buildPaymentPayload(),
-        buildPaymentRequirements(),
-      );
+      const result = await server.settlePayment(buildPaymentPayload(), buildPaymentRequirements());
 
       expect(result.success).toBe(true);
       expect(result.transaction).toBe("0xRecoveredBySecond");

--- a/typescript/packages/core/test/unit/server/x402ResourceServer.hookErrorIsolation.test.ts
+++ b/typescript/packages/core/test/unit/server/x402ResourceServer.hookErrorIsolation.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { x402ResourceServer } from "../../../src/server/x402ResourceServer";
+import {
+  MockFacilitatorClient,
+  buildSupportedResponse,
+  buildVerifyResponse,
+  buildSettleResponse,
+  buildPaymentPayload,
+  buildPaymentRequirements,
+} from "../../mocks";
+import { Network } from "../../../src/types";
+
+describe("x402ResourceServer - Hook Error Isolation", () => {
+  let server: x402ResourceServer;
+  let mockFacilitator: MockFacilitatorClient;
+
+  beforeEach(async () => {
+    mockFacilitator = new MockFacilitatorClient(
+      buildSupportedResponse({
+        kinds: [{ x402Version: 2, scheme: "test-scheme", network: "test:network" as Network }],
+      }),
+      buildVerifyResponse({ isValid: true }),
+      buildSettleResponse({ success: true, transaction: "0xSettledTx", network: "test:network" as Network }),
+    );
+
+    server = new x402ResourceServer(mockFacilitator);
+    await server.initialize();
+  });
+
+  describe("afterVerify error isolation", () => {
+    it("should return successful verify result even if afterVerify hook throws", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      server.onAfterVerify(async () => {
+        throw new Error("afterVerify hook crashed");
+      });
+
+      const result = await server.verifyPayment(
+        buildPaymentPayload(),
+        buildPaymentRequirements(),
+      );
+
+      expect(result.isValid).toBe(true);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Error in afterVerify hook:",
+        expect.any(Error),
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it("should continue executing remaining afterVerify hooks after one throws", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      let secondHookCalled = false;
+
+      server
+        .onAfterVerify(async () => {
+          throw new Error("First hook throws");
+        })
+        .onAfterVerify(async () => {
+          secondHookCalled = true;
+        });
+
+      const result = await server.verifyPayment(
+        buildPaymentPayload(),
+        buildPaymentRequirements(),
+      );
+
+      expect(result.isValid).toBe(true);
+      expect(secondHookCalled).toBe(true);
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("onVerifyFailure error isolation", () => {
+    it("should propagate original error even if onVerifyFailure hook throws", async () => {
+      mockFacilitator.setVerifyResponse(new Error("Original verification error"));
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      server.onVerifyFailure(async () => {
+        throw new Error("Failure hook also crashed");
+      });
+
+      await expect(
+        server.verifyPayment(buildPaymentPayload(), buildPaymentRequirements()),
+      ).rejects.toThrow("Original verification error");
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Error in onVerifyFailure hook:",
+        expect.any(Error),
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it("should still allow recovery even with error isolation", async () => {
+      mockFacilitator.setVerifyResponse(new Error("Verification failed"));
+
+      server.onVerifyFailure(async () => {
+        return {
+          recovered: true,
+          result: { isValid: true, payer: "0xRecovered" },
+        };
+      });
+
+      const result = await server.verifyPayment(
+        buildPaymentPayload(),
+        buildPaymentRequirements(),
+      );
+
+      expect(result.isValid).toBe(true);
+      expect(result.payer).toBe("0xRecovered");
+    });
+
+    it("should try subsequent failure hooks if first one throws", async () => {
+      mockFacilitator.setVerifyResponse(new Error("Verification failed"));
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      server
+        .onVerifyFailure(async () => {
+          throw new Error("First failure hook crashes");
+        })
+        .onVerifyFailure(async () => {
+          return {
+            recovered: true,
+            result: { isValid: true, payer: "0xRecoveredBySecond" },
+          };
+        });
+
+      const result = await server.verifyPayment(
+        buildPaymentPayload(),
+        buildPaymentRequirements(),
+      );
+
+      expect(result.isValid).toBe(true);
+      expect(result.payer).toBe("0xRecoveredBySecond");
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("afterSettle error isolation", () => {
+    it("should return successful settlement even if afterSettle hook throws", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      server.onAfterSettle(async () => {
+        throw new Error("afterSettle hook crashed (e.g. external API failed)");
+      });
+
+      const result = await server.settlePayment(
+        buildPaymentPayload(),
+        buildPaymentRequirements(),
+      );
+
+      // Settlement succeeded — must return result despite hook error
+      expect(result.success).toBe(true);
+      expect(result.transaction).toBe("0xSettledTx");
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Error in afterSettle hook:",
+        expect.any(Error),
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it("should continue executing remaining afterSettle hooks after one throws", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      let secondHookCalled = false;
+
+      server
+        .onAfterSettle(async () => {
+          throw new Error("First hook throws");
+        })
+        .onAfterSettle(async () => {
+          secondHookCalled = true;
+        });
+
+      const result = await server.settlePayment(
+        buildPaymentPayload(),
+        buildPaymentRequirements(),
+      );
+
+      expect(result.success).toBe(true);
+      expect(secondHookCalled).toBe(true);
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("onSettleFailure error isolation", () => {
+    it("should propagate original error even if onSettleFailure hook throws", async () => {
+      mockFacilitator.setSettleResponse(new Error("Original settlement error"));
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      server.onSettleFailure(async () => {
+        throw new Error("Failure hook also crashed");
+      });
+
+      await expect(
+        server.settlePayment(buildPaymentPayload(), buildPaymentRequirements()),
+      ).rejects.toThrow("Original settlement error");
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Error in onSettleFailure hook:",
+        expect.any(Error),
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it("should still allow recovery even with error isolation", async () => {
+      mockFacilitator.setSettleResponse(new Error("Settlement failed"));
+
+      server.onSettleFailure(async () => {
+        return {
+          recovered: true,
+          result: {
+            success: true,
+            transaction: "0xRecoveredTx",
+            network: "test:network",
+          },
+        };
+      });
+
+      const result = await server.settlePayment(
+        buildPaymentPayload(),
+        buildPaymentRequirements(),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.transaction).toBe("0xRecoveredTx");
+    });
+
+    it("should try subsequent failure hooks if first one throws", async () => {
+      mockFacilitator.setSettleResponse(new Error("Settlement failed"));
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      server
+        .onSettleFailure(async () => {
+          throw new Error("First failure hook crashes");
+        })
+        .onSettleFailure(async () => {
+          return {
+            recovered: true,
+            result: {
+              success: true,
+              transaction: "0xRecoveredBySecond",
+              network: "test:network",
+            },
+          };
+        });
+
+      const result = await server.settlePayment(
+        buildPaymentPayload(),
+        buildPaymentRequirements(),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.transaction).toBe("0xRecoveredBySecond");
+
+      consoleSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- isolate TypeScript facilitator and resource-server lifecycle hook failures so verify and settle responses still complete when optional hooks throw
- switch Go SVM facilitator fee-payer selection to `crypto/rand` and safely handle empty signer pools
- make Python `FacilitatorWeb3Signer` gas limits configurable with signer-wide defaults and per-call overrides
- add changelog fragments and focused regression tests

## Why
- `#1826`: thrown lifecycle hooks could turn a successful verify or settle path into an error response
- `#1845`: Go SVM facilitator fee-payer selection used `math/rand`
- `#1846`: Python facilitator signers hardcoded a `300000` gas limit

## Validation
- `pnpm --dir typescript --filter @x402/core test -- test/unit/server/x402ResourceServer.hookErrorIsolation.test.ts test/unit/facilitator/x402Facilitator.hookErrorIsolation.test.ts`
- `go test -p 1 ./mechanisms/svm/exact/facilitator ./mechanisms/svm/exact/v1/facilitator`
- `uv run pytest tests/unit/mechanisms/evm/test_signer.py tests/unit/mechanisms/evm/test_facilitator.py tests/unit/mechanisms/evm/test_permit2.py`

Closes #1826
Closes #1845
Closes #1846
