### PR TITLE
docs: add missing EVM networks to network support tables

### DIFF
--- a/docs/core-concepts/network-and-token-support.mdx
+++ b/docs/core-concepts/network-and-token-support.mdx
@@ -23,10 +23,16 @@ x402 V2 uses [CAIP-2](https://chainagnostic.org/CAIPs/caip-2) standard network i
 | `avalanche-fuji` | `eip155:43113` | 43113 | Avalanche Fuji testnet |
 | `polygon` | `eip155:137` | 137 | Polygon mainnet |
 | `polygon-amoy` | `eip155:80002` | 80002 | Polygon Amoy testnet |
+| - | `eip155:42161` | 42161 | Arbitrum One mainnet |
+| - | `eip155:421614` | 421614 | Arbitrum Sepolia testnet |
 | `sei` | `eip155:1329` | 1329 | Sei mainnet |
 | `sei-testnet` | `eip155:713715` | 713715 | Sei testnet |
 | `skale-base` | `eip155:1187947933` | 1187947933 | SKALE mainnet |
 | `skale-base-sepolia` | `eip155:324705682` | 324705682 | SKALE testnet |
+| - | `eip155:4326` | 4326 | MegaETH mainnet |
+| - | `eip155:143` | 143 | Monad mainnet |
+| - | `eip155:988` | 988 | Stable mainnet |
+| - | `eip155:2201` | 2201 | Stable testnet |
 
 ### Format Explanation
 - **EVM networks**: `eip155:<chainId>` where chainId is the numeric chain identifier
@@ -270,7 +276,7 @@ x402's network support is designed to be extensible while maintaining security a
 
 Key takeaways:
 
-* Base (`eip155:8453`), Base Sepolia (`eip155:84532`), Solana (`solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`), and Solana Devnet (`solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`) have the best out-of-the-box support
+* Base (`eip155:8453`), Base Sepolia (`eip155:84532`), Solana (`solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`), and Solana Devnet (`solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`) have the best out-of-the-box support; Arbitrum One (`eip155:42161`), Polygon (`eip155:137`), MegaETH (`eip155:4326`), Monad (`eip155:143`), and Stable (`eip155:988`) are also supported with default stablecoins configured
 * Any EVM network can be supported with a custom facilitator using CAIP-2 format
 * Any ERC-20 token works on any facilitator (via EIP-3009 or Permit2)
 * Use price strings for USDC or TokenAmount for custom tokens

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -67,6 +67,13 @@ Yes. x402 handles the _payment execution_. You can still meter usage, aggregate 
 | Base Sepolia   | `eip155:84532` | Any ERC-20 token  | fee-free | **Testnet** |
 | Solana         | `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` | Any SPL token or Token-2022 token | fee-free | **Mainnet** |
 | Solana Devnet  | `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` | Any SPL token or Token-2022 | fee-free | **Testnet** |
+| Arbitrum One   | `eip155:42161` | Any ERC-20 token  | fee-free | **Mainnet** |
+| Arbitrum Sepolia | `eip155:421614` | Any ERC-20 token | fee-free | **Testnet** |
+| Polygon        | `eip155:137` | Any ERC-20 token  | fee-free | **Mainnet** |
+| MegaETH        | `eip155:4326` | MegaUSD (ERC-20)  | fee-free | **Mainnet** |
+| Monad          | `eip155:143` | Any ERC-20 token  | fee-free | **Mainnet** |
+| Stable         | `eip155:988` | USDT0 (ERC-20)    | fee-free | **Mainnet** |
+| Stable Testnet | `eip155:2201` | USDT0 (ERC-20)   | fee-free | **Testnet** |
 
 \* Gas paid on chain; many facilitators offer **zero** facilitator fees (see [ecosystem](https://www.x402.org/ecosystem?filter=facilitators) for details).
 


### PR DESCRIPTION
## Summary

Add **Arbitrum One**, **Arbitrum Sepolia**, **MegaETH**, **Monad**, **Stable mainnet**, and **Stable testnet** to the network identifier reference table in `network-and-token-support.mdx` and the FAQ assets/networks table.

## Problem

These 6 networks are already supported in the TypeScript SDK via `defaultAssets.ts` but were not listed in the documentation reference tables, creating a confusing gap between implementation and docs:

| Network | CAIP-2 | Added to code | In docs? |
|---------|--------|---------------|----------|
| Arbitrum One | `eip155:42161` | PR #1877 | ❌ missing |
| Arbitrum Sepolia | `eip155:421614` | PR #1877 | ❌ missing |
| MegaETH | `eip155:4326` | (previous) | ❌ missing |
| Monad | `eip155:143` | (previous) | ❌ missing |
| Stable mainnet | `eip155:988` | PR #1786 | ❌ missing |
| Stable testnet | `eip155:2201` | PR #1786 | ❌ missing |

## Changes

- **`docs/core-concepts/network-and-token-support.mdx`**: Added all 6 missing networks to the V2 Network Identifiers reference table; updated key takeaways to mention the broader network support
- **`docs/faq.md`**: Added Arbitrum One/Sepolia, Polygon, MegaETH, Monad, and Stable to the "Which assets and networks are supported today?" table

Developers using these networks were unable to find them in the docs even though the SDK already had them wired up.