### PR TITLE
fix(python/evm): Decimal-precise nanopayment conversion — mirrors TS fix

### DIFF
--- a/python/x402/changelog.d/evm-nanopayment-decimal-precision.bugfix.md
+++ b/python/x402/changelog.d/evm-nanopayment-decimal-precision.bugfix.md
@@ -1,0 +1,1 @@
+Fix silent truncation of nanopayment amounts in Python EVM server. Added `number_to_decimal_string` and `convert_to_token_amount` utilities that use `Decimal` arithmetic and raise `ValueError` when a non-zero USD price is too small to represent in the token's atomic units (mirrors TypeScript nanopayment precision fix).

--- a/python/x402/mechanisms/evm/exact/server.py
+++ b/python/x402/mechanisms/evm/exact/server.py
@@ -5,8 +5,10 @@ from collections.abc import Callable
 from ....schemas import AssetAmount, Network, PaymentRequirements, Price, SupportedKind
 from ..constants import SCHEME_EXACT
 from ..utils import (
+    convert_to_token_amount,
     get_asset_info,
     get_network_config,
+    number_to_decimal_string,
     parse_amount,
     parse_money_to_decimal,
 )
@@ -181,7 +183,11 @@ class ExactEvmScheme:
                 "use register_money_parser or specify an explicit AssetAmount"
             )
 
-        token_amount = int(amount * (10 ** asset["decimals"]))
+        # Convert float → plain decimal string → atomic units via Decimal arithmetic.
+        # This avoids float-precision truncation and mirrors the TypeScript
+        # `numberToDecimalString` + `convertToTokenAmount` fix for nanopayments.
+        decimal_str = number_to_decimal_string(amount)
+        token_amount = convert_to_token_amount(decimal_str, asset["decimals"])
 
         atm = asset.get("asset_transfer_method")
         include_eip712_domain = not atm or asset.get("supports_eip2612", False)
@@ -194,7 +200,7 @@ class ExactEvmScheme:
             extra["assetTransferMethod"] = atm
 
         return AssetAmount(
-            amount=str(token_amount),
+            amount=token_amount,
             asset=asset["address"],
             extra=extra,
         )

--- a/python/x402/mechanisms/evm/utils.py
+++ b/python/x402/mechanisms/evm/utils.py
@@ -183,6 +183,79 @@ def is_valid_address(address: str) -> bool:
         return False
 
 
+def number_to_decimal_string(n: float | int) -> str:
+    """Convert a number to a plain decimal string, expanding scientific notation.
+
+    Mirrors the TypeScript ``numberToDecimalString`` utility added in the
+    nanopayment precision fix. Python's ``float`` shares the same scientific-
+    notation stringification problem as JavaScript (e.g. ``str(1e-7)`` yields
+    ``'1e-07'`` instead of ``'0.0000001'``).
+
+    Args:
+        n: The number to convert.
+
+    Returns:
+        A plain decimal string with no scientific notation (e.g. ``'0.0000001'``).
+
+    Examples:
+        >>> number_to_decimal_string(1e-7)
+        '0.0000001'
+        >>> number_to_decimal_string(4.02)
+        '4.02'
+    """
+    s = str(n)
+    if "e" not in s.lower():
+        return s
+    # Use Decimal to expand the scientific notation without float round-tripping
+    return format(Decimal(s), "f")
+
+
+def convert_to_token_amount(decimal_amount: str, decimals: int) -> str:
+    """Convert a plain decimal string to token smallest units.
+
+    Mirrors the TypeScript ``convertToTokenAmount`` utility.  Accepts only
+    plain decimal strings — scientific notation strings are rejected.  Raises
+    a ``ValueError`` when the non-zero amount is too small to be represented
+    with the given decimal precision (i.e. it would silently round to zero),
+    preventing silent fund-loss bugs for nanopayments.
+
+    Args:
+        decimal_amount: The decimal amount as a plain string (e.g. ``'0.10'``).
+            Must not use scientific notation.
+        decimals: The number of decimals for the token (e.g. 6 for USDC).
+
+    Returns:
+        The amount in smallest units as a string.
+
+    Raises:
+        ValueError: If *decimal_amount* uses scientific notation, is not a
+            valid number, or is non-zero but too small to represent at the
+            requested precision.
+
+    Examples:
+        >>> convert_to_token_amount('0.10', 6)
+        '100000'
+        >>> convert_to_token_amount('0.000001', 6)
+        '1'
+    """
+    if re.search(r"[eE]", decimal_amount):
+        raise ValueError(
+            f"Invalid amount: {decimal_amount!r} — use decimal notation, not scientific notation"
+        )
+    try:
+        d = Decimal(decimal_amount)
+    except Exception as exc:
+        raise ValueError(f"Invalid amount: {decimal_amount!r}") from exc
+
+    token_amount_dec = d * Decimal(10**decimals)
+    token_amount = int(token_amount_dec)
+    if token_amount == 0 and d != 0:
+        raise ValueError(
+            f"Amount {decimal_amount!r} is too small to represent with {decimals} decimal places"
+        )
+    return str(token_amount)
+
+
 def parse_amount(amount: str, decimals: int) -> int:
     """Convert decimal string to smallest unit (wei).
 

--- a/python/x402/tests/unit/mechanisms/evm/test_server.py
+++ b/python/x402/tests/unit/mechanisms/evm/test_server.py
@@ -117,6 +117,45 @@ class TestParsePrice:
             with pytest.raises(ValueError, match="Asset address required"):
                 server.parse_price({"amount": "123456"}, network)
 
+    class TestNanopayments:
+        """Test nanopayment precision — mirrors TypeScript nanopayment fix."""
+
+        def test_should_raise_for_amount_below_usdc_minimum_unit(self):
+            """Should raise ValueError when price is too small to represent in USDC atomic units."""
+            server = ExactEvmServerScheme()
+            network = "eip155:8453"  # USDC has 6 decimals; min = 0.000001
+
+            # 0.0000001 USDC = 0.1 atomic units → truncates to 0 — must error
+            with pytest.raises(ValueError, match="too small to represent"):
+                server.parse_price("0.0000001", network)
+
+        def test_should_handle_minimum_usdc_unit(self):
+            """Should correctly convert the minimum representable USDC amount."""
+            server = ExactEvmServerScheme()
+            network = "eip155:8453"
+
+            result = server.parse_price("0.000001", network)
+
+            assert result.amount == "1"  # 1 atomic unit
+
+        def test_should_handle_scientific_notation_float_prices(self):
+            """Float values in scientific notation (e.g. 1e-3) should convert correctly."""
+            server = ExactEvmServerScheme()
+            network = "eip155:8453"
+
+            # 1e-3 == 0.001 USDC == 1000 atomic units
+            result = server.parse_price(1e-3, network)
+
+            assert result.amount == "1000"
+
+        def test_should_raise_for_scientific_notation_float_below_minimum(self):
+            """Float values below the minimum unit should raise, not silently become 0."""
+            server = ExactEvmServerScheme()
+            network = "eip155:8453"
+
+            with pytest.raises(ValueError, match="too small to represent"):
+                server.parse_price(1e-7, network)  # 0.0000001 USDC < min unit
+
     class TestErrorCases:
         """Test error cases."""
 

--- a/python/x402/tests/unit/mechanisms/evm/test_utils.py
+++ b/python/x402/tests/unit/mechanisms/evm/test_utils.py
@@ -1,0 +1,134 @@
+"""Unit tests for EVM utility functions — number_to_decimal_string and convert_to_token_amount.
+
+These tests mirror the TypeScript `utils.test.ts` coverage added alongside the
+nanopayment scientific-notation precision fix.
+"""
+
+import pytest
+
+from x402.mechanisms.evm.utils import convert_to_token_amount, number_to_decimal_string
+
+
+class TestNumberToDecimalString:
+    """Tests for number_to_decimal_string — expands scientific notation to plain decimal."""
+
+    def test_plain_float_returned_unchanged(self):
+        """Plain floats with no scientific notation pass through as-is."""
+        assert number_to_decimal_string(4.02) == "4.02"
+
+    def test_integer_returned_unchanged(self):
+        """Integers pass through as-is."""
+        assert number_to_decimal_string(42) == "42"
+
+    def test_positive_scientific_notation_expanded(self):
+        """Large numbers in scientific notation are expanded (no 'e' in result)."""
+        # 1e7 = 10000000 — Python str(1e7) = '10000000.0' (no scientific notation)
+        result = number_to_decimal_string(1e7)
+        assert "e" not in result.lower()
+        assert "E" not in result
+        # The decimal equivalent should evaluate correctly
+        from decimal import Decimal
+        assert Decimal(result) == Decimal("10000000")
+
+    def test_negative_scientific_notation_expanded(self):
+        """Small numbers in scientific notation are expanded."""
+        # 1e-7 = 0.0000001
+        result = number_to_decimal_string(1e-7)
+        assert result == "0.0000001"
+
+    def test_1e_minus_6(self):
+        """1e-6 (minimum USDC unit as float) expands correctly."""
+        result = number_to_decimal_string(1e-6)
+        assert result == "0.000001"
+
+    def test_1e_minus_3(self):
+        """1e-3 expands to 0.001."""
+        result = number_to_decimal_string(1e-3)
+        assert result == "0.001"
+
+    def test_zero(self):
+        """Zero is handled correctly."""
+        result = number_to_decimal_string(0)
+        assert result == "0"
+
+    def test_zero_float(self):
+        """Zero float is handled correctly (no scientific notation)."""
+        result = number_to_decimal_string(0.0)
+        assert "e" not in result.lower()
+        from decimal import Decimal
+        assert Decimal(result) == Decimal("0")
+
+
+class TestConvertToTokenAmount:
+    """Tests for convert_to_token_amount — plain decimal string → atomic units."""
+
+    # --- Happy path ---
+
+    def test_converts_tenth_usdc(self):
+        """0.10 USDC → 100000 atomic units (6 decimals)."""
+        assert convert_to_token_amount("0.10", 6) == "100000"
+
+    def test_converts_one_usdc(self):
+        """1.00 USDC → 1000000 atomic units."""
+        assert convert_to_token_amount("1.00", 6) == "1000000"
+
+    def test_converts_whole_number(self):
+        """'100' → 100000000 for 6 decimals."""
+        assert convert_to_token_amount("100", 6) == "100000000"
+
+    def test_converts_minimum_usdc_unit(self):
+        """0.000001 USDC (minimum) → 1 atomic unit."""
+        assert convert_to_token_amount("0.000001", 6) == "1"
+
+    def test_converts_zero(self):
+        """Zero input → '0'."""
+        assert convert_to_token_amount("0", 6) == "0"
+        assert convert_to_token_amount("0.000000", 6) == "0"
+
+    def test_converts_with_18_decimals(self):
+        """Works correctly with 18-decimal tokens."""
+        # 0.0000001 with 18 decimals = 100000000000 units
+        assert convert_to_token_amount("0.0000001", 18) == "100000000000"
+
+    # --- Error: scientific notation rejected ---
+
+    def test_raises_on_positive_scientific_notation(self):
+        """Scientific notation strings are rejected."""
+        with pytest.raises(ValueError, match="scientific notation"):
+            convert_to_token_amount("1e7", 6)
+
+    def test_raises_on_negative_scientific_notation(self):
+        """Small scientific notation strings are rejected."""
+        with pytest.raises(ValueError, match="scientific notation"):
+            convert_to_token_amount("1e-7", 6)
+
+    def test_raises_on_uppercase_E(self):
+        """Uppercase E notation is also rejected."""
+        with pytest.raises(ValueError, match="scientific notation"):
+            convert_to_token_amount("1E-3", 6)
+
+    # --- Error: amount too small ---
+
+    def test_raises_when_amount_truncates_to_zero_usdc(self):
+        """Non-zero amount that rounds to 0 atomic units raises ValueError."""
+        # 0.0000001 USDC = 0.1 atomic units → truncates to 0 → error
+        with pytest.raises(ValueError, match="too small to represent"):
+            convert_to_token_amount("0.0000001", 6)
+
+    def test_raises_when_amount_below_min_unit(self):
+        """Amounts below the minimum representable unit raise ValueError."""
+        # 0.0000009 USDC = 0.9 atomic units → truncates to 0 → error
+        with pytest.raises(ValueError, match="too small to represent"):
+            convert_to_token_amount("0.0000009", 6)
+
+    # --- Error: invalid input ---
+
+    def test_raises_on_non_numeric_string(self):
+        """Non-numeric strings raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid amount"):
+            convert_to_token_amount("abc", 6)
+
+    def test_raises_on_dollar_prefixed_string(self):
+        """Dollar-prefixed strings are not accepted (must be pre-parsed)."""
+        with pytest.raises(ValueError):
+            convert_to_token_amount("$0.10", 6)


### PR DESCRIPTION
## Summary

Mirrors the TypeScript `fix/nanopayment-usd-pricing` fix in the Python EVM SDK.

### Problem

The previous `_default_money_conversion` used raw float arithmetic:

```python
token_amount = int(amount * (10 ** asset["decimals"]))
```

This **silently truncated** amounts smaller than one atomic unit to `0` with no error. For example, a price of `$0.0000001` with USDC (6 decimals) would produce `amount="0"` — the API endpoint would appear to be free. The bug also had latent float-precision risk for borderline values near atomic unit boundaries.

The TypeScript SDK fixed this via `numberToDecimalString` + `convertToTokenAmount` utilities. The Python EVM SDK had no equivalent.

### Changes

- **`python/x402/mechanisms/evm/utils.py`**: Add two new utilities:
  - `number_to_decimal_string(n)` — expands scientific-notation floats (e.g. `1e-7 → '0.0000001'`) using `Decimal.format('f')`, matching the TypeScript `numberToDecimalString` utility
  - `convert_to_token_amount(decimal_amount, decimals)` — converts plain decimal strings to atomic units via `Decimal` arithmetic, rejects scientific-notation strings, and raises `ValueError` when a non-zero amount is too small to represent at the requested precision
- **`python/x402/mechanisms/evm/exact/server.py`**: Update `_default_money_conversion` to use `number_to_decimal_string` + `convert_to_token_amount` instead of float multiplication
- **`python/x402/tests/unit/mechanisms/evm/test_utils.py`**: 21 new unit tests for both utilities
- **`python/x402/tests/unit/mechanisms/evm/test_server.py`**: 4 new nanopayment test cases in `TestNanopayments` class
- **Changeset fragment** for Python SDK patch release

### Before / After

```python
# Before — silent truncation
server.parse_price("$0.0000001", "eip155:8453")
# → AssetAmount(amount="0", ...) ← BUG: endpoint appears free!

# After — explicit error
server.parse_price("$0.0000001", "eip155:8453")
# → ValueError: Amount '0.0000001' is too small to represent with 6 decimal places
```

### Test results

All 758 unit tests pass.

Related: TypeScript PR in `fix/nanopayment-usd-pricing` branch