### PR TITLE
fix(python): enable redirect following in legacy HTTPFacilitatorClient

### DIFF
--- a/python/legacy/src/x402/clients/httpx.py
+++ b/python/legacy/src/x402/clients/httpx.py
@@ -59,7 +59,7 @@ class HttpxHooks:
             request.headers["Access-Control-Expose-Headers"] = "X-Payment-Response"
 
             # Retry the request
-            async with AsyncClient() as client:
+            async with AsyncClient(follow_redirects=True) as client:
                 retry_response = await client.send(request)
 
                 # Copy the retry response data to the original response
@@ -130,6 +130,7 @@ class x402HttpxClient(AsyncClient):
                 and returns a PaymentRequirements object.
             **kwargs: Additional arguments to pass to AsyncClient
         """
+        kwargs.setdefault("follow_redirects", True)
         super().__init__(**kwargs)
         self.event_hooks = x402_payment_hooks(
             account, max_value, payment_requirements_selector


### PR DESCRIPTION
## Summary

`httpx` defaults to `follow_redirects=False`. When the facilitator URL `https://x402.org/facilitator` returns a 308 redirect to `https://www.x402.org/facilitator`, the legacy Python SDK silently fails because redirects are not followed.

The v2 SDK (`python/x402/http/facilitator_client.py`) already passes `follow_redirects=True` when creating `httpx.Client` / `httpx.AsyncClient`, but two places in the **legacy** SDK were missed:

1. **`HttpxHooks.on_response`** — The retry `AsyncClient()` created at line 62 did not enable redirect following, so payment retry requests would fail on redirecting facilitator URLs.
2. **`x402HttpxClient.__init__`** — The convenience client class passed `**kwargs` through to `AsyncClient` without defaulting `follow_redirects=True`, so users who didn't explicitly set it would hit the same issue.

## Changes

- `python/legacy/src/x402/clients/httpx.py`: Add `follow_redirects=True` to `AsyncClient()` in `HttpxHooks.on_response` retry path
- `python/legacy/src/x402/clients/httpx.py`: Default `follow_redirects=True` via `kwargs.setdefault()` in `x402HttpxClient.__init__`

## How to reproduce

1. Use the legacy Python SDK with default facilitator URL (`https://x402.org/facilitator`)
2. The facilitator returns HTTP 308 redirect to `https://www.x402.org/facilitator`
3. Without this fix, `verify()`, `settle()`, and payment retry calls fail silently

## Test plan

- [ ] Verify redirect following works with `https://x402.org/facilitator` endpoint
- [ ] Confirm `x402HttpxClient` follows redirects by default
- [ ] Confirm explicit `follow_redirects=False` still overrides the default