### PR TITLE
ecosystem: add x402-insights — spend observability for facilitator flows

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/x402-insights/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-insights/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402-insights",
+  "description": "Spend observability for x402 facilitator flows. Instruments verify and settle hooks to surface cost concentration, retry waste, and settlement latency. Tested on Base Sepolia.",
+  "logoUrl": "/logos/x402-insights.svg",
+  "websiteUrl": "https://github.com/Bortlesboat/x402-insights",
+  "category": "Infrastructure & Tooling"
+}

--- a/typescript/site/public/logos/x402-insights.svg
+++ b/typescript/site/public/logos/x402-insights.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none">
+  <rect width="120" height="120" rx="16" fill="#0b0d10"/>
+  <rect x="20" y="70" width="16" height="30" rx="3" fill="#4c8bf5"/>
+  <rect x="44" y="50" width="16" height="50" rx="3" fill="#4c8bf5"/>
+  <rect x="68" y="30" width="16" height="70" rx="3" fill="#4c8bf5"/>
+  <circle cx="92" cy="40" r="8" fill="#51cf66"/>
+  <path d="M28 60 L52 40 L76 22" stroke="#e8eaed" stroke-width="2.5" stroke-linecap="round" opacity="0.5"/>
+</svg>


### PR DESCRIPTION
## x402-insights — Spend Observability

**Category:** Infrastructure & Tooling

**Repo:** https://github.com/Bortlesboat/x402-insights

Instruments the six lifecycle hooks on `x402Facilitator` (onBeforeVerify, onAfterVerify, onVerifyFailure, onBeforeSettle, onAfterSettle, onSettleFailure) to capture spend, latency, and errors per endpoint.

**What it shows:**
- Cost concentration by endpoint
- Verify vs settle latency split (settle dominates ~20:1 in practice)
- Retry spend as % of total
- Error rate and failed settlement cost

**Integration:**
```ts
import { attachInsights } from "@x402-insights/facilitator";
attachInsights(facilitator, { baseUrl, apiKey, source: "my-facilitator" });
```

Tested on Base Sepolia with real verify/settle calls — not simulated traffic.

**Changes:**
- `typescript/site/app/ecosystem/partners-data/x402-insights/metadata.json`
- `typescript/site/public/logos/x402-insights.svg`