### PR TITLE
docs(bazaar): clarify EXTENSION-RESPONSES header applies to verify and settle

### DIFF
--- a/specs/extensions/bazaar.md
+++ b/specs/extensions/bazaar.md
@@ -362,9 +362,9 @@ When a facilitator receives a `PaymentPayload` containing the `bazaar` extension
 
 How a facilitator stores, indexes, and exposes discovered resources is an implementation detail. Facilitators may choose to catalog resources in a database, expose them via a discovery API, or process them in any manner they see fit.
 
-### Settlement Response Header
+### Verify and Settlement Response Header
 
-After processing a `PaymentPayload`, a facilitator **MAY** append an `EXTENSION-RESPONSES` HTTP header to the settlement response to communicate extension-specific outcomes to the client.
+After processing a `PaymentPayload`, a facilitator **MAY** append an `EXTENSION-RESPONSES` HTTP header to the verify or settlement response to communicate extension-specific outcomes to the client.
 
 **Header name:** `EXTENSION-RESPONSES`
 


### PR DESCRIPTION
## Description

Updates the bazaar extension spec to clarify that facilitators may respond with the `EXTENSION-RESPONSES` header on both verify and settlement responses, not only settlement.

## Tests

Docs-only change — no tests required.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

Made with [Cursor](https://cursor.com)