### PR TITLE
docs: add repo move note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> **Note:** We've moved the x402 repo under the x402 Foundation repo. All issues and PRs were transferred here: [github.com/x402-foundation/x402](https://github.com/x402-foundation/x402)
+>
+> Our repo ([coinbase/x402](https://github.com/coinbase/x402)) is now a development fork.
+
 # x402
 
 x402 is an open standard for internet native payments. It aims to support all networks (both crypto & fiat) and forms of value (stablecoins, tokens, fiat).


### PR DESCRIPTION
## Summary
- Adds a note at the top of the README indicating the repo has moved under the x402 Foundation
- Links to the new canonical repo (x402-foundation/x402) and clarifies coinbase/x402 is now a development fork

## Test plan
- [ ] Verify the note renders correctly on GitHub