### PR TITLE
Add DevDrops to x402 ecosystem — 43 pay-per-query APIs + universal MCP server

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/devdrops/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/devdrops/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "DevDrops",
+  "description": "43 pay-per-query data APIs on Base mainnet — weather, FX, stocks, crypto, SEC filings, sanctions screening, sentiment analysis, IP geolocation, and more. Universal MCP server with 18 tools for AI agents. Prepaid USDC credit bundles. Free tier: 5 queries/day/IP on select endpoints. No API keys, no signups.",
+  "logoUrl": "/logos/devdrops.svg",
+  "websiteUrl": "https://devdrops.run",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/devdrops.svg
+++ b/typescript/site/public/logos/devdrops.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="24" fill="#0a0a0b"/>
+  <text x="100" y="80" font-family="monospace" font-size="48" font-weight="700" fill="#22c55e" text-anchor="middle">dd</text>
+  <text x="100" y="130" font-family="monospace" font-size="18" fill="#9d9b95" text-anchor="middle">devdrops</text>
+  <text x="100" y="158" font-family="monospace" font-size="13" fill="#5c5b57" text-anchor="middle">x402 APIs</text>
+</svg>


### PR DESCRIPTION
## DevDrops — Services/Endpoints

**Website:** https://devdrops.run  
**API:** https://api.devdrops.run/catalog  
**GitHub:** https://github.com/metamorphosis-sre/devdrops

### What it is

DevDrops is a catalog of 43 pay-per-query data APIs running on Cloudflare Workers, all gated with x402 micropayments on Base mainnet. No API keys, no signups, no subscriptions — just HTTP 402 + USDC.

### x402 integration

- Uses `@x402/hono` middleware for payment gating
- Facilitator: Coinbase CDP (`api.cdp.coinbase.com/platform/v2/x402`)
- Network: Base mainnet (`eip155:8453`)
- Price range: $0.001–$0.10 USDC per request
- Free tier: 5 queries/day/IP on select endpoints (FX, crypto, weather, IP, etc.)

### Products

- **Financial markets**: FX rates, crypto prices, stock quotes, prediction markets, sports odds
- **Compliance**: Sanctions screening (OFAC/UN/HMT), VAT verification, SEC filings, company enrichment  
- **AI-enhanced**: News sentiment, research briefs, URL summarization, text classification, NER (all Claude-powered)
- **Infrastructure**: IP geolocation, WHOIS/DNS, email verification, ASN/BGP
- **Universal MCP server** at `/api/mcp` — 18 tools for AI agents via JSON-RPC 2.0
- **Prepaid credit bundles** — $5/$25/$100 USDC, 10-20% bonus

### Mainnet status

Live at https://api.devdrops.run — processing real x402 payments on Base mainnet.

### Checklist

- [x] Working mainnet x402 integration  
- [x] API documentation at https://api.devdrops.run/openapi.json  
- [x] Health monitoring (GitHub Actions healthcheck every 4h)  
- [x] Logo added to `/public/logos/devdrops.svg`  
- [x] Category: `Services/Endpoints`