### PR TITLE
ecosystem: add AAAA-Nexus — hosted AI infrastructure with x402 payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,5 @@ See `specs/schemes` for more details on schemes, and see `specs/schemes/exact/sc
 Because a scheme is a logical way of moving money, the way a scheme is implemented can be different for different blockchains. (ex: the way you need to implement `exact` on Ethereum is very different from the way you need to implement `exact` on Solana).
 
 Clients and facilitators must explicitly support different `(scheme, network)` pairs in order to be able to create proper payloads and verify / settle payments.
+
+- [Aethel-Nexus AAAA](https://aaaa-nexus.atomadictech.workers.dev) - 22-endpoint AI infrastructure on Cloudflare Workers: streaming CoT inference, Leech lattice compression, AIBOM drift, EU AI Act compliance, agent swarm, quantum RNG. x402 USDC micropayments on Base L2. Google A2A agent card (22 skills) + MCP server.

--- a/README.md
+++ b/README.md
@@ -137,4 +137,4 @@ Because a scheme is a logical way of moving money, the way a scheme is implement
 
 Clients and facilitators must explicitly support different `(scheme, network)` pairs in order to be able to create proper payloads and verify / settle payments.
 
-- [Aethel-Nexus AAAA](https://aaaa-nexus.atomadictech.workers.dev) - 22-endpoint AI infrastructure on Cloudflare Workers: streaming CoT inference, Leech lattice compression, AIBOM drift, EU AI Act compliance, agent swarm, quantum RNG. x402 USDC micropayments on Base L2. Google A2A agent card (22 skills) + MCP server.
+- [AAAA-Nexus](https://aaaa-nexus.atomadictech.workers.dev) - Hosted AI infrastructure with x402 pay-per-call access, MCP support, and public agent discovery.

--- a/typescript/site/app/ecosystem/partners-data/aaaa-nexus/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/aaaa-nexus/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "AAAA-Nexus",
+  "description": "Hosted AI infrastructure with x402 pay-per-call access, MCP support, and agent-card based discovery.",
+  "logoUrl": "/logos/aaaa-nexus.png",
+  "websiteUrl": "https://aaaa-nexus.atomadictech.workers.dev",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/app/ecosystem/partners-data/aethel-nexus-aaaa/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/aethel-nexus-aaaa/metadata.json
@@ -1,7 +1,0 @@
-{
-  "name": "Aethel-Nexus AAAA",
-  "description": "Pay-per-call AI inference (Llama-3.1-8B, OpenAI-compatible) + Leech lattice tensor compression (8:1, Lean 4 formally verified) via x402 USDC micropayments on Base L2. No account, no API key. Google A2A agent card at /.well-known/agent.json with 22 machine-readable skills.",
-  "logoUrl": "/logos/aethel-nexus-aaaa.png",
-  "websiteUrl": "https://aaaa-nexus.atomadictech.workers.dev",
-  "category": "Services/Endpoints"
-}

--- a/typescript/site/app/ecosystem/partners-data/aethel-nexus-aaaa/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/aethel-nexus-aaaa/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Aethel-Nexus AAAA",
+  "description": "Pay-per-call AI inference (Llama-3.1-8B, OpenAI-compatible) + Leech lattice tensor compression (8:1, Lean 4 formally verified) via x402 USDC micropayments on Base L2. No account, no API key. Google A2A agent card at /.well-known/agent.json with 22 machine-readable skills.",
+  "logoUrl": "/logos/aethel-nexus-aaaa.png",
+  "websiteUrl": "https://aaaa-nexus.atomadictech.workers.dev",
+  "category": "Services/Endpoints"
+}


### PR DESCRIPTION
## Summary

Adding AAAA-Nexus to the x402 ecosystem.

## Why it belongs

- hosted AI infrastructure with x402 pay-per-call access
- public API at https://aaaa-nexus.atomadictech.workers.dev
- hosted MCP endpoint at /mcp
- public repo: https://github.com/atomadictech/aaaa-nexus
- agent card: https://aaaa-nexus.atomadictech.workers.dev/.well-known/agent.json

This updates the submission to the current approved public positioning and removes older naming from the ecosystem entry.