### PR TITLE
feat(ecosystem): add AgentIAM Facilitator

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/agentiam-facilitator/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/agentiam-facilitator/metadata.json
@@ -1,0 +1,19 @@
+{
+  "name": "AgentIAM Facilitator",
+  "description": "x402 facilitator on Base Mainnet for autonomous AI agents. Non-custodial USDC settlement via EIP-3009 with Postgres-backed nonce replay protection and settlement ledger. Part of Project Olympus.",
+  "logoUrl": "/logos/agentiam.svg",
+  "websiteUrl": "https://achillesalpha-facilitator.onrender.com",
+  "category": "Facilitators",
+  "facilitator": {
+    "baseUrl": "https://achillesalpha.onrender.com/facilitator",
+    "networks": ["base"],
+    "schemes": ["exact"],
+    "assets": ["EIP-3009"],
+    "supports": {
+      "verify": true,
+      "settle": true,
+      "supported": true,
+      "list": false
+    }
+  }
+}

--- a/typescript/site/app/ecosystem/partners-data/agentiam-facilitator/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/agentiam-facilitator/metadata.json
@@ -2,7 +2,7 @@
   "name": "AgentIAM Facilitator",
   "description": "x402 facilitator on Base Mainnet for autonomous AI agents. Non-custodial USDC settlement via EIP-3009 with Postgres-backed nonce replay protection and settlement ledger. Part of Project Olympus.",
   "logoUrl": "/logos/agentiam.svg",
-  "websiteUrl": "https://achillesalpha-facilitator.onrender.com",
+  "websiteUrl": "https://achillesalpha.onrender.com/agentiam",
   "category": "Facilitators",
   "facilitator": {
     "baseUrl": "https://achillesalpha.onrender.com/facilitator",

--- a/typescript/site/public/logos/agentiam.svg
+++ b/typescript/site/public/logos/agentiam.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1a1a2e"/>
+      <stop offset="100%" stop-color="#16213e"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#g)"/>
+  <path d="M64 22 L96 86 L82 86 L75 70 L53 70 L46 86 L32 86 Z M58 58 L70 58 L64 42 Z" fill="#f5c518"/>
+  <circle cx="64" cy="100" r="6" fill="#f5c518"/>
+</svg>


### PR DESCRIPTION
## Summary

Adds **AgentIAM Facilitator** to the ecosystem directory under **Facilitators**.

AgentIAM is a non-custodial x402 facilitator on Base Mainnet, purpose-built for autonomous AI agents. It uses EIP-3009 `transferWithAuthorization` for USDC settlement, with a Postgres-backed nonce ledger for replay protection and a public settlement ledger for reputation signals.

- **Networks:** Base Mainnet (chain 8453)
- **Scheme:** exact
- **Asset:** USDC (EIP-3009)
- **Manifest:** https://achillesalpha.onrender.com/.well-known/x402-facilitator.json
- **Base URL:** https://achillesalpha.onrender.com/facilitator
- **Repo:** https://github.com/achilliesbot/agentiam-facilitator (Apache-2.0)
- **Operator:** Project Olympus

## Endpoints live

- `GET  /facilitator/supported` → `{"kinds":[{"scheme":"exact","network":"base"}]}`
- `POST /facilitator/verify`
- `POST /facilitator/settle`
- `GET  /facilitator/stats`
- `GET  /facilitator/health`

## Files

- `typescript/site/app/ecosystem/partners-data/agentiam-facilitator/metadata.json`
- `typescript/site/public/logos/agentiam.svg`
