### PR TITLE
feat: add claw-pay facilitator to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/claw-pay/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/claw-pay/metadata.json
@@ -1,0 +1,19 @@
+{
+  "name": "claw-pay",
+  "description": "x402 payment facilitator for OpenClaw agents — autonomous USDC micropayments on Base L2. No registration, no monthly fee. 3% per settled transaction (covers gas + infrastructure). Open source (BSL-1.1).",
+  "logoUrl": "/logos/claw-pay.png",
+  "websiteUrl": "https://clawpay.eu",
+  "category": "Facilitators",
+  "facilitator": {
+    "baseUrl": "https://claw-pay.org",
+    "networks": ["base"],
+    "schemes": ["exact"],
+    "assets": ["EIP-3009"],
+    "supports": {
+      "verify": true,
+      "settle": true,
+      "supported": true,
+      "list": false
+    }
+  }
+}


### PR DESCRIPTION
## New Ecosystem Entry — claw-pay Facilitator

**Website:** https://clawpay.eu  
**Facilitator API:** https://claw-pay.org  
**Source:** https://github.com/orca-labs-sudo/claw-pay  

### What is claw-pay?

claw-pay is an x402 payment facilitator built for OpenClaw agents. It enables autonomous USDC micropayments on Base L2 — agents pay for x402-gated services automatically, within user-defined spending limits.

### Details

- **Category:** Facilitators
- **Networks:** Base Mainnet (`eip155:8453`)
- **Scheme:** `exact` (ERC-3009 / EIP-712)
- **Asset:** USDC
- **Fee:** 3% per settled transaction (covers Base L2 gas + infrastructure)
- **Endpoints:** `/verify`, `/settle`, `/health`
- **License:** BSL-1.1 (open source)
- **Status:** Live on Base Mainnet

### Changes

- `typescript/site/app/ecosystem/partners-data/claw-pay/metadata.json` — new entry
- `typescript/site/public/logos/claw-pay.png` — logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)