### PR TITLE
test(go/svm): add unit tests for SettlementCache

### DIFF
--- a/go/.changes/unreleased/test-go-svm-settlement-cache-coverage.yaml
+++ b/go/.changes/unreleased/test-go-svm-settlement-cache-coverage.yaml
@@ -1,0 +1,3 @@
+kind: added
+body: Add unit tests for SVM SettlementCache (NewSettlementCache, IsDuplicate, TTL-based prune, concurrency safety)
+time: 2026-04-19T06:20:00.000000+00:00

--- a/go/mechanisms/svm/settlement_cache_test.go
+++ b/go/mechanisms/svm/settlement_cache_test.go
@@ -1,0 +1,164 @@
+package svm
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNewSettlementCache(t *testing.T) {
+	c := NewSettlementCache()
+	if c == nil {
+		t.Fatal("NewSettlementCache() returned nil")
+	}
+	if len(c.Entries()) != 0 {
+		t.Errorf("NewSettlementCache() entries = %d, want 0", len(c.Entries()))
+	}
+}
+
+func TestIsDuplicate_NewKey(t *testing.T) {
+	c := NewSettlementCache()
+	got := c.IsDuplicate("tx1")
+	if got {
+		t.Error("IsDuplicate(new key) = true, want false")
+	}
+	if _, exists := c.Entries()["tx1"]; !exists {
+		t.Error("IsDuplicate(new key) did not record the key")
+	}
+}
+
+func TestIsDuplicate_ExistingKey(t *testing.T) {
+	c := NewSettlementCache()
+	c.IsDuplicate("tx1") // record it
+	got := c.IsDuplicate("tx1")
+	if !got {
+		t.Error("IsDuplicate(existing key) = false, want true")
+	}
+}
+
+func TestIsDuplicate_MultipleDistinctKeys(t *testing.T) {
+	c := NewSettlementCache()
+	keys := []string{"txA", "txB", "txC"}
+	for _, k := range keys {
+		if c.IsDuplicate(k) {
+			t.Errorf("IsDuplicate(%q) = true on first call, want false", k)
+		}
+	}
+	if len(c.Entries()) != 3 {
+		t.Errorf("Entries() count = %d, want 3", len(c.Entries()))
+	}
+	// Each should now be a duplicate
+	for _, k := range keys {
+		if !c.IsDuplicate(k) {
+			t.Errorf("IsDuplicate(%q) = false on second call, want true", k)
+		}
+	}
+}
+
+func TestIsDuplicate_EmptyStringKey(t *testing.T) {
+	c := NewSettlementCache()
+	got := c.IsDuplicate("")
+	if got {
+		t.Error("IsDuplicate(\"\") = true on first call, want false")
+	}
+	if !c.IsDuplicate("") {
+		t.Error("IsDuplicate(\"\") = false on second call, want true")
+	}
+}
+
+func TestIsDuplicate_ExpiredKeyIsNotDuplicate(t *testing.T) {
+	c := NewSettlementCache()
+	// Manually insert a stale entry older than SettlementTTL.
+	c.Mu().Lock()
+	c.Entries()["oldtx"] = time.Now().Add(-(SettlementTTL + time.Second))
+	c.Mu().Unlock()
+
+	// IsDuplicate should prune the expired entry and treat it as new.
+	got := c.IsDuplicate("oldtx")
+	if got {
+		t.Error("IsDuplicate(expired key) = true, want false (expired entry should be pruned)")
+	}
+}
+
+func TestIsDuplicate_FreshKeyIsStillDuplicate(t *testing.T) {
+	c := NewSettlementCache()
+	// Insert with a near-but-not-expired timestamp.
+	c.Mu().Lock()
+	c.Entries()["recenttx"] = time.Now().Add(-(SettlementTTL / 2))
+	c.Mu().Unlock()
+
+	got := c.IsDuplicate("recenttx")
+	if !got {
+		t.Error("IsDuplicate(recent key within TTL) = false, want true")
+	}
+}
+
+func TestIsDuplicate_PrunesOnlyExpiredEntries(t *testing.T) {
+	c := NewSettlementCache()
+	c.Mu().Lock()
+	c.Entries()["old"] = time.Now().Add(-(SettlementTTL + time.Second))
+	c.Entries()["fresh"] = time.Now()
+	c.Mu().Unlock()
+
+	// Trigger prune by calling IsDuplicate with any key.
+	c.IsDuplicate("trigger")
+
+	c.Mu().Lock()
+	_, oldExists := c.Entries()["old"]
+	_, freshExists := c.Entries()["fresh"]
+	c.Mu().Unlock()
+
+	if oldExists {
+		t.Error("prune() did not remove the expired 'old' entry")
+	}
+	if !freshExists {
+		t.Error("prune() incorrectly removed the fresh entry")
+	}
+}
+
+func TestIsDuplicate_ConcurrentSafety(t *testing.T) {
+	c := NewSettlementCache()
+	const goroutines = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			key := "concurrent-key"
+			c.IsDuplicate(key)
+		}(i)
+	}
+	wg.Wait()
+
+	// After all goroutines ran, the key must exist exactly once.
+	c.Mu().Lock()
+	count := len(c.Entries())
+	c.Mu().Unlock()
+	if count != 1 {
+		t.Errorf("after concurrent IsDuplicate calls, Entries() count = %d, want 1", count)
+	}
+}
+
+func TestIsDuplicate_ConcurrentDistinctKeys(t *testing.T) {
+	c := NewSettlementCache()
+	const goroutines = 20
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	results := make([]bool, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			// Each goroutine uses a unique key — all should return false.
+			results[id] = c.IsDuplicate("unique-" + string(rune('A'+id)))
+		}(i)
+	}
+	wg.Wait()
+
+	for i, dup := range results {
+		if dup {
+			t.Errorf("goroutine %d: IsDuplicate(unique key) = true, want false", i)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add `settlement_cache_test.go` with **10 unit tests** covering the `SettlementCache` struct directly in the `go/mechanisms/svm` package.

`SettlementCache` is the in-memory deduplication guard that prevents the same Solana transaction from being settled twice. Previously it only had integration-level coverage (via `TestDuplicateSettlementCacheV1` inside `svm/exact/v1/facilitator`). These tests exercise the struct's public contract at the unit level, including edge cases and concurrency safety.

## Tests added

| Test | What it checks |
|------|----------------|
| `TestNewSettlementCache` | Zero-entry map on construction |
| `TestIsDuplicate_NewKey` | Returns false and records the key on first call |
| `TestIsDuplicate_ExistingKey` | Returns true for an already-recorded key |
| `TestIsDuplicate_MultipleDistinctKeys` | Tracks each key independently |
| `TestIsDuplicate_EmptyStringKey` | Empty string is a valid (trackable) key |
| `TestIsDuplicate_ExpiredKeyIsNotDuplicate` | Prune removes TTL-expired entries; re-insert allowed |
| `TestIsDuplicate_FreshKeyIsStillDuplicate` | Entry within TTL window stays a duplicate |
| `TestIsDuplicate_PrunesOnlyExpiredEntries` | Prune removes stale, leaves fresh entries intact |
| `TestIsDuplicate_ConcurrentSafety` | 50 goroutines on same key — no data race, single map entry |
| `TestIsDuplicate_ConcurrentDistinctKeys` | 20 goroutines on unique keys — each returns false |

All tests pass with `go test -race ./mechanisms/svm/`.

## Checklist
- [x] GPG-signed commit
- [x] Changeset fragment added (`go/.changes/unreleased/test-go-svm-settlement-cache-coverage.yaml`)
- [x] All tests pass (`go test -race ./mechanisms/svm/`)
- [x] No new dependencies