### PR TITLE
Add MERX - first TRON x402 facilitator in registry (USDT, USDC, USDD)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/merx/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/merx/metadata.json
@@ -1,0 +1,19 @@
+{
+  "name": "MERX",
+  "description": "First x402 facilitator for TRON. Verify USDT/USDC/USDD payments on TRON mainnet, issue JWT authorizations. Sub-3s confirmation for micropayments. Express middleware available.",
+  "logoUrl": "/logos/merx.png",
+  "websiteUrl": "https://github.com/Hovsteder/x402-tron",
+  "category": "Facilitators",
+  "facilitator": {
+    "baseUrl": "https://x402.merx.exchange",
+    "networks": ["tron"],
+    "schemes": ["exact"],
+    "assets": ["TRC20"],
+    "supports": {
+      "verify": true,
+      "settle": true,
+      "supported": true,
+      "list": false
+    }
+  }
+}

--- a/typescript/site/app/ecosystem/partners-data/merx/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/merx/metadata.json
@@ -1,14 +1,14 @@
 {
   "name": "MERX",
-  "description": "First x402 facilitator for TRON. Verify USDT/USDC/USDD payments on TRON mainnet, issue JWT authorizations. Sub-3s confirmation for micropayments. Express middleware available.",
+  "description": "TRON x402 facilitator. Settles USDT, USDC, and USDD on TRON mainnet via three schemes (exact direct transfer, exact_permit, exact_gasfree). Also supports Base USDC. Runs on own TRON Lite FullNode with energy aggregation across 8 providers. First TRON facilitator submitted to this registry.",
   "logoUrl": "/logos/merx.png",
-  "websiteUrl": "https://github.com/Hovsteder/x402-tron",
+  "websiteUrl": "https://merx.exchange",
   "category": "Facilitators",
   "facilitator": {
     "baseUrl": "https://x402.merx.exchange",
-    "networks": ["tron"],
-    "schemes": ["exact"],
-    "assets": ["TRC20"],
+    "networks": ["tron", "base"],
+    "schemes": ["exact", "exact_permit", "exact_gasfree"],
+    "assets": ["USDT", "USDC", "USDD"],
     "supports": {
       "verify": true,
       "settle": true,


### PR DESCRIPTION
## MERX - TRON x402 facilitator (USDT, USDC, USDD)

Adds MERX to `partners-data/` as a hosted x402 facilitator targeting TRON mainnet, with secondary support for Base USDC. As of this PR, this directory contains 198 partner directories with zero TRON-related entries.

**Facilitator URL:** https://x402.merx.exchange
**Networks:** TRON mainnet (`tron:mainnet`, also CAIP-2 hex `tron:0x2b6653dc`), Base mainnet (`eip155:8453`)
**Schemes:** `exact`, `exact_permit`, `exact_gasfree`
**Assets on TRON:**
- USDT (`TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t`, 6 decimals)
- USDC (`TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8`, 6 decimals)
- USDD (`TPYmHEhy5n8TCEfYGqW2rPxsghSfzghPDn`, 18 decimals)

### About MERX

MERX runs as part of a complete TRON infrastructure stack:
- Own TRON Lite FullNode (no TronGrid dependency for verification)
- TRON energy aggregator across 8 providers
- 12 paid x402 resource endpoints at `merx.exchange/x402/*` (prices, account, estimate, swap, watch, receive, invoice, send, send/batch, swap/execute, network, rpc proxy)
- Own deployed GasFreeController contract `TKjJ1r5XYqnLZmLakcP3knis7Lh6gm3qtR` for permit-based settlement
- npm middleware `merx-x402` for sellers
- 60-tool MCP server for AI agents

### Verified mainnet settlements

Six on-chain settlement transactions were executed on TRON mainnet to verify the full pipeline. All txids are independently verifiable on TronScan.

**`exact` scheme** (buyer broadcasts TRC-20 transfer, facilitator parses on-chain Transfer event log and issues authorization JWT):

| Token | TRON mainnet txid |
|---|---|
| USDT | https://tronscan.org/#/transaction/bf1292ec5ae3d6195fe487c77fdbfde48ebc29024c090d0854d2daacc948e6db |
| USDC | https://tronscan.org/#/transaction/b83b2d363f34ba6a600b567e73b66e914aa339dbf96f261efa145e7c790e6785 |
| USDD | https://tronscan.org/#/transaction/349f8b1d360e4ef058a47188f8f4b5f30056e88655c6d4c666f6c511c8f0415c |

**`exact_gasfree` scheme** (buyer signs TIP-712 PermitTransfer off-chain, facilitator broadcasts via MERX GasFreeController, contract pulls value+fee from per-user GasFree subaccount):

| Token | TRON mainnet txid | Commission to serviceProvider |
|---|---|---|
| USDT | https://tronscan.org/#/transaction/423f86eff6569ca577ba484bd4436bc3d14f30cac968befb4f835d81d7ac0500 | +2 USDT |
| USDC | https://tronscan.org/#/transaction/5974b4085c14a799d727201e80fb72369e077b712b21e70a2fe2cfd964006402 | +2 USDC |
| USDD | https://tronscan.org/#/transaction/9744ad7b0c8c321654c043e008b28f4c8ac537c5bf470a32c9acb62b64569260 | +2 USDD |

**Commission flow on serviceProvider wallet** `TMjNmsTzdqEofvoiMg7ZWa9nG2SAVHQd8M`:

```
              BEFORE         AFTER          DELTA
USDT       0.032094  ->   2.032094       +2.000000
USDC       0.000000  ->   2.000000       +2.000000
USDD       0.000000  ->   2.000000       +2.000000
```

This is on-chain proof that MERX collects fees as the serviceProvider of its own GasFreeController contract (not Justlend, not a third party).

### Standard x402 v2 facilitator interface

```
GET  /supported           - x402 v2 supported kinds (10 entries: 9 TRON + 1 Base)
POST /verify              - x402 v2 verify
POST /settle              - x402 v2 settle (dispatches by scheme)
GET  /health              - service status, supported assets, confirmation policy
GET  /openapi.json        - OpenAPI 3.1 spec
GET  /.well-known/x402    - resource discovery (12 paid endpoints)
GET  /.well-known/x402/facilitator - facilitator metadata
```

### USDD 18-decimal handling

USDD on TRON uses 18 decimals (unlike USDT/USDC which use 6). The facilitator handles this correctly at every layer: TIP-712 typed-data signing, off-chain verifier, on-chain settlement, JWT amount field, and balance display. The USDD settlement transactions above transfer 0.5 USDD (atomic value `500000000000000000`) and 0.1 USDD via permit (atomic value `100000000000000000`).

### Category

Facilitators

### Note on prior art

Other TRON x402 implementations exist at the SDK and standalone-service layer. The narrowly-scoped claim being made here is registry membership: as of this PR there are zero TRON entries in `coinbase/x402/typescript/site/app/ecosystem/partners-data/`. See the comment thread for the full prior-art audit.
