### PR TITLE
feat(ecosystem): add Haldir — cryptographic trust layer (RFC 6962 audit proofs)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/haldir/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/haldir/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Haldir",
+  "description": "Cryptographic trust layer for AI agents. x402-gated endpoints for RFC 6962 inclusion proofs ($0.01), Ed25519-signed tree heads ($0.001), and signed audit-prep evidence packs ($0.10). Every settled payment becomes a leaf in Haldir's own Merkle tree — the audit layer attests to its own revenue. USDC on Base.",
+  "logoUrl": "/logos/haldir.svg",
+  "websiteUrl": "https://haldir.xyz",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/haldir.svg
+++ b/typescript/site/public/logos/haldir.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 92" width="256" height="294">
+  <defs>
+    <linearGradient id="haldirShield" x1="40" y1="4" x2="40" y2="88" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#e8c84a"/>
+      <stop offset="100%" stop-color="#8a6d1b"/>
+    </linearGradient>
+  </defs>
+  <path d="M40 4 L72 18 V46 C72 68 58 80 40 88 C22 80 8 68 8 46 V18 Z"
+        fill="url(#haldirShield)" fill-opacity="0.15"
+        stroke="url(#haldirShield)" stroke-width="2"/>
+  <path d="M32 44 L38 50 L52 36"
+        stroke="#c9a33e" stroke-width="4"
+        stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>


### PR DESCRIPTION
## Summary

Adds **Haldir** to the x402 ecosystem directory under **Services/Endpoints**.

Haldir is the cryptographic trust layer for AI agents. Three x402-v2 gated endpoints expose its audit surface as pay-per-request primitives on Base Sepolia (eip155:84532):

- `GET /v1/x402/tree-head` — $0.001 USDC — Ed25519-signed RFC 6962 Signed Tree Head. Public verification key at `/.well-known/jwks.json` (RFC 7517 OKP/Ed25519 JWK).
- `GET /v1/x402/inclusion-proof/<entry_id>` — $0.01 USDC — RFC 6962 inclusion proof bundled with the current STH; verifies offline against the pinned public key with the Haldir SDK or any RFC 6962 verifier.
- `GET /v1/x402/evidence-pack` — $0.10 USDC — signed audit-prep evidence pack relevant to SOC2 Trust Services Criteria (CC5.2, CC6.1, CC6.7, CC7.2, CC7.3, CC8.1).

Every settled payment is written back to Haldir's own Merkle-covered audit log — the trust layer attests to its own revenue.

Full machine-readable manifest: https://haldir.xyz/.well-known/x402.json (also at `/v1/x402/manifest`).
Website: https://haldir.xyz
Source: https://github.com/ExposureGuard/haldir
Free adversarial tamper demo: https://haldir.xyz/demo/tamper (click "Tamper" to watch the Merkle tree reject a DB mutation in real time).

## Changes

- `typescript/site/app/ecosystem/partners-data/haldir/metadata.json` — partner metadata
- `typescript/site/public/logos/haldir.svg` — brand mark (gold shield + checkmark)

## Notes

- Network: eip155:84532 (Base Sepolia) for testnet; eip155:8453 (Base mainnet) once the paid surface is flipped on in production.
- Facilitator: default `https://x402.org/facilitator` (configurable).
- The paid surface is gated behind a deploy-time `HALDIR_X402_ENABLED=1` flag on our side; the free adversarial demo and JWKS endpoint are always reachable.