### PR TITLE
docs: update upto scheme status — now live in TypeScript and Go SDKs

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -51,7 +51,7 @@ There is no single answer, but common patterns are:
 
 * **Flat per‑call** (e.g., `$0.001` per request)
 * **Tiered** (`/basic` vs `/pro` endpoints with different prices)
-* **Up‑to** (work in progress): "pay‑up‑to" where the final cost equals usage (tokens, MB, etc.)
+* **Up‑to**: "pay‑up‑to" where the final cost equals usage (tokens, MB, etc.) — available now in TypeScript and Go SDKs (Python support coming soon)
 
 #### Can I integrate x402 with a usage / plan manager like Metronome?
 
@@ -119,7 +119,7 @@ Yes. Programmatic wallets (e.g., **CDP Wallet API**, **viem**, **ethers‑v6** H
 Tracked in public GitHub issues + community RFCs. Major themes:
 
 * Multi‑asset support
-* Additional schemes (`upto`, `stream`)
+* Additional schemes (`stream`) — note: `upto` is already live in TypeScript and Go SDKs
 * Discovery layer for service search & reputation
 
 **Why is x402 hosted in the Coinbase GitHub?**


### PR DESCRIPTION
## Summary

The FAQ currently lists the `upto` scheme as "work in progress" in two places, but it has been shipping in both the TypeScript and Go SDKs for some time now.

## Changes

- **Pricing section**: Remove "(work in progress)" from the `upto` bullet and replace with "available now in TypeScript and Go SDKs (Python support coming soon)"
- **Roadmap section**: Move `upto` out of the upcoming schemes list and note it is already live

## Why

New developers reading the FAQ would incorrectly conclude that `upto` payments aren't usable yet, potentially missing a key differentiating feature of the protocol. This is a small copy fix with no code changes.

## Related

- `upto` Go SDK support: #1833
- SDK features matrix: `sdk-features.md` already correctly marks `upto/evm (Permit2)` as ✅ for TypeScript and Go