### PR TITLE
Add Wallet Intel API to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/wallet-intel-api/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/wallet-intel-api/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Wallet Intel API",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/wallet-intel-api.svg",
+  "description": "Crypto intelligence API for AI agents. 8 endpoints: wallet threat + reputation scoring (dual-score model with sanctions, phishing, darkweb detection), token security (honeypot, rug pull, tax analysis across 7 chains), identity resolution (ENS, wallet age, DeFi protocols, behavioral labels), Polymarket prediction markets, perpetual funding rates, and cross-exchange arbitrage spreads. Pay $0.01–$0.02 USDC per call on Base — no API key required.",
+  "websiteUrl": "https://wallet-intel-api-production-3ec7.up.railway.app"
+}

--- a/typescript/site/public/logos/wallet-intel-api.svg
+++ b/typescript/site/public/logos/wallet-intel-api.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="32" fill="#0D1117"/>
+  <g transform="translate(100,100)">
+    <!-- Shield outline -->
+    <path d="M0-65 L55-40 L55,15 Q55,55 0,75 Q-55,55 -55,15 L-55-40 Z" fill="none" stroke="#58A6FF" stroke-width="5"/>
+    <!-- Inner shield fill -->
+    <path d="M0-55 L45-33 L45,12 Q45,45 0,62 Q-45,45 -45,12 L-45-33 Z" fill="#161B22"/>
+    <!-- Eye/scan icon -->
+    <ellipse cx="0" cy="-5" rx="28" ry="18" fill="none" stroke="#58A6FF" stroke-width="3"/>
+    <circle cx="0" cy="-5" r="9" fill="#58A6FF"/>
+    <!-- Signal waves -->
+    <path d="M-20,30 Q0,20 20,30" fill="none" stroke="#3FB950" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M-28,38 Q0,25 28,38" fill="none" stroke="#3FB950" stroke-width="2.5" stroke-linecap="round"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Wallet Intel API — Crypto Intelligence for AI Agents

**Category:** Services/Endpoints

**Website:** https://wallet-intel-api-production-3ec7.up.railway.app

**Description:**
Crypto intelligence API with 8 pay-per-query endpoints via x402 on Base mainnet. No API key required — agents pay directly in USDC.

**Endpoints:**
| Endpoint | Price | Description |
|---|---|---|
| `GET /api/v1/wallet-risk/{address}` | $0.02 | Dual threat + reputation scoring (sanctions, phishing, darkweb + behavioral reputation) |
| `GET /api/v1/token-risk/{chainId}/{address}` | $0.02 | Token security: honeypot, rug pull, tax, liquidity, holder concentration. 7 chains |
| `GET /api/v1/identity/{address}` | $0.02 | ENS, wallet age, tx count, DeFi protocols, tokens, NFTs, behavioral labels |
| `GET /api/v1/polymarket/trending` | $0.01 | Trending prediction markets with odds, volume, liquidity |
| `GET /api/v1/polymarket/search?query=` | $0.01 | Search prediction markets by category |
| `GET /api/v1/polymarket/event/{slug}` | $0.01 | Full event details with all sub-markets |
| `GET /api/v1/funding-rates?symbol=` | $0.01 | Perpetual funding rates from 4 exchanges, 700+ pairs |
| `GET /api/v1/arb-spreads/{symbol}` | $0.01 | Cross-exchange arbitrage from 5 exchanges |

**x402 Integration:**
- Network: Base mainnet (`eip155:8453`)
- Scheme: `exact` (x402 v2)
- Facilitator: CDP
- All 8 endpoints listed in Bazaar catalog

**Changes:**
- `typescript/site/app/ecosystem/partners-data/wallet-intel-api/metadata.json`
- `typescript/site/public/logos/wallet-intel-api.svg`