### PR TITLE
feat(template): harden express example and add server tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -26,3 +26,28 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           pnpm run test
+
+  test-examples-express:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ["20", "22"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "pnpm"
+          cache-dependency-path: ./examples/typescript
+
+      - name: Install and Test Express Example
+        working-directory: ./examples/typescript
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm --filter @x402/express-server-example test

--- a/examples/typescript/servers/express/app.ts
+++ b/examples/typescript/servers/express/app.ts
@@ -1,0 +1,64 @@
+import { randomUUID } from "crypto";
+import express from "express";
+
+import { buildErrorEnvelope } from "./server-utils";
+
+type PaymentGuard = express.RequestHandler;
+
+const defaultPaymentGuard: PaymentGuard = (_req, _res, next) => {
+  next();
+};
+
+export const createApp = (paymentGuard: PaymentGuard = defaultPaymentGuard) => {
+  const app = express();
+
+  app.use((req, res, next) => {
+    const requestId = req.header("x-request-id") || randomUUID();
+    res.locals.requestId = requestId;
+    res.setHeader("x-request-id", requestId);
+    next();
+  });
+
+  app.use(express.json({ limit: "256kb" }));
+  app.use(paymentGuard);
+
+  app
+    .route("/weather")
+    .get((_req, res) => {
+      res.send({
+        report: {
+          weather: "sunny",
+          temperature: 70,
+        },
+      });
+    })
+    .all((_req, res) => {
+      res
+        .status(405)
+        .json(buildErrorEnvelope("METHOD_NOT_ALLOWED", "method not allowed", res.locals.requestId));
+    });
+
+  app.use(
+    (
+      error: { type?: string },
+      _req: express.Request,
+      res: express.Response,
+      next: express.NextFunction,
+    ) => {
+      if (error.type === "entity.parse.failed") {
+        res
+          .status(400)
+          .json(buildErrorEnvelope("BAD_REQUEST", "invalid json payload", res.locals.requestId));
+        return;
+      }
+
+      next(error);
+    },
+  );
+
+  app.use((_req, res) => {
+    res.status(404).json(buildErrorEnvelope("NOT_FOUND", "route not found", res.locals.requestId));
+  });
+
+  return app;
+};

--- a/examples/typescript/servers/express/index.ts
+++ b/examples/typescript/servers/express/index.ts
@@ -1,64 +1,53 @@
 import { config } from "dotenv";
-import express from "express";
 import { paymentMiddleware, x402ResourceServer } from "@x402/express";
 import { ExactEvmScheme } from "@x402/evm/exact/server";
 import { ExactSvmScheme } from "@x402/svm/exact/server";
 import { HTTPFacilitatorClient } from "@x402/core/server";
+
+import { createApp } from "./app";
+import { readEnvConfig } from "./server-utils";
+
 config();
 
-const evmAddress = process.env.EVM_ADDRESS as `0x${string}`;
-const svmAddress = process.env.SVM_ADDRESS;
-if (!evmAddress || !svmAddress) {
-  console.error("Missing required environment variables");
-  process.exit(1);
-}
+const env = readEnvConfig(process.env);
+const facilitatorClient = new HTTPFacilitatorClient({ url: env.facilitatorUrl });
 
-const facilitatorUrl = process.env.FACILITATOR_URL;
-if (!facilitatorUrl) {
-  console.error("❌ FACILITATOR_URL environment variable is required");
-  process.exit(1);
-}
-const facilitatorClient = new HTTPFacilitatorClient({ url: facilitatorUrl });
-
-const app = express();
-
-app.use(
-  paymentMiddleware(
-    {
-      "GET /weather": {
-        accepts: [
-          {
-            scheme: "exact",
-            price: "$0.001",
-            network: "eip155:84532",
-            payTo: evmAddress,
-          },
-          {
-            scheme: "exact",
-            price: "$0.001",
-            network: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
-            payTo: svmAddress,
-          },
-        ],
-        description: "Weather data",
-        mimeType: "application/json",
-      },
+const paidMiddleware = paymentMiddleware(
+  {
+    "GET /weather": {
+      accepts: [
+        {
+          scheme: "exact",
+          price: "$0.001",
+          network: "eip155:84532",
+          payTo: env.evmAddress,
+        },
+        {
+          scheme: "exact",
+          price: "$0.001",
+          network: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+          payTo: env.svmAddress,
+        },
+      ],
+      description: "Weather data",
+      mimeType: "application/json",
     },
-    new x402ResourceServer(facilitatorClient)
-      .register("eip155:84532", new ExactEvmScheme())
-      .register("solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1", new ExactSvmScheme()),
-  ),
+  },
+  new x402ResourceServer(facilitatorClient)
+    .register("eip155:84532", new ExactEvmScheme())
+    .register("solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1", new ExactSvmScheme()),
 );
 
-app.get("/weather", (req, res) => {
-  res.send({
-    report: {
-      weather: "sunny",
-      temperature: 70,
-    },
-  });
+const app = createApp(paidMiddleware);
+const server = app.listen(env.port, () => {
+  console.log(`Server listening at http://localhost:${env.port}`);
 });
 
-app.listen(4021, () => {
-  console.log(`Server listening at http://localhost:${4021}`);
-});
+const shutdown = () => {
+  server.close(() => {
+    process.exit(0);
+  });
+};
+
+process.once("SIGINT", shutdown);
+process.once("SIGTERM", shutdown);

--- a/examples/typescript/servers/express/package.json
+++ b/examples/typescript/servers/express/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx index.ts",
+    "test": "node --test --import tsx test/*.test.ts",
     "format": "prettier -c .prettierrc --write \"**/*.{ts,js,cjs,json,md}\"",
     "format:check": "prettier -c .prettierrc --check \"**/*.{ts,js,cjs,json,md}\"",
     "lint": "eslint . --ext .ts --fix",

--- a/examples/typescript/servers/express/server-utils.ts
+++ b/examples/typescript/servers/express/server-utils.ts
@@ -1,0 +1,62 @@
+type EnvLike = Record<string, string | undefined>;
+
+export type EnvConfig = {
+  evmAddress: `0x${string}`;
+  svmAddress: string;
+  facilitatorUrl: string;
+  port: number;
+};
+
+export type ErrorEnvelope = {
+  ok: false;
+  requestId: string;
+  error: {
+    code: string;
+    message: string;
+  };
+};
+
+const parsePort = (rawPort: string | undefined): number => {
+  if (!rawPort) {
+    return 4021;
+  }
+
+  const parsed = Number(rawPort);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+    throw new Error("Invalid PORT, expected integer in range 1-65535");
+  }
+
+  return parsed;
+};
+
+export const readEnvConfig = (env: EnvLike): EnvConfig => {
+  const evmAddress = env.EVM_ADDRESS as `0x${string}` | undefined;
+  const svmAddress = env.SVM_ADDRESS;
+  const facilitatorUrl = env.FACILITATOR_URL;
+
+  if (!evmAddress || !svmAddress || !facilitatorUrl) {
+    throw new Error(
+      "Missing required environment variables: EVM_ADDRESS, SVM_ADDRESS, FACILITATOR_URL",
+    );
+  }
+
+  return {
+    evmAddress,
+    svmAddress,
+    facilitatorUrl,
+    port: parsePort(env.PORT),
+  };
+};
+
+export const buildErrorEnvelope = (
+  code: string,
+  message: string,
+  requestId: string,
+): ErrorEnvelope => ({
+  ok: false,
+  requestId,
+  error: {
+    code,
+    message,
+  },
+});

--- a/examples/typescript/servers/express/test/app.integration.test.ts
+++ b/examples/typescript/servers/express/test/app.integration.test.ts
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createApp } from "../app.ts";
+
+const startServer = async () => {
+  const app = createApp();
+  const server = await new Promise<import("node:http").Server>(resolve => {
+    const instance = app.listen(0, () => resolve(instance));
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to resolve test server address");
+  }
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${address.port}`,
+  };
+};
+
+test("404 response uses error envelope and request id", async () => {
+  const { server, baseUrl } = await startServer();
+  try {
+    const response = await fetch(`${baseUrl}/missing`, {
+      headers: { "x-request-id": "req-404" },
+    });
+    const body = (await response.json()) as {
+      ok: boolean;
+      requestId: string;
+      error: { code: string; message: string };
+    };
+
+    assert.equal(response.status, 404);
+    assert.equal(response.headers.get("x-request-id"), "req-404");
+    assert.equal(body.ok, false);
+    assert.equal(body.requestId, "req-404");
+    assert.equal(body.error.code, "NOT_FOUND");
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+});
+
+test("invalid json returns BAD_REQUEST envelope", async () => {
+  const { server, baseUrl } = await startServer();
+  try {
+    const response = await fetch(`${baseUrl}/weather`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-request-id": "req-json",
+      },
+      body: "{bad-json",
+    });
+
+    const body = (await response.json()) as {
+      ok: boolean;
+      requestId: string;
+      error: { code: string; message: string };
+    };
+
+    assert.equal(response.status, 400);
+    assert.equal(body.ok, false);
+    assert.equal(body.requestId, "req-json");
+    assert.equal(body.error.code, "BAD_REQUEST");
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+});

--- a/examples/typescript/servers/express/test/server-utils.test.ts
+++ b/examples/typescript/servers/express/test/server-utils.test.ts
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildErrorEnvelope, readEnvConfig } from "../server-utils.ts";
+
+test("readEnvConfig throws when required env is missing", () => {
+  assert.throws(() => readEnvConfig({}), /Missing required environment variables/);
+});
+
+test("readEnvConfig parses explicit port", () => {
+  const config = readEnvConfig({
+    EVM_ADDRESS: "0x1111111111111111111111111111111111111111",
+    SVM_ADDRESS: "SVM-PAYEE-ADDRESS",
+    FACILITATOR_URL: "https://x402.org/facilitator",
+    PORT: "4023",
+  });
+
+  assert.equal(config.port, 4023);
+  assert.equal(config.evmAddress, "0x1111111111111111111111111111111111111111");
+});
+
+test("buildErrorEnvelope includes requestId and code", () => {
+  const envelope = buildErrorEnvelope("BAD_REQUEST", "invalid json", "req-123");
+
+  assert.deepEqual(envelope, {
+    ok: false,
+    requestId: "req-123",
+    error: {
+      code: "BAD_REQUEST",
+      message: "invalid json",
+    },
+  });
+});


### PR DESCRIPTION
## Summary\n- refactor express server example into reusable app/server utilities\n- add integration + utility tests for error envelopes and env parsing\n- update unit test workflow coverage for the example\n\n## Validation\n- pnpm --filter @x402/express-server-example test\n\nBuilt by [@tmoney_145](https://x.com/tmoney_145).