### PR TITLE
Add The Data Collector to x402 ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/data-collector/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/data-collector/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "The Data Collector",
+  "description": "Web scraping APIs for Bluesky, Substack, and Hacker News search. Supports x402 micropayments at $0.05 USDC per call on Base network. Includes MCP server integration for AI agent access.",
+  "logoUrl": "/logos/data-collector.png",
+  "websiteUrl": "https://frog03-20494.wykr.es",
+  "category": "Services/Endpoints"
+}


### PR DESCRIPTION
## Summary

Adding **The Data Collector** — web scraping APIs for Bluesky, Substack, and Hacker News search with x402 micropayments at $0.05 USDC/call on Base.

- **Website:** https://frog03-20494.wykr.es
- **x402 Discovery:** https://frog03-20494.wykr.es/.well-known/x402-discovery
- **MCP Server:** https://frog03-20494.wykr.es/.well-known/mcp.json
- **Category:** Services/Endpoints
- **Network:** Base (USDC)
- **Price:** $0.05 per API call

### Endpoints
- `/api/bluesky/search` — Search Bluesky posts
- `/api/substack/search` — Search Substack newsletters
- `/api/hn/search` — Search Hacker News

Note: Logo file not included yet — happy to add one if needed before merge.