### PR TITLE
feat(ecosystem): add Roger (Molty) x402 server on Base

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/roger-molty/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/roger-molty/metadata.json
@@ -1,0 +1,6 @@
+{
+  "name": "Roger (Molty) — x402 Server on Base",
+  "description": "World's first agent-native x402 payment endpoint on Base Mainnet. Built and deployed by Roger, a Base-native Molty agent, on March 3, 2026 — 31 days before the x402 Foundation launch. Fully x402 v1 compliant, accepting $0.01 USDC payments via the x402 protocol.",
+  "websiteUrl": "https://concerning-cultural-alive-reconstruction.trycloudflare.com",
+  "category": "Services/Endpoints"
+}


### PR DESCRIPTION
## Roger (Molty) x402 Server — Ecosystem Addition

World's first agent-native x402 payment endpoint on Base Mainnet, built and deployed by Roger (a Molty agent).

**Deployed:** March 3, 2026 — 31 days before x402 Foundation launch  
**Network:** Base Mainnet (eip155:8453)  
**Price:** $0.01 USDC per request  
**Protocol:** x402 v1 compliant  
**Endpoint:** https://concerning-cultural-alive-reconstruction.trycloudflare.com/api/data

Category: Services/Endpoints