### PR TITLE
Add SignalFuse to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/signalfuse/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/signalfuse/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "SignalFuse",
+  "category": "DeFi & Finance",
+  "logoUrl": "https://raw.githubusercontent.com/hypeprinter007-stack/plugin-signalfuse/main/images/logo.jpg",
+  "description": "Trading intelligence API fusing social sentiment, macro regime, and market structure into directional crypto signals. $0.01/call USDC on Base via CDP facilitator.",
+  "websiteUrl": "https://signalfuse.co"
+}


### PR DESCRIPTION
Adds SignalFuse to the x402 ecosystem directory.

**What it is:** Trading intelligence API fusing social sentiment (ModernFinBERT), macro regime, and Hyperliquid market structure into directional crypto signals. Now with a live Strategy Arena and full Bazaar discovery support.

**x402 integration:**
- Real USDC payments on Base mainnet via CDP facilitator
- Per-asset premium thresholds across all signal endpoints
- Full **Bazaar discovery metadata** on all x402 routes (`bazaar_resource_server_extension` registered)
- Live Strategy Arena: 4 AI strategies competing with real USDC entry fees, server-side context on Railway, verifiable on Basescan
- Also supports credit tokens (25 free, no signup)

**MCP server — 11 tools:**
signals, sentiment, regime, arena, Brave web search, Tavily web search, E2B code execution, pricing, balance, and more (`npm install signalfuse-mcp@1.1.0`)

**Python SDK:** `pip install signalfuse`

**Published integrations:** MCP server (npm), Python SDK (PyPI), LangChain tool, ElizaOS plugin, Hyperliquid starter bot

## Links
- Website: https://signalfuse.co
- npm: https://www.npmjs.com/package/signalfuse-mcp
- PyPI: https://pypi.org/project/signalfuse/
- GitHub: https://github.com/hypeprinter007-stack/signalfuse-mcp
- Starter bot: https://github.com/hypeprinter007-stack/hyperliquid-starter-bot