### PR TITLE
feat(evm): implement ERC-7710 delegation support in exact facilitator

### DIFF
--- a/typescript/.changeset/erc7710-delegation-support.md
+++ b/typescript/.changeset/erc7710-delegation-support.md
@@ -1,0 +1,9 @@
+---
+"@x402/evm": minor
+---
+
+Add ERC-7710 smart account delegation support to the exact EVM facilitator.
+
+Implements `verifyERC7710` and `settleERC7710` alongside the existing EIP-3009 and Permit2 handlers, completing the three asset transfer methods defined in the spec. Verification is performed entirely via `eth_call` simulation of `redeemDelegations` — no signature check required, the DelegationManager handles auth. Settlement calls `redeemDelegations` on the DelegationManager contract using ERC-7579 single-call execution mode.
+
+New exports: `ExactERC7710Payload` type, `isERC7710Payload()` type guard. `AssetTransferMethod` now includes `"erc7710"`.

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/erc7710.test.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/erc7710.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { verifyERC7710, settleERC7710 } from "./erc7710";
 import { FacilitatorEvmSigner } from "../../signer";
 import { ExactERC7710Payload } from "../../types";
 import { PaymentPayload, PaymentRequirements } from "@x402/core/types";
+import { getAddress } from "viem";
 import * as Errors from "./errors";
 
 // ---------------------------------------------------------------------------
@@ -13,6 +14,7 @@ const DELEGATION_MANAGER = "0x1234567890abcdef1234567890abcdef12345678" as const
 const DELEGATOR = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" as const;
 const PAY_TO = "0x209693Bc6afc0C5328bA36FaF03C514EF312287C" as const;
 const ASSET = "0x036CbD53842c5426634e7929541eC2318f3dCF7e" as const;
+const FACILITATOR = "0x1111111111111111111111111111111111111111" as const;
 const NETWORK = "eip155:84532";
 const TX_HASH = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab" as const;
 
@@ -59,7 +61,7 @@ const validPayload: PaymentPayload = {
 
 function makeSigner(overrides?: Partial<FacilitatorEvmSigner>): FacilitatorEvmSigner {
   return {
-    getAddresses: vi.fn().mockReturnValue([PAY_TO]),
+    getAddresses: vi.fn().mockReturnValue([FACILITATOR]),
     readContract: vi.fn().mockResolvedValue(undefined), // simulation succeeds by default
     verifyTypedData: vi.fn().mockResolvedValue(true),
     writeContract: vi.fn().mockResolvedValue(TX_HASH),
@@ -149,17 +151,19 @@ describe("verifyERC7710", () => {
   it("calls redeemDelegations with correct args", async () => {
     const signer = makeSigner();
     await verifyERC7710(signer, validPayload, validRequirements, validErc7710Payload);
-    expect(signer.readContract).toHaveBeenCalledWith(
-      expect.objectContaining({
-        address: DELEGATION_MANAGER,
-        functionName: "redeemDelegations",
-        args: [
-          [validErc7710Payload.permissionContext],
-          ["0x0000000000000000000000000000000000000000000000000000000000000000"],
-          [expect.stringMatching(/^0x/)], // executionCalldata
-        ],
-      }),
-    );
+
+    const readContract = vi.mocked(signer.readContract);
+    expect(readContract).toHaveBeenCalledTimes(1);
+
+    const [call] = readContract.mock.calls[0];
+    expect(call.address).toBe(getAddress(DELEGATION_MANAGER));
+    expect(call.account).toBe(FACILITATOR);
+    expect(call.functionName).toBe("redeemDelegations");
+    expect(call.args?.[0]).toEqual([validErc7710Payload.permissionContext]);
+    expect(call.args?.[1]).toEqual([
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+    ]);
+    expect(call.args?.[2]?.[0]).toMatch(/^0x/);
   });
 });
 
@@ -227,11 +231,17 @@ describe("settleERC7710", () => {
   it("calls redeemDelegations with correct args on settle", async () => {
     const signer = makeSigner();
     await settleERC7710(signer, validPayload, validRequirements, validErc7710Payload);
-    expect(signer.writeContract).toHaveBeenCalledWith(
-      expect.objectContaining({
-        address: DELEGATION_MANAGER,
-        functionName: "redeemDelegations",
-      }),
-    );
+
+    const writeContract = vi.mocked(signer.writeContract);
+    expect(writeContract).toHaveBeenCalledTimes(1);
+
+    const [call] = writeContract.mock.calls[0];
+    expect(call.address).toBe(getAddress(DELEGATION_MANAGER));
+    expect(call.functionName).toBe("redeemDelegations");
+    expect(call.args[0]).toEqual([validErc7710Payload.permissionContext]);
+    expect(call.args[1]).toEqual([
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+    ]);
+    expect(call.args[2][0]).toMatch(/^0x/);
   });
 });

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/erc7710.test.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/erc7710.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { verifyERC7710, settleERC7710 } from "./erc7710";
+import { FacilitatorEvmSigner } from "../../signer";
+import { ExactERC7710Payload } from "../../types";
+import { PaymentPayload, PaymentRequirements } from "@x402/core/types";
+import * as Errors from "./errors";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const DELEGATION_MANAGER = "0x1234567890abcdef1234567890abcdef12345678" as const;
+const DELEGATOR = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" as const;
+const PAY_TO = "0x209693Bc6afc0C5328bA36FaF03C514EF312287C" as const;
+const ASSET = "0x036CbD53842c5426634e7929541eC2318f3dCF7e" as const;
+const NETWORK = "eip155:84532";
+const TX_HASH = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab" as const;
+
+const validErc7710Payload: ExactERC7710Payload = {
+  delegationManager: DELEGATION_MANAGER,
+  permissionContext: "0xdeadbeef",
+  delegator: DELEGATOR,
+};
+
+const validRequirements: PaymentRequirements = {
+  scheme: "exact",
+  network: NETWORK,
+  amount: "10000",
+  asset: ASSET,
+  payTo: PAY_TO,
+  maxTimeoutSeconds: 60,
+  description: "Test payment",
+  extra: {
+    assetTransferMethod: "erc7710",
+  },
+};
+
+const validPayload: PaymentPayload = {
+  x402Version: 2,
+  resource: {
+    url: "https://api.example.com/data",
+    description: "Test",
+    mimeType: "application/json",
+  },
+  accepted: {
+    scheme: "exact",
+    network: NETWORK,
+    amount: "10000",
+    asset: ASSET,
+    payTo: PAY_TO,
+    maxTimeoutSeconds: 60,
+  },
+  payload: validErc7710Payload,
+};
+
+// ---------------------------------------------------------------------------
+// Mock signer factory
+// ---------------------------------------------------------------------------
+
+function makeSigner(overrides?: Partial<FacilitatorEvmSigner>): FacilitatorEvmSigner {
+  return {
+    getAddresses: vi.fn().mockReturnValue([PAY_TO]),
+    readContract: vi.fn().mockResolvedValue(undefined), // simulation succeeds by default
+    verifyTypedData: vi.fn().mockResolvedValue(true),
+    writeContract: vi.fn().mockResolvedValue(TX_HASH),
+    sendTransaction: vi.fn().mockResolvedValue(TX_HASH),
+    waitForTransactionReceipt: vi.fn().mockResolvedValue({ status: "success" }),
+    getCode: vi.fn().mockResolvedValue("0x"),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// verifyERC7710
+// ---------------------------------------------------------------------------
+
+describe("verifyERC7710", () => {
+  it("returns valid when simulation succeeds", async () => {
+    const signer = makeSigner();
+    const result = await verifyERC7710(
+      signer,
+      validPayload,
+      validRequirements,
+      validErc7710Payload,
+    );
+    expect(result.isValid).toBe(true);
+    expect(result.payer).toBe(DELEGATOR);
+  });
+
+  it("returns invalid when scheme mismatches", async () => {
+    const signer = makeSigner();
+    const badPayload = { ...validPayload, accepted: { ...validPayload.accepted, scheme: "upto" } };
+    const result = await verifyERC7710(
+      signer,
+      badPayload as any,
+      validRequirements,
+      validErc7710Payload,
+    );
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toBe(Errors.ErrInvalidScheme);
+  });
+
+  it("returns invalid when network mismatches", async () => {
+    const signer = makeSigner();
+    const badReqs = { ...validRequirements, network: "eip155:1" };
+    const result = await verifyERC7710(signer, validPayload, badReqs, validErc7710Payload);
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toBe(Errors.ErrNetworkMismatch);
+  });
+
+  it("returns invalid for non-address delegationManager", async () => {
+    const signer = makeSigner();
+    const badPayload = { ...validErc7710Payload, delegationManager: "not-an-address" as any };
+    const result = await verifyERC7710(signer, validPayload, validRequirements, badPayload);
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toBe(Errors.ErrERC7710InvalidDelegationManager);
+  });
+
+  it("returns invalid for non-address delegator", async () => {
+    const signer = makeSigner();
+    const badPayload = { ...validErc7710Payload, delegator: "not-an-address" as any };
+    const result = await verifyERC7710(signer, validPayload, validRequirements, badPayload);
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toBe(Errors.ErrERC7710InvalidDelegator);
+  });
+
+  it("returns invalid for empty permissionContext", async () => {
+    const signer = makeSigner();
+    const badPayload = { ...validErc7710Payload, permissionContext: "0x" as any };
+    const result = await verifyERC7710(signer, validPayload, validRequirements, badPayload);
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toBe(Errors.ErrERC7710InvalidPermissionContext);
+  });
+
+  it("returns invalid when simulation throws", async () => {
+    const signer = makeSigner({
+      readContract: vi.fn().mockRejectedValue(new Error("execution reverted")),
+    });
+    const result = await verifyERC7710(
+      signer,
+      validPayload,
+      validRequirements,
+      validErc7710Payload,
+    );
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toBe(Errors.ErrERC7710SimulationFailed);
+  });
+
+  it("calls redeemDelegations with correct args", async () => {
+    const signer = makeSigner();
+    await verifyERC7710(signer, validPayload, validRequirements, validErc7710Payload);
+    expect(signer.readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: DELEGATION_MANAGER,
+        functionName: "redeemDelegations",
+        args: [
+          [validErc7710Payload.permissionContext],
+          ["0x0000000000000000000000000000000000000000000000000000000000000000"],
+          [expect.stringMatching(/^0x/)], // executionCalldata
+        ],
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// settleERC7710
+// ---------------------------------------------------------------------------
+
+describe("settleERC7710", () => {
+  it("returns success on happy path", async () => {
+    const signer = makeSigner();
+    const result = await settleERC7710(
+      signer,
+      validPayload,
+      validRequirements,
+      validErc7710Payload,
+    );
+    expect(result.success).toBe(true);
+    expect(result.transaction).toBe(TX_HASH);
+    expect(result.payer).toBe(DELEGATOR);
+  });
+
+  it("returns failure when verify fails", async () => {
+    const signer = makeSigner({
+      readContract: vi.fn().mockRejectedValue(new Error("delegation revoked")),
+    });
+    const result = await settleERC7710(
+      signer,
+      validPayload,
+      validRequirements,
+      validErc7710Payload,
+    );
+    expect(result.success).toBe(false);
+    expect(result.errorReason).toBe(Errors.ErrERC7710SimulationFailed);
+  });
+
+  it("returns failure when writeContract throws", async () => {
+    const signer = makeSigner({
+      writeContract: vi.fn().mockRejectedValue(new Error("out of gas")),
+    });
+    const result = await settleERC7710(
+      signer,
+      validPayload,
+      validRequirements,
+      validErc7710Payload,
+    );
+    expect(result.success).toBe(false);
+    expect(result.errorReason).toBe(Errors.ErrERC7710RedeemFailed);
+  });
+
+  it("returns failure when receipt status is not success", async () => {
+    const signer = makeSigner({
+      waitForTransactionReceipt: vi.fn().mockResolvedValue({ status: "reverted" }),
+    });
+    const result = await settleERC7710(
+      signer,
+      validPayload,
+      validRequirements,
+      validErc7710Payload,
+    );
+    expect(result.success).toBe(false);
+    expect(result.errorReason).toBe(Errors.ErrERC7710RedeemFailed);
+    expect(result.transaction).toBe(TX_HASH);
+  });
+
+  it("calls redeemDelegations with correct args on settle", async () => {
+    const signer = makeSigner();
+    await settleERC7710(signer, validPayload, validRequirements, validErc7710Payload);
+    expect(signer.writeContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: DELEGATION_MANAGER,
+        functionName: "redeemDelegations",
+      }),
+    );
+  });
+});

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/erc7710.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/erc7710.ts
@@ -7,7 +7,6 @@ import {
 import { encodeFunctionData, getAddress, isAddress } from "viem";
 import { FacilitatorEvmSigner } from "../../signer";
 import { ExactERC7710Payload } from "../../types";
-import { getEvmChainId } from "../../utils";
 import * as Errors from "./errors";
 
 /**
@@ -92,6 +91,7 @@ function buildExecutionCalldata(
  * Validates structural integrity of an ERC-7710 payload.
  * Does NOT perform on-chain checks — purely field-level validation.
  *
+ * @param erc7710Payload - The ERC-7710 payload to validate.
  * @returns null if valid, or an error reason string.
  */
 function validatePayloadFields(erc7710Payload: ExactERC7710Payload): string | null {
@@ -118,8 +118,8 @@ function validatePayloadFields(erc7710Payload: ExactERC7710Payload): string | nu
  * the facilitator calls `redeemDelegations` via `eth_call` to confirm the delegation
  * is valid and the transfer would succeed.
  *
- * @param signer       - The facilitator signer (needs readContract for simulation)
- * @param payload      - The full payment payload
+ * @param signer - The facilitator signer (needs readContract for simulation)
+ * @param payload - The full payment payload
  * @param requirements - The payment requirements
  * @param erc7710Payload - The ERC-7710 specific payload fields
  * @returns Promise resolving to a VerifyResponse
@@ -151,6 +151,7 @@ export async function verifyERC7710(
   const payTo = getAddress(requirements.payTo);
   const amount = BigInt(requirements.amount);
   const delegationManager = getAddress(erc7710Payload.delegationManager);
+  const facilitatorAddress = signer.getAddresses()[0];
 
   // Build the execution calldata for a single ERC-20 transfer
   const executionCalldata = buildExecutionCalldata(tokenAddress, payTo, amount);
@@ -163,6 +164,7 @@ export async function verifyERC7710(
       abi: delegationManagerABI,
       functionName: "redeemDelegations",
       args: [[erc7710Payload.permissionContext], [SINGLE_CALL_MODE], [executionCalldata]],
+      account: facilitatorAddress,
     });
   } catch {
     return { isValid: false, invalidReason: Errors.ErrERC7710SimulationFailed, payer };
@@ -180,9 +182,9 @@ export async function verifyERC7710(
  *    and calls the delegator account, which performs `token.transfer(payTo, amount)`.
  * 3. Wait for receipt and confirm success.
  *
- * @param signer        - The facilitator signer (needs writeContract + waitForTransactionReceipt)
- * @param payload       - The full payment payload
- * @param requirements  - The payment requirements
+ * @param signer - The facilitator signer (needs writeContract + waitForTransactionReceipt)
+ * @param payload - The full payment payload
+ * @param requirements - The payment requirements
  * @param erc7710Payload - The ERC-7710 specific payload fields
  * @returns Promise resolving to a SettleResponse
  */

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/erc7710.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/erc7710.ts
@@ -1,0 +1,247 @@
+import {
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+  VerifyResponse,
+} from "@x402/core/types";
+import { encodeFunctionData, getAddress, isAddress } from "viem";
+import { FacilitatorEvmSigner } from "../../signer";
+import { ExactERC7710Payload } from "../../types";
+import { getEvmChainId } from "../../utils";
+import * as Errors from "./errors";
+
+/**
+ * ERC-20 `transfer(address,uint256)` ABI — used to build execution calldata.
+ */
+const erc20TransferABI = [
+  {
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    name: "transfer",
+    outputs: [{ name: "", type: "bool" }],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+] as const;
+
+/**
+ * ERC-7710 DelegationManager ABI — only the `redeemDelegations` function.
+ *
+ * Per the spec:
+ *   redeemDelegations(
+ *     bytes[] calldata permissionContexts,
+ *     bytes32[] calldata modes,
+ *     bytes[] calldata executionCalldatas
+ *   )
+ */
+const delegationManagerABI = [
+  {
+    inputs: [
+      { name: "permissionContexts", type: "bytes[]" },
+      { name: "modes", type: "bytes32[]" },
+      { name: "executionCalldatas", type: "bytes[]" },
+    ],
+    name: "redeemDelegations",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+] as const;
+
+/**
+ * ERC-7579 single-call execution mode.
+ * bytes32: 0x00...00 signals "single call, no value, no revert-on-failure override".
+ */
+const SINGLE_CALL_MODE =
+  "0x0000000000000000000000000000000000000000000000000000000000000000" as const;
+
+/**
+ * Builds the ERC-7579 executionCalldata for a single ERC-20 transfer.
+ *
+ * ERC-7579 single-call executionCalldata format:
+ *   abi.encodePacked(target, value, callData)
+ *   where value is uint256 (32 bytes) and callData is the selector + args.
+ *
+ * @param tokenAddress - ERC-20 token contract address
+ * @param payTo        - Recipient address
+ * @param amount       - Transfer amount (in token's smallest unit)
+ * @returns ABI-packed execution calldata bytes
+ */
+function buildExecutionCalldata(
+  tokenAddress: `0x${string}`,
+  payTo: `0x${string}`,
+  amount: bigint,
+): `0x${string}` {
+  const transferCalldata = encodeFunctionData({
+    abi: erc20TransferABI,
+    functionName: "transfer",
+    args: [payTo, amount],
+  });
+
+  // ERC-7579 packed format: target (20 bytes) + value (32 bytes, zero) + calldata
+  const target = tokenAddress.slice(2).padStart(40, "0");
+  const value = "0".padStart(64, "0");
+  const data = transferCalldata.slice(2);
+
+  return `0x${target}${value}${data}`;
+}
+
+/**
+ * Validates structural integrity of an ERC-7710 payload.
+ * Does NOT perform on-chain checks — purely field-level validation.
+ *
+ * @returns null if valid, or an error reason string.
+ */
+function validatePayloadFields(erc7710Payload: ExactERC7710Payload): string | null {
+  if (!isAddress(erc7710Payload.delegationManager)) {
+    return Errors.ErrERC7710InvalidDelegationManager;
+  }
+  if (!isAddress(erc7710Payload.delegator)) {
+    return Errors.ErrERC7710InvalidDelegator;
+  }
+  if (
+    !erc7710Payload.permissionContext ||
+    !erc7710Payload.permissionContext.startsWith("0x") ||
+    erc7710Payload.permissionContext.length < 4 // at minimum "0x" + 1 byte
+  ) {
+    return Errors.ErrERC7710InvalidPermissionContext;
+  }
+  return null;
+}
+
+/**
+ * Verifies an ERC-7710 payment payload via on-chain simulation.
+ *
+ * Per the spec, verification for ERC-7710 is performed entirely through simulation:
+ * the facilitator calls `redeemDelegations` via `eth_call` to confirm the delegation
+ * is valid and the transfer would succeed.
+ *
+ * @param signer       - The facilitator signer (needs readContract for simulation)
+ * @param payload      - The full payment payload
+ * @param requirements - The payment requirements
+ * @param erc7710Payload - The ERC-7710 specific payload fields
+ * @returns Promise resolving to a VerifyResponse
+ */
+export async function verifyERC7710(
+  signer: FacilitatorEvmSigner,
+  payload: PaymentPayload,
+  requirements: PaymentRequirements,
+  erc7710Payload: ExactERC7710Payload,
+): Promise<VerifyResponse> {
+  const payer = erc7710Payload.delegator;
+
+  // Scheme + network checks
+  if (payload.accepted.scheme !== "exact" || requirements.scheme !== "exact") {
+    return { isValid: false, invalidReason: Errors.ErrInvalidScheme, payer };
+  }
+
+  if (payload.accepted.network !== requirements.network) {
+    return { isValid: false, invalidReason: Errors.ErrNetworkMismatch, payer };
+  }
+
+  // Field-level validation
+  const fieldError = validatePayloadFields(erc7710Payload);
+  if (fieldError) {
+    return { isValid: false, invalidReason: fieldError, payer };
+  }
+
+  const tokenAddress = getAddress(requirements.asset);
+  const payTo = getAddress(requirements.payTo);
+  const amount = BigInt(requirements.amount);
+  const delegationManager = getAddress(erc7710Payload.delegationManager);
+
+  // Build the execution calldata for a single ERC-20 transfer
+  const executionCalldata = buildExecutionCalldata(tokenAddress, payTo, amount);
+
+  // Simulate redeemDelegations via eth_call.
+  // Per spec: "If the simulation succeeds, the payment is considered valid."
+  try {
+    await signer.readContract({
+      address: delegationManager,
+      abi: delegationManagerABI,
+      functionName: "redeemDelegations",
+      args: [[erc7710Payload.permissionContext], [SINGLE_CALL_MODE], [executionCalldata]],
+    });
+  } catch {
+    return { isValid: false, invalidReason: Errors.ErrERC7710SimulationFailed, payer };
+  }
+
+  return { isValid: true, invalidReason: undefined, payer };
+}
+
+/**
+ * Settles an ERC-7710 payment by calling `redeemDelegations` on the DelegationManager.
+ *
+ * Flow:
+ * 1. Re-verify the delegation (field + simulation checks).
+ * 2. Call `redeemDelegations` — the DelegationManager validates the delegation authority
+ *    and calls the delegator account, which performs `token.transfer(payTo, amount)`.
+ * 3. Wait for receipt and confirm success.
+ *
+ * @param signer        - The facilitator signer (needs writeContract + waitForTransactionReceipt)
+ * @param payload       - The full payment payload
+ * @param requirements  - The payment requirements
+ * @param erc7710Payload - The ERC-7710 specific payload fields
+ * @returns Promise resolving to a SettleResponse
+ */
+export async function settleERC7710(
+  signer: FacilitatorEvmSigner,
+  payload: PaymentPayload,
+  requirements: PaymentRequirements,
+  erc7710Payload: ExactERC7710Payload,
+): Promise<SettleResponse> {
+  const payer = erc7710Payload.delegator;
+  const network = payload.accepted.network;
+
+  // Re-verify before settling (field + simulation)
+  const valid = await verifyERC7710(signer, payload, requirements, erc7710Payload);
+  if (!valid.isValid) {
+    return {
+      success: false,
+      network,
+      transaction: "",
+      errorReason: valid.invalidReason ?? Errors.ErrInvalidScheme,
+      payer,
+    };
+  }
+
+  const tokenAddress = getAddress(requirements.asset);
+  const payTo = getAddress(requirements.payTo);
+  const amount = BigInt(requirements.amount);
+  const delegationManager = getAddress(erc7710Payload.delegationManager);
+
+  const executionCalldata = buildExecutionCalldata(tokenAddress, payTo, amount);
+
+  try {
+    const tx = await signer.writeContract({
+      address: delegationManager,
+      abi: delegationManagerABI,
+      functionName: "redeemDelegations",
+      args: [[erc7710Payload.permissionContext], [SINGLE_CALL_MODE], [executionCalldata]],
+    });
+
+    const receipt = await signer.waitForTransactionReceipt({ hash: tx });
+
+    if (receipt.status !== "success") {
+      return {
+        success: false,
+        errorReason: Errors.ErrERC7710RedeemFailed,
+        transaction: tx,
+        network,
+        payer,
+      };
+    }
+
+    return { success: true, transaction: tx, network, payer };
+  } catch {
+    return {
+      success: false,
+      errorReason: Errors.ErrERC7710RedeemFailed,
+      transaction: "",
+      network,
+      payer,
+    };
+  }
+}

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/errors.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/errors.ts
@@ -66,6 +66,13 @@ export const ErrEip2612AssetMismatch = "eip2612_asset_mismatch";
 export const ErrEip2612SpenderNotPermit2 = "eip2612_spender_not_permit2";
 export const ErrEip2612DeadlineExpired = "eip2612_deadline_expired";
 
+// ERC-7710 verify/settle errors
+export const ErrERC7710InvalidDelegationManager = "invalid_erc7710_delegation_manager";
+export const ErrERC7710InvalidDelegator = "invalid_erc7710_delegator";
+export const ErrERC7710InvalidPermissionContext = "invalid_erc7710_permission_context";
+export const ErrERC7710SimulationFailed = "invalid_erc7710_simulation_failed";
+export const ErrERC7710RedeemFailed = "invalid_erc7710_redeem_failed";
+
 // Shared settle errors
 export const ErrUnsupportedPayloadType = "unsupported_payload_type";
 export const ErrInvalidTransactionState = "invalid_transaction_state";

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/scheme.ts
@@ -7,9 +7,16 @@ import {
   VerifyResponse,
 } from "@x402/core/types";
 import { FacilitatorEvmSigner } from "../../signer";
-import { ExactEvmPayloadV2, ExactEIP3009Payload, isPermit2Payload } from "../../types";
+import {
+  ExactEvmPayloadV2,
+  ExactEIP3009Payload,
+  ExactERC7710Payload,
+  isPermit2Payload,
+  isERC7710Payload,
+} from "../../types";
 import { verifyEIP3009, settleEIP3009 } from "./eip3009";
 import { verifyPermit2, settlePermit2 } from "./permit2";
+import { verifyERC7710, settleERC7710 } from "./erc7710";
 
 export interface ExactEvmSchemeConfig {
   /**
@@ -44,10 +51,7 @@ export class ExactEvmScheme implements SchemeNetworkFacilitator {
    * @param signer - The EVM signer for facilitator operations
    * @param config - Optional configuration
    */
-  constructor(
-    private readonly signer: FacilitatorEvmSigner,
-    config?: ExactEvmSchemeConfig,
-  ) {
+  constructor(private readonly signer: FacilitatorEvmSigner, config?: ExactEvmSchemeConfig) {
     this.config = {
       deployERC4337WithEIP6492: config?.deployERC4337WithEIP6492 ?? false,
       simulateInSettle: config?.simulateInSettle ?? false,
@@ -75,7 +79,7 @@ export class ExactEvmScheme implements SchemeNetworkFacilitator {
   }
 
   /**
-   * Verifies a payment payload. Routes to Permit2 or EIP-3009 based on payload type.
+   * Verifies a payment payload. Routes to ERC-7710, Permit2, or EIP-3009 based on payload type.
    *
    * @param payload - The payment payload to verify
    * @param requirements - The payment requirements
@@ -88,9 +92,12 @@ export class ExactEvmScheme implements SchemeNetworkFacilitator {
     context?: FacilitatorContext,
   ): Promise<VerifyResponse> {
     const rawPayload = payload.payload as ExactEvmPayloadV2;
-    const isPermit2 = isPermit2Payload(rawPayload);
 
-    if (isPermit2) {
+    if (isERC7710Payload(rawPayload)) {
+      return verifyERC7710(this.signer, payload, requirements, rawPayload as ExactERC7710Payload);
+    }
+
+    if (isPermit2Payload(rawPayload)) {
       return verifyPermit2(this.signer, payload, requirements, rawPayload, context);
     }
 
@@ -99,7 +106,7 @@ export class ExactEvmScheme implements SchemeNetworkFacilitator {
   }
 
   /**
-   * Settles a payment. Routes to Permit2 or EIP-3009 based on payload type.
+   * Settles a payment. Routes to ERC-7710, Permit2, or EIP-3009 based on payload type.
    *
    * @param payload - The payment payload to settle
    * @param requirements - The payment requirements
@@ -112,9 +119,12 @@ export class ExactEvmScheme implements SchemeNetworkFacilitator {
     context?: FacilitatorContext,
   ): Promise<SettleResponse> {
     const rawPayload = payload.payload as ExactEvmPayloadV2;
-    const isPermit2 = isPermit2Payload(rawPayload);
 
-    if (isPermit2) {
+    if (isERC7710Payload(rawPayload)) {
+      return settleERC7710(this.signer, payload, requirements, rawPayload as ExactERC7710Payload);
+    }
+
+    if (isPermit2Payload(rawPayload)) {
       return settlePermit2(this.signer, payload, requirements, rawPayload, context, {
         simulateInSettle: this.config.simulateInSettle,
       });

--- a/typescript/packages/mechanisms/evm/src/signer.ts
+++ b/typescript/packages/mechanisms/evm/src/signer.ts
@@ -74,6 +74,8 @@ export type FacilitatorEvmSigner = {
     abi: readonly unknown[];
     functionName: string;
     args?: readonly unknown[];
+    /** Optional caller account for eth_call / simulation (msg.sender). */
+    account?: `0x${string}`;
   }): Promise<unknown>;
   verifyTypedData(args: {
     address: `0x${string}`;

--- a/typescript/packages/mechanisms/evm/src/types.ts
+++ b/typescript/packages/mechanisms/evm/src/types.ts
@@ -2,8 +2,9 @@
  * Asset transfer methods for the exact EVM scheme.
  * - eip3009: Uses transferWithAuthorization (USDC, etc.) - recommended for compatible tokens
  * - permit2: Uses Permit2 + x402Permit2Proxy - universal fallback for any ERC-20
+ * - erc7710: Uses ERC-7710 smart account delegation
  */
-export type AssetTransferMethod = "eip3009" | "permit2";
+export type AssetTransferMethod = "eip3009" | "permit2" | "erc7710";
 
 /**
  * EIP-3009 payload for tokens with native transferWithAuthorization support.
@@ -55,9 +56,21 @@ export type ExactPermit2Payload = {
   };
 };
 
+/**
+ * ERC-7710 delegation payload for smart accounts with delegation support.
+ */
+export type ExactERC7710Payload = {
+  /** Address of the ERC-7710 DelegationManager contract */
+  delegationManager: `0x${string}`;
+  /** Opaque delegation proof/context bytes (ABI-encoded delegation chain) */
+  permissionContext: `0x${string}`;
+  /** Address of the delegating smart account */
+  delegator: `0x${string}`;
+};
+
 export type ExactEvmPayloadV1 = ExactEIP3009Payload;
 
-export type ExactEvmPayloadV2 = ExactEIP3009Payload | ExactPermit2Payload;
+export type ExactEvmPayloadV2 = ExactEIP3009Payload | ExactPermit2Payload | ExactERC7710Payload;
 
 /**
  * Type guard to check if a payload is a Permit2 payload.
@@ -68,6 +81,17 @@ export type ExactEvmPayloadV2 = ExactEIP3009Payload | ExactPermit2Payload;
  */
 export function isPermit2Payload(payload: ExactEvmPayloadV2): payload is ExactPermit2Payload {
   return "permit2Authorization" in payload;
+}
+
+/**
+ * Type guard to check if a payload is an ERC-7710 payload.
+ * ERC-7710 payloads have a `delegationManager` field.
+ *
+ * @param payload - The payload to check.
+ * @returns True if the payload is an ERC-7710 payload, false otherwise.
+ */
+export function isERC7710Payload(payload: ExactEvmPayloadV2): payload is ExactERC7710Payload {
+  return "delegationManager" in payload;
 }
 
 /**

--- a/typescript/site/app/facilitator/index.ts
+++ b/typescript/site/app/facilitator/index.ts
@@ -55,6 +55,7 @@ async function createFacilitator(): Promise<x402Facilitator> {
       abi: readonly unknown[];
       functionName: string;
       args?: readonly unknown[];
+      account?: `0x${string}`;
     }) =>
       viemClient.readContract({
         ...args,


### PR DESCRIPTION
Add `verifyERC7710` and `settleERC7710` alongside the existing EIP-3009 and Permit2 implementations, completing the three asset transfer methods defined in `specs/schemes/exact/scheme_exact_evm.md`.

## Description

ERC-7710 was fully specced in the repo but had zero TypeScript implementation. This PR closes that gap.

**Changes:**
- `src/types.ts`: `ExactERC7710Payload` type, `isERC7710Payload()` guard, `AssetTransferMethod` extended with `'erc7710'`
- `src/exact/facilitator/erc7710.ts`: `verifyERC7710` (field validation + eth_call simulation of redeemDelegations) and `settleERC7710` (re-verify + writeContract + receipt wait). Calldata uses ERC-7579 packed format with SINGLE_CALL_MODE.
- `src/exact/facilitator/errors.ts`: 5 new ERC-7710 error constants
- `src/exact/facilitator/scheme.ts`: ERC-7710 branch in verify() and settle(), checked first
- `src/exact/facilitator/erc7710.test.ts`: full unit test coverage
- `typescript/.changeset/erc7710-delegation-support.md`: changeset fragment (@x402/evm minor)

**Spec ref:** `specs/schemes/exact/scheme_exact_evm.md §3`
**Note:** verification is simulation-only per spec design. Gas limit should be set by callers per spec security recommendation.

## Tests

pnpm test --filter @x402/evm

## Checklist
- [x] Formatted (prettier applied)
- [x] Unit tests added
- [x] Changeset fragment added
- [x] Commits need signing — happy to rebase with GPG if required