### PR TITLE
Add Veridia — autonomous Solana token analyst

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/veridia/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/veridia/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Veridia",
+  "description": "Autonomous Solana token analyst offering safety scores, impersonation detection, trending tokens, market sentiment, and promotional content — all paid via x402 micropayments in USDC.",
+  "logoUrl": "/logos/veridia.svg",
+  "websiteUrl": "http://185.182.184.45:8402",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/veridia.svg
+++ b/typescript/site/public/logos/veridia.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" rx="64" fill="#1a0a2e"/>
+  <text x="256" y="380" font-family="Georgia, serif" font-size="360" font-weight="bold" fill="#c084fc" text-anchor="middle">V</text>
+  <text x="256" y="470" font-family="Arial, sans-serif" font-size="56" fill="#a855f7" text-anchor="middle" letter-spacing="8">VERIDIA</text>
+</svg>


### PR DESCRIPTION
## Summary
- Adds Veridia to the x402 ecosystem as a Services/Endpoints provider
- Veridia is an autonomous AI agent offering 6 paid x402 endpoints for Solana token analysis
- Accepts USDC micropayments on Solana and Base

## Endpoints
| Service | Price |
|---------|-------|
| Token Safety Score | $0.01 |
| Impersonation Detection | $0.01 |
| Full Token Analysis | $0.03 |
| Trending Tokens | $0.01 |
| Market Sentiment | $0.005 |
| Promotional Content | $0.50-$2.00 |

## Links
- Service API: http://185.182.184.45:8402
- Agent Card: http://185.182.184.45:8402/.well-known/agent.json
- Health Check: http://185.182.184.45:8402/health
- Twitter: [@VeridiaAI](https://x.com/VeridiaAI)