### PR TITLE
Add TrustGate to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/trustgate/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/trustgate/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "TrustGate",
+  "description": "ERC-8004 reputation + on-chain wallet history + x402 dispute rate. Trust scoring for AI agents before they hit your paid endpoint.",
+  "logoUrl": "/logos/trustgate.svg",
+  "websiteUrl": "https://trust-gate-production.up.railway.app",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/app/ecosystem/partners-data/trustgate/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/trustgate/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "TrustGate",
-  "description": "ERC-8004 reputation + on-chain wallet history + x402 dispute rate. Trust scoring for AI agents before they hit your paid endpoint.",
+  "description": "ERC-8004 reputation + on-chain wallet history + x402 dispute rate. Trust scoring for AI agents before they hit your paid endpoint. Supports Solana and EVM chains. Available as an npm package (@oceanrun/plugin-trustgate).",
   "logoUrl": "/logos/trustgate.svg",
   "websiteUrl": "https://trust-gate-production.up.railway.app",
   "category": "Services/Endpoints"

--- a/typescript/site/public/logos/trustgate.svg
+++ b/typescript/site/public/logos/trustgate.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" fill="#0d0d0d"/>
+  <text x="32" y="28" font-family="'Courier New', monospace" font-size="10" fill="#ccc" text-anchor="middle" letter-spacing="1">TRUST</text>
+  <text x="32" y="44" font-family="'Courier New', monospace" font-size="10" fill="#ccc" text-anchor="middle" letter-spacing="1">GATE</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds TrustGate to the x402 ecosystem directory.

**What it does**: Layered trust scoring for x402 agent wallets — combines ERC-8004 reputation, on-chain wallet history, and x402 dispute rates into a composite 0-10 score. Supports both EVM and Solana addresses.

**npm package**: `npm install @oceanrun/trustgate` — Express middleware, 3 lines to integrate.

```typescript
import { trustGate } from '@oceanrun/trustgate'
app.use(trustGate())
```

- **Pricing**: $0.01 USDC per check on Base mainnet via x402
- **Category**: Services/Endpoints
- **Live**: https://trust-gate-production.up.railway.app
- **npm**: https://www.npmjs.com/package/@oceanrun/trustgate
- **Source**: https://github.com/oceanrun/trust-gate

## Files added

- `typescript/site/app/ecosystem/partners-data/trustgate/metadata.json`
- `typescript/site/public/logos/trustgate.svg`