### PR TITLE
test(go/extensions): add unit tests for paymentidentifier utils and extension types

### DIFF
--- a/go/extensions/paymentidentifier/utils_test.go
+++ b/go/extensions/paymentidentifier/utils_test.go
@@ -1,0 +1,200 @@
+package paymentidentifier
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// GeneratePaymentID
+// ---------------------------------------------------------------------------
+
+func TestGeneratePaymentID_DefaultPrefix(t *testing.T) {
+	id := GeneratePaymentID("")
+	if !strings.HasPrefix(id, "pay_") {
+		t.Errorf("expected default prefix 'pay_', got %q", id)
+	}
+}
+
+func TestGeneratePaymentID_CustomPrefix(t *testing.T) {
+	id := GeneratePaymentID("txn_")
+	if !strings.HasPrefix(id, "txn_") {
+		t.Errorf("expected prefix 'txn_', got %q", id)
+	}
+}
+
+func TestGeneratePaymentID_UUIDSuffixLength(t *testing.T) {
+	// UUID v4 without hyphens is 32 hex characters.
+	prefix := "pay_"
+	id := GeneratePaymentID(prefix)
+	suffix := strings.TrimPrefix(id, prefix)
+	if len(suffix) != 32 {
+		t.Errorf("expected 32-char UUID suffix, got %d chars: %q", len(suffix), suffix)
+	}
+}
+
+func TestGeneratePaymentID_UUIDSuffixIsHex(t *testing.T) {
+	id := GeneratePaymentID("")
+	suffix := strings.TrimPrefix(id, "pay_")
+	for _, ch := range suffix {
+		if !strings.ContainsRune("0123456789abcdef", ch) {
+			t.Errorf("UUID suffix contains non-hex character %q in %q", ch, id)
+		}
+	}
+}
+
+func TestGeneratePaymentID_Unique(t *testing.T) {
+	id1 := GeneratePaymentID("")
+	id2 := GeneratePaymentID("")
+	if id1 == id2 {
+		t.Errorf("expected unique IDs, but got identical values: %q", id1)
+	}
+}
+
+func TestGeneratePaymentID_LongPrefix(t *testing.T) {
+	prefix := "payment_order_"
+	id := GeneratePaymentID(prefix)
+	if !strings.HasPrefix(id, prefix) {
+		t.Errorf("expected prefix %q, got %q", prefix, id)
+	}
+	suffix := strings.TrimPrefix(id, prefix)
+	if len(suffix) != 32 {
+		t.Errorf("expected 32-char UUID suffix after custom prefix, got %d", len(suffix))
+	}
+}
+
+func TestGeneratePaymentID_ResultIsValidPaymentID(t *testing.T) {
+	id := GeneratePaymentID("")
+	if !IsValidPaymentID(id) {
+		t.Errorf("GeneratePaymentID result failed IsValidPaymentID check: %q", id)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IsValidPaymentID
+// ---------------------------------------------------------------------------
+
+func TestIsValidPaymentID_ValidMinLength(t *testing.T) {
+	// Exactly PAYMENT_ID_MIN_LENGTH (16) alphanumeric characters.
+	id := strings.Repeat("a", PAYMENT_ID_MIN_LENGTH)
+	if !IsValidPaymentID(id) {
+		t.Errorf("expected valid for min-length ID %q", id)
+	}
+}
+
+func TestIsValidPaymentID_ValidMaxLength(t *testing.T) {
+	// Exactly PAYMENT_ID_MAX_LENGTH (128) alphanumeric characters.
+	id := strings.Repeat("z", PAYMENT_ID_MAX_LENGTH)
+	if !IsValidPaymentID(id) {
+		t.Errorf("expected valid for max-length ID %q", id)
+	}
+}
+
+func TestIsValidPaymentID_ValidWithHyphensAndUnderscores(t *testing.T) {
+	ids := []string{
+		"pay_abc123def456ghi7",
+		"order-0000-1111-2222",
+		"PAY_UPPERCASE_ID1234",
+		"mix_and-match-HYBRID1",
+	}
+	for _, id := range ids {
+		if !IsValidPaymentID(id) {
+			t.Errorf("expected valid for %q", id)
+		}
+	}
+}
+
+func TestIsValidPaymentID_TooShort(t *testing.T) {
+	// One character below minimum.
+	id := strings.Repeat("x", PAYMENT_ID_MIN_LENGTH-1)
+	if IsValidPaymentID(id) {
+		t.Errorf("expected invalid for too-short ID %q (len=%d)", id, len(id))
+	}
+}
+
+func TestIsValidPaymentID_Empty(t *testing.T) {
+	if IsValidPaymentID("") {
+		t.Error("expected invalid for empty string")
+	}
+}
+
+func TestIsValidPaymentID_TooLong(t *testing.T) {
+	// One character above maximum.
+	id := strings.Repeat("a", PAYMENT_ID_MAX_LENGTH+1)
+	if IsValidPaymentID(id) {
+		t.Errorf("expected invalid for too-long ID (len=%d)", len(id))
+	}
+}
+
+func TestIsValidPaymentID_InvalidCharSpace(t *testing.T) {
+	id := "pay_valid_but has space"
+	if IsValidPaymentID(id) {
+		t.Errorf("expected invalid for ID containing space: %q", id)
+	}
+}
+
+func TestIsValidPaymentID_InvalidCharAt(t *testing.T) {
+	id := "pay_invalid@char12345"
+	if IsValidPaymentID(id) {
+		t.Errorf("expected invalid for ID containing '@': %q", id)
+	}
+}
+
+func TestIsValidPaymentID_InvalidCharDot(t *testing.T) {
+	id := "pay_invalid.dot12345"
+	if IsValidPaymentID(id) {
+		t.Errorf("expected invalid for ID containing '.': %q", id)
+	}
+}
+
+func TestIsValidPaymentID_InvalidCharSlash(t *testing.T) {
+	id := "pay_invalid/slash1234"
+	if IsValidPaymentID(id) {
+		t.Errorf("expected invalid for ID containing '/': %q", id)
+	}
+}
+
+func TestIsValidPaymentID_BoundaryAtMinLength(t *testing.T) {
+	// Exactly min length with all valid chars.
+	id := "abcdefghijklmnop" // 16 chars
+	if len(id) != PAYMENT_ID_MIN_LENGTH {
+		t.Fatalf("test data length %d != PAYMENT_ID_MIN_LENGTH %d", len(id), PAYMENT_ID_MIN_LENGTH)
+	}
+	if !IsValidPaymentID(id) {
+		t.Errorf("expected valid for boundary min-length ID %q", id)
+	}
+}
+
+func TestIsValidPaymentID_BelowBoundary(t *testing.T) {
+	id := "abcdefghijklmno" // 15 chars
+	if len(id) != PAYMENT_ID_MIN_LENGTH-1 {
+		t.Fatalf("test data length %d", len(id))
+	}
+	if IsValidPaymentID(id) {
+		t.Errorf("expected invalid for below-boundary ID %q", id)
+	}
+}
+
+func TestIsValidPaymentID_AllUppercase(t *testing.T) {
+	id := strings.Repeat("A", PAYMENT_ID_MIN_LENGTH)
+	if !IsValidPaymentID(id) {
+		t.Errorf("expected valid for all-uppercase ID %q", id)
+	}
+}
+
+func TestIsValidPaymentID_AllDigits(t *testing.T) {
+	id := strings.Repeat("9", PAYMENT_ID_MIN_LENGTH)
+	if !IsValidPaymentID(id) {
+		t.Errorf("expected valid for all-digit ID %q", id)
+	}
+}
+
+func TestIsValidPaymentID_GeneratedIDsPassValidation(t *testing.T) {
+	prefixes := []string{"", "pay_", "order_", "txn-"}
+	for _, prefix := range prefixes {
+		id := GeneratePaymentID(prefix)
+		if !IsValidPaymentID(id) {
+			t.Errorf("GeneratePaymentID(%q) = %q failed IsValidPaymentID", prefix, id)
+		}
+	}
+}

--- a/go/extensions/types/types_test.go
+++ b/go/extensions/types/types_test.go
@@ -1,0 +1,217 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// IsQueryMethod
+// ---------------------------------------------------------------------------
+
+func TestIsQueryMethod_GET(t *testing.T) {
+	if !IsQueryMethod("GET") {
+		t.Error("expected GET to be a query method")
+	}
+}
+
+func TestIsQueryMethod_HEAD(t *testing.T) {
+	if !IsQueryMethod("HEAD") {
+		t.Error("expected HEAD to be a query method")
+	}
+}
+
+func TestIsQueryMethod_DELETE(t *testing.T) {
+	if !IsQueryMethod("DELETE") {
+		t.Error("expected DELETE to be a query method")
+	}
+}
+
+func TestIsQueryMethod_POST(t *testing.T) {
+	if IsQueryMethod("POST") {
+		t.Error("expected POST to NOT be a query method")
+	}
+}
+
+func TestIsQueryMethod_PUT(t *testing.T) {
+	if IsQueryMethod("PUT") {
+		t.Error("expected PUT to NOT be a query method")
+	}
+}
+
+func TestIsQueryMethod_PATCH(t *testing.T) {
+	if IsQueryMethod("PATCH") {
+		t.Error("expected PATCH to NOT be a query method")
+	}
+}
+
+func TestIsQueryMethod_Lowercase(t *testing.T) {
+	if IsQueryMethod("get") {
+		t.Error("expected lowercase 'get' to NOT be a query method (case-sensitive)")
+	}
+}
+
+func TestIsQueryMethod_Empty(t *testing.T) {
+	if IsQueryMethod("") {
+		t.Error("expected empty string to NOT be a query method")
+	}
+}
+
+func TestIsQueryMethod_Unknown(t *testing.T) {
+	if IsQueryMethod("OPTIONS") {
+		t.Error("expected OPTIONS to NOT be a query method")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IsBodyMethod
+// ---------------------------------------------------------------------------
+
+func TestIsBodyMethod_POST(t *testing.T) {
+	if !IsBodyMethod("POST") {
+		t.Error("expected POST to be a body method")
+	}
+}
+
+func TestIsBodyMethod_PUT(t *testing.T) {
+	if !IsBodyMethod("PUT") {
+		t.Error("expected PUT to be a body method")
+	}
+}
+
+func TestIsBodyMethod_PATCH(t *testing.T) {
+	if !IsBodyMethod("PATCH") {
+		t.Error("expected PATCH to be a body method")
+	}
+}
+
+func TestIsBodyMethod_GET(t *testing.T) {
+	if IsBodyMethod("GET") {
+		t.Error("expected GET to NOT be a body method")
+	}
+}
+
+func TestIsBodyMethod_HEAD(t *testing.T) {
+	if IsBodyMethod("HEAD") {
+		t.Error("expected HEAD to NOT be a body method")
+	}
+}
+
+func TestIsBodyMethod_DELETE(t *testing.T) {
+	if IsBodyMethod("DELETE") {
+		t.Error("expected DELETE to NOT be a body method")
+	}
+}
+
+func TestIsBodyMethod_Lowercase(t *testing.T) {
+	if IsBodyMethod("post") {
+		t.Error("expected lowercase 'post' to NOT be a body method (case-sensitive)")
+	}
+}
+
+func TestIsBodyMethod_Empty(t *testing.T) {
+	if IsBodyMethod("") {
+		t.Error("expected empty string to NOT be a body method")
+	}
+}
+
+func TestIsBodyMethod_Unknown(t *testing.T) {
+	if IsBodyMethod("CONNECT") {
+		t.Error("expected CONNECT to NOT be a body method")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mutual exclusivity: no method should be both query and body
+// ---------------------------------------------------------------------------
+
+func TestMethodMutualExclusivity(t *testing.T) {
+	methods := []string{"GET", "HEAD", "DELETE", "POST", "PUT", "PATCH"}
+	for _, m := range methods {
+		q := IsQueryMethod(m)
+		b := IsBodyMethod(m)
+		if q && b {
+			t.Errorf("method %q is both query and body — should be mutually exclusive", m)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DiscoveryInfo UnmarshalJSON
+// ---------------------------------------------------------------------------
+
+func TestDiscoveryInfo_UnmarshalJSON_QueryInput(t *testing.T) {
+	raw := `{
+		"input": {
+			"type": "http",
+			"method": "GET",
+			"queryParams": {"q": "string"}
+		}
+	}`
+	var d DiscoveryInfo
+	if err := json.Unmarshal([]byte(raw), &d); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	qi, ok := d.Input.(QueryInput)
+	if !ok {
+		t.Fatalf("expected QueryInput, got %T", d.Input)
+	}
+	if qi.Method != MethodGET {
+		t.Errorf("expected method GET, got %q", qi.Method)
+	}
+}
+
+func TestDiscoveryInfo_UnmarshalJSON_BodyInput(t *testing.T) {
+	raw := `{
+		"input": {
+			"type": "http",
+			"method": "POST",
+			"bodyType": "json",
+			"body": {"key": "value"}
+		}
+	}`
+	var d DiscoveryInfo
+	if err := json.Unmarshal([]byte(raw), &d); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	bi, ok := d.Input.(BodyInput)
+	if !ok {
+		t.Fatalf("expected BodyInput, got %T", d.Input)
+	}
+	if bi.Method != MethodPOST {
+		t.Errorf("expected method POST, got %q", bi.Method)
+	}
+	if bi.BodyType != BodyTypeJSON {
+		t.Errorf("expected bodyType json, got %q", bi.BodyType)
+	}
+}
+
+func TestDiscoveryInfo_UnmarshalJSON_WithOutput(t *testing.T) {
+	raw := `{
+		"input": {
+			"type": "http",
+			"method": "GET"
+		},
+		"output": {
+			"type": "json",
+			"format": "application/json"
+		}
+	}`
+	var d DiscoveryInfo
+	if err := json.Unmarshal([]byte(raw), &d); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d.Output == nil {
+		t.Fatal("expected Output to be populated")
+	}
+	if d.Output.Type != "json" {
+		t.Errorf("expected output type 'json', got %q", d.Output.Type)
+	}
+}
+
+func TestDiscoveryInfo_UnmarshalJSON_InvalidJSON(t *testing.T) {
+	var d DiscoveryInfo
+	if err := json.Unmarshal([]byte(`not json`), &d); err == nil {
+		t.Error("expected error for invalid JSON, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Adds direct unit test coverage to two Go extension packages that previously had **zero test coverage**:

- `go/extensions/paymentidentifier/utils_test.go` — 22 tests
- `go/extensions/types/types_test.go` — 23 tests

**45 tests total, all passing.**

---

## paymentidentifier/utils_test.go (22 tests)

Covers `GeneratePaymentID` and `IsValidPaymentID` in `go/extensions/paymentidentifier/utils.go`:

| Group | Tests |
|---|---|
| `TestGeneratePaymentID_*` (7) | Default prefix (`pay_`), custom prefix, UUID suffix length (32 hex chars), hex-only suffix chars, uniqueness entropy, long prefix, generated ID passes `IsValidPaymentID` |
| `TestIsValidPaymentID_*` (15) | Min/max boundary acceptance, mixed alphanumeric+hyphen+underscore, too-short (15 chars), empty string, too-long (129 chars), invalid chars (space, `@`, `.`, `/`), all-uppercase, all-digits, cross-validation with `GeneratePaymentID` across 4 prefixes |

---

## extensions/types/types_test.go (23 tests)

Covers `IsQueryMethod`, `IsBodyMethod`, and `DiscoveryInfo.UnmarshalJSON` in `go/extensions/types/types.go`:

| Group | Tests |
|---|---|
| `TestIsQueryMethod_*` (9) | GET/HEAD/DELETE accepted; POST/PUT/PATCH/lowercase/empty/OPTIONS rejected |
| `TestIsBodyMethod_*` (9) | POST/PUT/PATCH accepted; GET/HEAD/DELETE/lowercase/empty/CONNECT rejected |
| `TestMethodMutualExclusivity` (1) | All 6 HTTP verbs verified as non-overlapping between query and body sets |
| `TestDiscoveryInfo_UnmarshalJSON_*` (4) | Query input path, body input path (bodyType discriminant), populated output field, invalid JSON error path |

---

## Test run

```
ok  github.com/coinbase/x402/go/extensions/paymentidentifier  0.263s
ok  github.com/coinbase/x402/go/extensions/types              0.130s
```

Continues the Go test-coverage series (PRs #79 → #90, #94).