### PR TITLE
ecosystem: add Alderpost Intelligence — 8 bundled intelligence endpoints on Base

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/alderpost/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/alderpost/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Alderpost Intelligence",
+  "category": "Services",
+  "logoUrl": "/logos/alderpost.png",
+  "description": "AI-powered intelligence APIs bundling premium data sources (VirusTotal, People Data Labs, Hunter.io, AbuseIPDB, Qualys SSL Labs, NIH RxNorm). 8 endpoints covering security, company, threat, compliance, sales, health, property, and sports intelligence. $0.10-0.15 USDC per call on Base.",
+  "websiteUrl": "https://www.alderpost.co"
+}


### PR DESCRIPTION
## Description

Add Alderpost Intelligence to the x402 ecosystem. 

8 x402-gated intelligence API endpoints on Base mainnet, each bundling 7-9 premium data sources (VirusTotal, People Data Labs, Hunter.io, AbuseIPDB, Qualys SSL Labs, NIH RxNorm, US Census Bureau, OpenWeather) into single scored responses. $0.10-0.15 USDC per call.

Endpoints: domain-shield, company-xray, threat-pulse, prospect-iq, compliance-check, health-signal, property-intel, sports-edge.

Live at https://www.alderpost.co

Note: Logo file (alderpost.png) will be added in a follow-up commit.