### PR TITLE
 feat(evm): add optional ERC-8021 Builder Code attribution to settlement transactions

### DIFF
--- a/typescript/.changeset/add-erc8021-builder-code.md
+++ b/typescript/.changeset/add-erc8021-builder-code.md
@@ -1,0 +1,5 @@
+---
+"@x402/evm": minor
+---
+
+Add optional ERC-8021 Builder Code attribution to settlement transactions

--- a/typescript/packages/mechanisms/evm/src/erc8021.ts
+++ b/typescript/packages/mechanisms/evm/src/erc8021.ts
@@ -1,0 +1,59 @@
+import { encodeFunctionData, type Hex } from "viem";
+import type { FacilitatorEvmSigner } from "./signer";
+
+// ERC-8021 trailing marker (16 bytes) + schema byte
+const ERC_8021_MARKER = "8021000000000000000000008021";
+const ERC_8021_SCHEMA_ID = "01";
+
+/**
+ * Builds the raw ERC-8021 suffix: `[builderCode ASCII hex][schema 0x01][marker]`
+ *
+ * @param builderCode - UTF-8 builder code string to encode
+ * @returns Hex-encoded suffix string (without 0x prefix)
+ */
+export function buildErc8021Suffix(builderCode: string): string {
+  const codeHex = Buffer.from(builderCode, "utf-8").toString("hex");
+  return `${codeHex}${ERC_8021_SCHEMA_ID}${ERC_8021_MARKER}`;
+}
+
+/**
+ * Wraps `signer.writeContract` to optionally append an ERC-8021 Builder Code suffix.
+ * When no builderCode is provided, falls through to writeContract directly.
+ *
+ * @param signer - Facilitator signer for contract interactions
+ * @param writeArgs - Contract write parameters
+ * @param writeArgs.address - Target contract address
+ * @param writeArgs.abi - Contract ABI
+ * @param writeArgs.functionName - Function to call
+ * @param writeArgs.args - Function arguments
+ * @param writeArgs.gas - Optional gas limit
+ * @param builderCode - Optional ERC-8021 builder code to append
+ * @returns Transaction hash
+ */
+export async function writeContractWithBuilderCode(
+  signer: FacilitatorEvmSigner,
+  writeArgs: {
+    address: `0x${string}`;
+    abi: readonly unknown[];
+    functionName: string;
+    args: readonly unknown[];
+    gas?: bigint;
+  },
+  builderCode?: string,
+): Promise<Hex> {
+  if (!builderCode) {
+    return signer.writeContract(writeArgs);
+  }
+
+  const calldata = encodeFunctionData({
+    abi: writeArgs.abi as readonly Record<string, unknown>[],
+    functionName: writeArgs.functionName,
+    args: [...writeArgs.args],
+  });
+
+  const suffix = buildErc8021Suffix(builderCode);
+  return signer.sendTransaction({
+    to: writeArgs.address,
+    data: `${calldata}${suffix}` as Hex,
+  });
+}

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009-utils.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009-utils.ts
@@ -1,5 +1,6 @@
 import { PaymentRequirements, VerifyResponse } from "@x402/core/types";
 import { encodeFunctionData, getAddress, Hex, parseErc6492Signature, parseSignature } from "viem";
+import { writeContractWithBuilderCode } from "../../erc8021";
 import { eip3009ABI } from "../../constants";
 import { multicall, ContractCall, RawContractCall } from "../../multicall";
 import { FacilitatorEvmSigner } from "../../signer";
@@ -195,12 +196,14 @@ export async function diagnoseEip3009SimulationFailure(
  * @param erc20Address - ERC-20 token contract address
  * @param payload - EIP-3009 transfer authorization payload
  *
+ * @param builderCode - Optional ERC-8021 builder code to append to calldata
  * @returns Transaction hash
  */
 export async function executeTransferWithAuthorization(
   signer: FacilitatorEvmSigner,
   erc20Address: `0x${string}`,
   payload: ExactEIP3009Payload,
+  builderCode?: string,
 ): Promise<Hex> {
   const { signature } = parseErc6492Signature(payload.signature!);
   const signatureLength = signature.startsWith("0x") ? signature.length - 2 : signature.length;
@@ -218,23 +221,31 @@ export async function executeTransferWithAuthorization(
 
   if (isECDSA) {
     const parsedSig = parseSignature(signature);
-    return signer.writeContract({
+    return writeContractWithBuilderCode(
+      signer,
+      {
+        address: erc20Address,
+        abi: eip3009ABI,
+        functionName: "transferWithAuthorization",
+        args: [
+          ...baseArgs,
+          (parsedSig.v as number | undefined) || parsedSig.yParity,
+          parsedSig.r,
+          parsedSig.s,
+        ],
+      },
+      builderCode,
+    );
+  }
+
+  return writeContractWithBuilderCode(
+    signer,
+    {
       address: erc20Address,
       abi: eip3009ABI,
       functionName: "transferWithAuthorization",
-      args: [
-        ...baseArgs,
-        (parsedSig.v as number | undefined) || parsedSig.yParity,
-        parsedSig.r,
-        parsedSig.s,
-      ],
-    });
-  }
-
-  return signer.writeContract({
-    address: erc20Address,
-    abi: eip3009ABI,
-    functionName: "transferWithAuthorization",
-    args: [...baseArgs, signature],
-  });
+      args: [...baseArgs, signature],
+    },
+    builderCode,
+  );
 }

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
@@ -35,6 +35,8 @@ export interface EIP3009FacilitatorConfig {
    * @default false
    */
   simulateInSettle?: boolean;
+  /** ERC-8021 Builder Code to append to settlement calldata. */
+  builderCode?: string;
 }
 
 /**
@@ -297,6 +299,7 @@ export async function settleEIP3009(
       signer,
       getAddress(requirements.asset),
       eip3009Payload,
+      config.builderCode,
     );
 
     // Wait for transaction confirmation

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
@@ -15,6 +15,7 @@ import {
   type Erc20ApprovalGasSponsoringSigner,
 } from "../extensions";
 import { getAddress, encodeFunctionData } from "viem";
+import { writeContractWithBuilderCode, buildErc8021Suffix } from "../../erc8021";
 import {
   PERMIT2_ADDRESS,
   permit2WitnessTypes,
@@ -58,6 +59,8 @@ export interface Permit2FacilitatorConfig {
    * @default false
    */
   simulateInSettle?: boolean;
+  /** ERC-8021 Builder Code to append to settlement calldata. */
+  builderCode?: string;
 }
 
 /**
@@ -353,10 +356,19 @@ export async function settlePermit2(
     };
   }
 
+  const builderCode = config?.builderCode;
+
   // Branch: EIP-2612 gas sponsoring (atomic settleWithPermit via contract)
   const eip2612Info = extractEip2612GasSponsoringInfo(payload);
   if (eip2612Info) {
-    return settlePermit2WithEIP2612(exactProxyConfig, signer, payload, permit2Payload, eip2612Info);
+    return settlePermit2WithEIP2612(
+      exactProxyConfig,
+      signer,
+      payload,
+      permit2Payload,
+      eip2612Info,
+      builderCode,
+    );
   }
 
   // Branch: ERC-20 approval gas sponsoring (broadcast approval + settle via extension signer)
@@ -377,12 +389,13 @@ export async function settlePermit2(
         payload,
         permit2Payload,
         erc20Info,
+        builderCode,
       );
     }
   }
 
   // Branch: standard settle (allowance already on-chain)
-  return settlePermit2Direct(exactProxyConfig, signer, payload, permit2Payload);
+  return settlePermit2Direct(exactProxyConfig, signer, payload, permit2Payload, builderCode);
 }
 
 // ---------------------------------------------------------------------------
@@ -397,6 +410,7 @@ export async function settlePermit2(
  * @param payload - The payment payload for network info
  * @param permit2Payload - The Permit2 payload with authorization and signature
  * @param eip2612Info - The EIP-2612 gas sponsoring info from the payload extension
+ * @param builderCode - Optional ERC-8021 builder code to append to calldata
  * @returns Promise resolving to a settlement response
  */
 async function settlePermit2WithEIP2612(
@@ -405,26 +419,31 @@ async function settlePermit2WithEIP2612(
   payload: PaymentPayload,
   permit2Payload: ExactPermit2Payload,
   eip2612Info: Eip2612GasSponsoringInfo,
+  builderCode?: string,
 ): Promise<SettleResponse> {
   const payer = permit2Payload.permit2Authorization.from;
   try {
     const { v, r, s } = splitEip2612Signature(eip2612Info.signature);
 
-    const tx = await signer.writeContract({
-      address: config.proxyAddress,
-      abi: config.proxyABI,
-      functionName: "settleWithPermit",
-      args: [
-        {
-          value: BigInt(eip2612Info.amount),
-          deadline: BigInt(eip2612Info.deadline),
-          r,
-          s,
-          v,
-        },
-        ...buildExactPermit2SettleArgs(permit2Payload),
-      ],
-    });
+    const tx = await writeContractWithBuilderCode(
+      signer,
+      {
+        address: config.proxyAddress,
+        abi: config.proxyABI,
+        functionName: "settleWithPermit",
+        args: [
+          {
+            value: BigInt(eip2612Info.amount),
+            deadline: BigInt(eip2612Info.deadline),
+            r,
+            s,
+            v,
+          },
+          ...buildExactPermit2SettleArgs(permit2Payload),
+        ],
+      },
+      builderCode,
+    );
 
     return waitAndReturnSettleResponse(signer, tx, payload, payer);
   } catch (error) {
@@ -441,6 +460,7 @@ async function settlePermit2WithEIP2612(
  * @param permit2Payload - The Permit2 payload with authorization and signature
  * @param erc20Info - Object containing the signed approval transaction
  * @param erc20Info.signedTransaction - The RLP-encoded signed ERC-20 approve transaction
+ * @param builderCode - Optional ERC-8021 builder code to append to calldata
  * @returns Promise resolving to a settlement response
  */
 async function settlePermit2WithERC20Approval(
@@ -449,15 +469,20 @@ async function settlePermit2WithERC20Approval(
   payload: PaymentPayload,
   permit2Payload: ExactPermit2Payload,
   erc20Info: { signedTransaction: string },
+  builderCode?: string,
 ): Promise<SettleResponse> {
   const payer = permit2Payload.permit2Authorization.from;
 
   try {
-    const settleData = encodeFunctionData({
+    let settleData = encodeFunctionData({
       abi: config.proxyABI,
       functionName: "settle",
       args: buildExactPermit2SettleArgs(permit2Payload),
     });
+
+    if (builderCode) {
+      settleData = `${settleData}${buildErc8021Suffix(builderCode)}` as `0x${string}`;
+    }
 
     const txHashes = await extensionSigner.sendTransactions([
       erc20Info.signedTransaction as `0x${string}`,
@@ -478,6 +503,7 @@ async function settlePermit2WithERC20Approval(
  * @param signer - The facilitator signer for contract writes
  * @param payload - The payment payload for network info
  * @param permit2Payload - The Permit2 payload with authorization and signature
+ * @param builderCode - Optional ERC-8021 builder code to append to calldata
  * @returns Promise resolving to a settlement response
  */
 async function settlePermit2Direct(
@@ -485,15 +511,20 @@ async function settlePermit2Direct(
   signer: FacilitatorEvmSigner,
   payload: PaymentPayload,
   permit2Payload: ExactPermit2Payload,
+  builderCode?: string,
 ): Promise<SettleResponse> {
   const payer = permit2Payload.permit2Authorization.from;
   try {
-    const tx = await signer.writeContract({
-      address: config.proxyAddress,
-      abi: config.proxyABI,
-      functionName: "settle",
-      args: buildExactPermit2SettleArgs(permit2Payload),
-    });
+    const tx = await writeContractWithBuilderCode(
+      signer,
+      {
+        address: config.proxyAddress,
+        abi: config.proxyABI,
+        functionName: "settle",
+        args: buildExactPermit2SettleArgs(permit2Payload),
+      },
+      builderCode,
+    );
 
     return waitAndReturnSettleResponse(signer, tx, payload, payer);
   } catch (error) {

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/scheme.ts
@@ -25,6 +25,11 @@ export interface ExactEvmSchemeConfig {
    * @default false
    */
   simulateInSettle?: boolean;
+  /**
+   * ASCII Builder Code to append as an ERC-8021 suffix on settlement transactions.
+   * When set, settlement calldata is extended with the builder attribution tag.
+   */
+  builderCode?: string;
 }
 
 /**
@@ -51,6 +56,7 @@ export class ExactEvmScheme implements SchemeNetworkFacilitator {
     this.config = {
       deployERC4337WithEIP6492: config?.deployERC4337WithEIP6492 ?? false,
       simulateInSettle: config?.simulateInSettle ?? false,
+      builderCode: config?.builderCode ?? "",
     };
   }
 
@@ -117,6 +123,7 @@ export class ExactEvmScheme implements SchemeNetworkFacilitator {
     if (isPermit2) {
       return settlePermit2(this.signer, payload, requirements, rawPayload, context, {
         simulateInSettle: this.config.simulateInSettle,
+        builderCode: this.config.builderCode || undefined,
       });
     }
 

--- a/typescript/packages/mechanisms/evm/src/index.ts
+++ b/typescript/packages/mechanisms/evm/src/index.ts
@@ -36,6 +36,9 @@ export { UptoEvmScheme } from "./upto";
 export type { UptoPermit2Payload, UptoPermit2Witness, UptoPermit2Authorization } from "./types";
 export { isUptoPermit2Payload } from "./types";
 
+// ERC-8021 Builder Code
+export { buildErc8021Suffix } from "./erc8021";
+
 // Constants
 export {
   PERMIT2_ADDRESS,

--- a/typescript/packages/mechanisms/evm/src/upto/facilitator/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/upto/facilitator/permit2.ts
@@ -14,6 +14,7 @@ import {
   type Erc20ApprovalGasSponsoringSigner,
 } from "../../exact/extensions";
 import { getAddress, encodeFunctionData } from "viem";
+import { writeContractWithBuilderCode, buildErc8021Suffix } from "../../erc8021";
 import {
   PERMIT2_ADDRESS,
   uptoPermit2WitnessTypes,
@@ -57,6 +58,8 @@ export interface VerifyUptoPermit2Options {
 
 export interface UptoPermit2FacilitatorConfig {
   simulateInSettle?: boolean;
+  /** ERC-8021 Builder Code to append to settlement calldata. */
+  builderCode?: string;
 }
 
 /**
@@ -409,6 +412,7 @@ export async function settleUptoPermit2(
   }
 
   const facilitatorAddress = getAddress(permit2Payload.permit2Authorization.witness.facilitator);
+  const builderCode = config?.builderCode;
 
   // Branch: EIP-2612 gas sponsoring (atomic settleWithPermit via contract)
   const eip2612Info = extractEip2612GasSponsoringInfo(payload);
@@ -420,6 +424,7 @@ export async function settleUptoPermit2(
       eip2612Info,
       settlementAmount,
       facilitatorAddress,
+      builderCode,
     );
   }
 
@@ -442,12 +447,20 @@ export async function settleUptoPermit2(
         erc20Info,
         settlementAmount,
         facilitatorAddress,
+        builderCode,
       );
     }
   }
 
   // Branch: standard settle (allowance already on-chain)
-  return settleUptoDirect(signer, payload, permit2Payload, settlementAmount, facilitatorAddress);
+  return settleUptoDirect(
+    signer,
+    payload,
+    permit2Payload,
+    settlementAmount,
+    facilitatorAddress,
+    builderCode,
+  );
 }
 
 /**
@@ -459,6 +472,7 @@ export async function settleUptoPermit2(
  * @param eip2612Info - The EIP-2612 gas sponsoring info from the payload extension
  * @param settlementAmount - The amount to settle on-chain
  * @param facilitatorAddress - The facilitator address authorized in the witness
+ * @param builderCode - Optional ERC-8021 builder code to append to calldata
  * @returns Promise resolving to a settlement response
  */
 async function settleUptoWithEIP2612(
@@ -468,26 +482,31 @@ async function settleUptoWithEIP2612(
   eip2612Info: Eip2612GasSponsoringInfo,
   settlementAmount: bigint,
   facilitatorAddress: `0x${string}`,
+  builderCode?: string,
 ): Promise<SettleResponse> {
   const payer = permit2Payload.permit2Authorization.from;
   try {
     const { v, r, s } = splitEip2612Signature(eip2612Info.signature);
 
-    const tx = await signer.writeContract({
-      address: uptoProxyConfig.proxyAddress,
-      abi: uptoProxyConfig.proxyABI,
-      functionName: "settleWithPermit",
-      args: [
-        {
-          value: BigInt(eip2612Info.amount),
-          deadline: BigInt(eip2612Info.deadline),
-          r,
-          s,
-          v,
-        },
-        ...buildUptoPermit2SettleArgs(permit2Payload, settlementAmount, facilitatorAddress),
-      ],
-    });
+    const tx = await writeContractWithBuilderCode(
+      signer,
+      {
+        address: uptoProxyConfig.proxyAddress,
+        abi: uptoProxyConfig.proxyABI,
+        functionName: "settleWithPermit",
+        args: [
+          {
+            value: BigInt(eip2612Info.amount),
+            deadline: BigInt(eip2612Info.deadline),
+            r,
+            s,
+            v,
+          },
+          ...buildUptoPermit2SettleArgs(permit2Payload, settlementAmount, facilitatorAddress),
+        ],
+      },
+      builderCode,
+    );
 
     const response = await waitAndReturnSettleResponse(signer, tx, payload, payer);
     return { ...response, amount: settlementAmount.toString() };
@@ -509,6 +528,7 @@ async function settleUptoWithEIP2612(
  * @param erc20Info.signedTransaction - The RLP-encoded signed ERC-20 approve transaction hex string
  * @param settlementAmount - The amount to settle on-chain
  * @param facilitatorAddress - The facilitator address authorized in the witness
+ * @param builderCode - Optional ERC-8021 builder code to append to calldata
  * @returns Promise resolving to a settlement response
  */
 async function settleUptoWithERC20Approval(
@@ -518,15 +538,20 @@ async function settleUptoWithERC20Approval(
   erc20Info: { signedTransaction: string },
   settlementAmount: bigint,
   facilitatorAddress: `0x${string}`,
+  builderCode?: string,
 ): Promise<SettleResponse> {
   const payer = permit2Payload.permit2Authorization.from;
 
   try {
-    const settleData = encodeFunctionData({
+    let settleData = encodeFunctionData({
       abi: uptoProxyConfig.proxyABI,
       functionName: "settle",
       args: buildUptoPermit2SettleArgs(permit2Payload, settlementAmount, facilitatorAddress),
     });
+
+    if (builderCode) {
+      settleData = `${settleData}${buildErc8021Suffix(builderCode)}` as `0x${string}`;
+    }
 
     const txHashes = await extensionSigner.sendTransactions([
       erc20Info.signedTransaction as `0x${string}`,
@@ -554,6 +579,7 @@ async function settleUptoWithERC20Approval(
  * @param permit2Payload - The upto Permit2 specific payload with authorization and signature
  * @param settlementAmount - The amount to settle on-chain
  * @param facilitatorAddress - The facilitator address authorized in the witness
+ * @param builderCode - Optional ERC-8021 builder code to append to calldata
  * @returns Promise resolving to a settlement response
  */
 async function settleUptoDirect(
@@ -562,15 +588,20 @@ async function settleUptoDirect(
   permit2Payload: UptoPermit2Payload,
   settlementAmount: bigint,
   facilitatorAddress: `0x${string}`,
+  builderCode?: string,
 ): Promise<SettleResponse> {
   const payer = permit2Payload.permit2Authorization.from;
   try {
-    const tx = await signer.writeContract({
-      address: uptoProxyConfig.proxyAddress,
-      abi: uptoProxyConfig.proxyABI,
-      functionName: "settle",
-      args: buildUptoPermit2SettleArgs(permit2Payload, settlementAmount, facilitatorAddress),
-    });
+    const tx = await writeContractWithBuilderCode(
+      signer,
+      {
+        address: uptoProxyConfig.proxyAddress,
+        abi: uptoProxyConfig.proxyABI,
+        functionName: "settle",
+        args: buildUptoPermit2SettleArgs(permit2Payload, settlementAmount, facilitatorAddress),
+      },
+      builderCode,
+    );
 
     const response = await waitAndReturnSettleResponse(signer, tx, payload, payer);
     return { ...response, amount: settlementAmount.toString() };

--- a/typescript/packages/mechanisms/evm/src/upto/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/upto/facilitator/scheme.ts
@@ -14,16 +14,32 @@ import { verifyUptoPermit2, settleUptoPermit2 } from "./permit2";
  * EVM facilitator implementation for the Upto payment scheme.
  * Handles verification and settlement of Permit2-based payments.
  */
+export interface UptoEvmSchemeConfig {
+  /** ERC-8021 Builder Code to append to settlement calldata. */
+  builderCode?: string;
+}
+
+/**
+ * EVM facilitator implementation for the Upto payment scheme.
+ * Handles verification and settlement of Permit2-based payments.
+ */
 export class UptoEvmScheme implements SchemeNetworkFacilitator {
   readonly scheme = "upto";
   readonly caipFamily = "eip155:*";
+  private readonly config: UptoEvmSchemeConfig;
 
   /**
-   * Creates a new UptoEvmScheme facilitator instance.
+   * Creates an UptoEvmScheme facilitator.
    *
-   * @param signer - The EVM signer for facilitator operations
+   * @param signer - The facilitator EVM signer
+   * @param config - Optional scheme configuration
    */
-  constructor(private readonly signer: FacilitatorEvmSigner) {}
+  constructor(
+    private readonly signer: FacilitatorEvmSigner,
+    config?: UptoEvmSchemeConfig,
+  ) {
+    this.config = config ?? {};
+  }
 
   /**
    * Returns extra metadata required by the upto scheme, including the facilitator address.
@@ -104,6 +120,7 @@ export class UptoEvmScheme implements SchemeNetworkFacilitator {
       requirements,
       rawPayload as UptoPermit2Payload,
       context,
+      { builderCode: this.config.builderCode },
     );
   }
 }


### PR DESCRIPTION
## Description

Adds optional ERC-8021 (Builder Code) attribution to facilitator settlement transactions.

When `builderCode` is configured on `ExactEvmScheme` or `UptoEvmScheme`, an [ERC-8021](https://docs.base.org/builderkits/builder-codes/overview) trailing suffix is appended to settlement calldata. Smart contracts ignore trailing calldata beyond ABI-decoded arguments, so this is non-breaking. Without `builderCode` set, all paths fall through to the existing `writeContract` behavior — zero change.

Covers all settlement paths: Permit2 direct, settleWithPermit (EIP-2612), ERC-20 approval, and EIP-3009 transferWithAuthorization.

---

## Usage

```ts
new ExactEvmScheme(signer, { builderCode: "myapp" })
new UptoEvmScheme(signer, { builderCode: "myapp" })
```

---

## What Changed

- New `erc8021.ts` utility with `buildErc8021Suffix()` and `writeContractWithBuilderCode()` helper
- Added `builderCode?: string` to `ExactEvmSchemeConfig`, `UptoEvmSchemeConfig`, `Permit2FacilitatorConfig`, and `EIP3009FacilitatorConfig`
- Modified all settle functions to use `writeContractWithBuilderCode` (or append suffix to raw calldata for extension signer paths)
- Exported `buildErc8021Suffix` from `@x402/evm`

---

## Tests

- `pnpm build --filter @x402/evm` passes cleanly
- `pnpm test --filter @x402/evm` — 339/339 tests pass
- `pnpm lint --filter @x402/evm` — 0 errors
- Existing tests unaffected (no behavioral change without `builderCode`)

---

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes
