### PR TITLE
Add 12 x402 services to ecosystem (domain intel, security, performance, content)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/x402-biz-intel/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-biz-intel/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402 Czech Biz Intel",
+  "description": "Czech company due diligence API for AI agents. Returns structured data from ARES + ISIR (insolvency register) by IČO or company name. $0.02 USDC per query on Base.",
+  "logoUrl": "",
+  "websiteUrl": "https://x402-biz-intel.fly.dev",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/app/ecosystem/partners-data/x402-carbon/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-carbon/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402 Carbon",
+  "description": "Website carbon footprint estimator for AI agents. Calculates CO2 emissions per page view using the Sustainable Web Design methodology, checks green hosting via the Green Web Foundation, and provides sustainability recommendations. $0.01 USDC on Base.",
+  "logoUrl": "",
+  "websiteUrl": "https://x402-carbon.fly.dev",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/app/ecosystem/partners-data/x402-dns-intel/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-dns-intel/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402 DNS Intel",
+  "description": "DNS security and email deliverability intelligence for AI agents. Analyzes SPF, DKIM, DMARC, MX, DNSSEC, BIMI, MTA-STS, and TLS-RPT records. Returns a security score (0-100) with grade and detailed findings. $0.01 USDC per analysis on Base.",
+  "logoUrl": "",
+  "websiteUrl": "https://x402-dns-intel.fly.dev",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/app/ecosystem/partners-data/x402-domain-check/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-domain-check/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402 Domain Check",
+  "description": "Paid domain availability API for AI agents. RDAP + WHOIS + DNS layered lookup across 1200+ TLDs. $0.01 USDC per query on Base. Returns availability, registrar, and expiry data. Inconclusive lookups are not charged.",
+  "logoUrl": "",
+  "websiteUrl": "https://x402-domain-check.fly.dev",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/app/ecosystem/partners-data/x402-link-safety/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-link-safety/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402 Link Safety",
+  "description": "URL safety and redirect chain analyzer for AI agents. Unshortens URLs, follows redirect chains, detects phishing patterns, brand impersonation, suspicious TLDs, and non-ASCII domains. Returns safety verdict with risk score. $0.01 USDC on Base.",
+  "logoUrl": "",
+  "websiteUrl": "https://x402-link-safety.fly.dev",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/app/ecosystem/partners-data/x402-page-meta/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-page-meta/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402 Page Meta",
+  "description": "Page metadata extractor for AI agents. Extracts Open Graph tags, Twitter Cards, JSON-LD structured data, RSS/Atom feeds, favicons, canonical URLs, hreflang, and standard meta tags from any URL. $0.01 USDC on Base.",
+  "logoUrl": "",
+  "websiteUrl": "https://x402-page-meta.fly.dev",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/app/ecosystem/partners-data/x402-perf-check/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-perf-check/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402 Perf Check",
+  "description": "HTTP performance measurement for AI agents. Measures TTFB, download time, redirect latency, compression, caching headers, CDN detection, and security headers. Returns performance score and grade. $0.01 USDC on Base.",
+  "logoUrl": "",
+  "websiteUrl": "https://x402-perf-check.fly.dev",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/app/ecosystem/partners-data/x402-readability/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-readability/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402 Readability",
+  "description": "Text readability analyzer for AI agents. Calculates Flesch Reading Ease, Flesch-Kincaid Grade, Gunning Fog, Coleman-Liau, ARI, and SMOG indices. Returns grade level, reading time, vocabulary richness, and word statistics. $0.01 USDC on Base.",
+  "logoUrl": "",
+  "websiteUrl": "https://x402-readability.fly.dev",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/app/ecosystem/partners-data/x402-router/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-router/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402 Router",
+  "description": "Natural language orchestration layer for x402 endpoints. Agent describes intent, router selects and pays the right sub-service via x402-fetch. Pure dogfooding architecture.",
+  "logoUrl": "",
+  "websiteUrl": "https://x402-router.fly.dev",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/app/ecosystem/partners-data/x402-sentinel/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-sentinel/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402 Sentinel",
+  "description": "Quality verification service for x402 endpoints. Monitors 42+ services across 10 categories, provides quality scores (0-100) based on schema validation, temporal consistency, cross-reference, and LLM judge. Free catalog and badge endpoints. Paid deep scans.",
+  "logoUrl": "",
+  "websiteUrl": "https://x402-sentinel.fly.dev",
+  "category": "Infrastructure & Tooling"
+}

--- a/typescript/site/app/ecosystem/partners-data/x402-ssl-check/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-ssl-check/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402 SSL Check",
+  "description": "SSL/TLS certificate and connection analyzer for AI agents. Checks certificate validity, chain of trust, expiry, DV/OV/EV type, TLS protocol version, cipher strength, and Subject Alternative Names. Returns security score and grade. $0.01 USDC on Base.",
+  "logoUrl": "",
+  "websiteUrl": "https://x402-ssl-check.fly.dev",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/app/ecosystem/partners-data/x402-tech-stack/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-tech-stack/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402 Tech Stack",
+  "description": "Technology stack detection for AI agents. Identifies 100+ technologies from HTTP headers, HTML patterns, and cookies — frameworks, CMS, hosting, CDN, analytics, payment providers, and more. $0.01 USDC per detection on Base.",
+  "logoUrl": "",
+  "websiteUrl": "https://x402-tech-stack.fly.dev",
+  "category": "Services/Endpoints"
+}


### PR DESCRIPTION
## Summary

Adds **12 x402 services** to the ecosystem — a suite of paid APIs for AI agents, all live on Base mainnet.

### Services

| Service | URL | Price |
|---------|-----|-------|
| Domain Check | x402-domain-check.fly.dev | $0.01 |
| Czech Biz Intel | x402-biz-intel.fly.dev | $0.02 |
| Router | x402-router.fly.dev | $0.03-0.20 |
| Sentinel | x402-sentinel.fly.dev | varies |
| DNS Intel | x402-dns-intel.fly.dev | $0.01 |
| Tech Stack | x402-tech-stack.fly.dev | $0.01 |
| SSL Check | x402-ssl-check.fly.dev | $0.01 |
| Carbon | x402-carbon.fly.dev | $0.01 |
| Link Safety | x402-link-safety.fly.dev | $0.01 |
| Page Meta | x402-page-meta.fly.dev | $0.01 |
| Perf Check | x402-perf-check.fly.dev | $0.01 |
| Readability | x402-readability.fly.dev | $0.01 |

All live on Base mainnet with x402 payment gates. Every endpoint has agent.json, OpenAPI spec, and llms.txt for discovery.