### PR TITLE
test(go/evm): add unit tests for ExactEvmScheme and UptoEvmScheme facilitator structs

### DIFF
--- a/go/.changes/unreleased/test-go-evm-exact-server-scheme-coverage.yaml
+++ b/go/.changes/unreleased/test-go-evm-exact-server-scheme-coverage.yaml
@@ -1,0 +1,2 @@
+kind: added
+body: "add unit tests for ExactEvmScheme (ParsePrice, ValidatePaymentRequirements, EnhancePaymentRequirements, GetDisplayAmount, ConvertToTokenAmount, ConvertFromTokenAmount, GetSupportedNetworks, GetAssetDecimals)"

--- a/go/.changes/unreleased/test-go-evm-facilitator-scheme-unit-tests.yaml
+++ b/go/.changes/unreleased/test-go-evm-facilitator-scheme-unit-tests.yaml
@@ -1,0 +1,2 @@
+kind: added
+body: "add unit tests for ExactEvmScheme and UptoEvmScheme facilitator structs (NewScheme config copy, Scheme, CaipFamily, GetExtra, GetSigners, Verify/Settle payload routing)"

--- a/go/mechanisms/evm/exact/facilitator/scheme_test.go
+++ b/go/mechanisms/evm/exact/facilitator/scheme_test.go
@@ -1,0 +1,246 @@
+package facilitator
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	x402 "github.com/x402-foundation/x402/go"
+	"github.com/x402-foundation/x402/go/mechanisms/evm"
+	"github.com/x402-foundation/x402/go/types"
+)
+
+// mockExactFacilitatorSigner is a minimal stub satisfying evm.FacilitatorEvmSigner.
+type mockExactFacilitatorSigner struct {
+	addresses []string
+}
+
+func (m *mockExactFacilitatorSigner) GetAddresses() []string { return m.addresses }
+
+func (m *mockExactFacilitatorSigner) ReadContract(_ context.Context, _ string, _ []byte, _ string, _ ...interface{}) (interface{}, error) {
+	return nil, nil
+}
+
+func (m *mockExactFacilitatorSigner) VerifyTypedData(_ context.Context, _ string, _ evm.TypedDataDomain, _ map[string][]evm.TypedDataField, _ string, _ map[string]interface{}, _ []byte) (bool, error) {
+	return false, nil
+}
+
+func (m *mockExactFacilitatorSigner) WriteContract(_ context.Context, _ string, _ []byte, _ string, _ ...interface{}) (string, error) {
+	return "", nil
+}
+
+func (m *mockExactFacilitatorSigner) SendTransaction(_ context.Context, _ string, _ []byte) (string, error) {
+	return "", nil
+}
+
+func (m *mockExactFacilitatorSigner) WaitForTransactionReceipt(_ context.Context, _ string) (*evm.TransactionReceipt, error) {
+	return nil, nil
+}
+
+func (m *mockExactFacilitatorSigner) GetBalance(_ context.Context, _ string, _ string) (*big.Int, error) {
+	return big.NewInt(0), nil
+}
+
+func (m *mockExactFacilitatorSigner) GetChainID(_ context.Context) (*big.Int, error) {
+	return big.NewInt(8453), nil
+}
+
+func (m *mockExactFacilitatorSigner) GetCode(_ context.Context, _ string) ([]byte, error) {
+	return nil, nil
+}
+
+// ---------------------------------------------------------------------------
+// NewExactEvmScheme
+// ---------------------------------------------------------------------------
+
+func TestNewExactEvmScheme_NilConfig(t *testing.T) {
+	signer := &mockExactFacilitatorSigner{addresses: []string{"0xABCD"}}
+	s := NewExactEvmScheme(signer, nil)
+	if s == nil {
+		t.Fatal("expected non-nil scheme")
+	}
+	// nil config → zero-value ExactEvmSchemeConfig
+	if s.config.DeployERC4337WithEIP6492 {
+		t.Error("DeployERC4337WithEIP6492 should default to false")
+	}
+	if s.config.SimulateInSettle {
+		t.Error("SimulateInSettle should default to false")
+	}
+}
+
+func TestNewExactEvmScheme_NonNilConfig(t *testing.T) {
+	signer := &mockExactFacilitatorSigner{}
+	cfg := &ExactEvmSchemeConfig{
+		DeployERC4337WithEIP6492: true,
+		SimulateInSettle:         true,
+	}
+	s := NewExactEvmScheme(signer, cfg)
+	if !s.config.DeployERC4337WithEIP6492 {
+		t.Error("DeployERC4337WithEIP6492 should be true")
+	}
+	if !s.config.SimulateInSettle {
+		t.Error("SimulateInSettle should be true")
+	}
+}
+
+func TestNewExactEvmScheme_ConfigIsCopied(t *testing.T) {
+	signer := &mockExactFacilitatorSigner{}
+	cfg := &ExactEvmSchemeConfig{SimulateInSettle: true}
+	s := NewExactEvmScheme(signer, cfg)
+	// Mutating original struct must not affect scheme config.
+	cfg.SimulateInSettle = false
+	if !s.config.SimulateInSettle {
+		t.Error("scheme config should be a copy, not a pointer")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scheme / CaipFamily / GetExtra / GetSigners
+// ---------------------------------------------------------------------------
+
+func TestExactEvmScheme_Scheme(t *testing.T) {
+	s := NewExactEvmScheme(&mockExactFacilitatorSigner{}, nil)
+	if got := s.Scheme(); got != evm.SchemeExact {
+		t.Errorf("expected %q, got %q", evm.SchemeExact, got)
+	}
+}
+
+func TestExactEvmScheme_CaipFamily(t *testing.T) {
+	s := NewExactEvmScheme(&mockExactFacilitatorSigner{}, nil)
+	if got := s.CaipFamily(); got != "eip155:*" {
+		t.Errorf("expected %q, got %q", "eip155:*", got)
+	}
+}
+
+func TestExactEvmScheme_GetExtra_ReturnsNil(t *testing.T) {
+	s := NewExactEvmScheme(&mockExactFacilitatorSigner{}, nil)
+	extra := s.GetExtra(x402.Network("eip155:8453"))
+	if extra != nil {
+		t.Errorf("expected nil extra, got %v", extra)
+	}
+}
+
+func TestExactEvmScheme_GetSigners_ReturnsSignerAddresses(t *testing.T) {
+	addrs := []string{"0xAAA", "0xBBB"}
+	s := NewExactEvmScheme(&mockExactFacilitatorSigner{addresses: addrs}, nil)
+	got := s.GetSigners(x402.Network("eip155:8453"))
+	if len(got) != 2 || got[0] != addrs[0] || got[1] != addrs[1] {
+		t.Errorf("expected %v, got %v", addrs, got)
+	}
+}
+
+func TestExactEvmScheme_GetSigners_EmptyWhenNoAddresses(t *testing.T) {
+	s := NewExactEvmScheme(&mockExactFacilitatorSigner{addresses: nil}, nil)
+	got := s.GetSigners(x402.Network("eip155:1"))
+	if len(got) != 0 {
+		t.Errorf("expected empty slice, got %v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Verify routing
+// ---------------------------------------------------------------------------
+
+func TestExactEvmScheme_Verify_MalformedPermit2Payload(t *testing.T) {
+	// payload.Payload has "permit2Authorization" key → IsPermit2Payload returns true,
+	// but the value is not a map → Permit2PayloadFromMap returns an error.
+	s := NewExactEvmScheme(&mockExactFacilitatorSigner{}, nil)
+	payload := types.PaymentPayload{
+		X402Version: 2,
+		Payload: map[string]interface{}{
+			"permit2Authorization": "not-a-map",
+		},
+	}
+	req := types.PaymentRequirements{
+		Scheme:  evm.SchemeExact,
+		Network: "eip155:8453",
+	}
+	_, err := s.Verify(context.Background(), payload, req, nil)
+	if err == nil {
+		t.Fatal("expected error for malformed Permit2 payload")
+	}
+	// Error should carry ErrInvalidPayload code.
+	var verr *x402.VerifyError
+	if !errors.As(err, &verr) {
+		t.Fatalf("expected VerifyError, got %T: %v", err, err)
+	}
+	if verr.InvalidReason != ErrInvalidPayload {
+		t.Errorf("expected error code %q, got %q", ErrInvalidPayload, verr.InvalidReason)
+	}
+}
+
+func TestExactEvmScheme_Verify_NonPermit2RoutesToEIP3009_FailsOnBadNetwork(t *testing.T) {
+	// payload.Payload has no "permit2Authorization" → not Permit2 → routes to verifyEIP3009.
+	// verifyEIP3009 will fail because the network "eip155:99999" has no RPC config.
+	s := NewExactEvmScheme(&mockExactFacilitatorSigner{}, nil)
+	payload := types.PaymentPayload{
+		X402Version: 2,
+		Payload: map[string]interface{}{
+			"authorization": map[string]interface{}{},
+		},
+	}
+	req := types.PaymentRequirements{
+		Scheme:  evm.SchemeExact,
+		Network: "eip155:99999",
+	}
+	_, err := s.Verify(context.Background(), payload, req, nil)
+	if err == nil {
+		t.Fatal("expected error when network has no config")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Settle routing
+// ---------------------------------------------------------------------------
+
+func TestExactEvmScheme_Settle_MalformedPermit2Payload(t *testing.T) {
+	s := NewExactEvmScheme(&mockExactFacilitatorSigner{}, nil)
+	payload := types.PaymentPayload{
+		X402Version: 2,
+		Accepted: types.PaymentRequirements{
+			Scheme:  evm.SchemeExact,
+			Network: "eip155:8453",
+		},
+		Payload: map[string]interface{}{
+			"permit2Authorization": 42, // wrong type
+		},
+	}
+	req := types.PaymentRequirements{
+		Scheme:  evm.SchemeExact,
+		Network: "eip155:8453",
+	}
+	_, err := s.Settle(context.Background(), payload, req, nil)
+	if err == nil {
+		t.Fatal("expected error for malformed Permit2 payload")
+	}
+	var serr *x402.SettleError
+	if !errors.As(err, &serr) {
+		t.Fatalf("expected SettleError, got %T: %v", err, err)
+	}
+	if serr.ErrorReason != ErrInvalidPayload {
+		t.Errorf("expected error code %q, got %q", ErrInvalidPayload, serr.ErrorReason)
+	}
+}
+
+func TestExactEvmScheme_Settle_NonPermit2RoutesToEIP3009_FailsOnBadNetwork(t *testing.T) {
+	s := NewExactEvmScheme(&mockExactFacilitatorSigner{}, nil)
+	payload := types.PaymentPayload{
+		X402Version: 2,
+		Accepted: types.PaymentRequirements{
+			Scheme:  evm.SchemeExact,
+			Network: "eip155:99999",
+		},
+		Payload: map[string]interface{}{
+			"authorization": map[string]interface{}{},
+		},
+	}
+	req := types.PaymentRequirements{
+		Scheme:  evm.SchemeExact,
+		Network: "eip155:99999",
+	}
+	_, err := s.Settle(context.Background(), payload, req, nil)
+	if err == nil {
+		t.Fatal("expected error when network has no RPC config")
+	}
+}

--- a/go/mechanisms/evm/exact/server/scheme_test.go
+++ b/go/mechanisms/evm/exact/server/scheme_test.go
@@ -1,0 +1,381 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	x402 "github.com/x402-foundation/x402/go"
+)
+
+const (
+	baseSepoliaUSDC   = "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+	validPayToAddress = "0x1234567890123456789012345678901234567890"
+)
+
+// TestScheme verifies the scheme identifier.
+func TestScheme(t *testing.T) {
+	s := NewExactEvmScheme()
+	if s.Scheme() != "exact" {
+		t.Errorf("Expected scheme='exact', got %q", s.Scheme())
+	}
+}
+
+// TestGetAssetDecimals verifies decimal lookup for known and unknown assets.
+func TestGetAssetDecimals(t *testing.T) {
+	s := NewExactEvmScheme()
+
+	// Known USDC asset on Base mainnet → 6 decimals
+	dec := s.GetAssetDecimals(baseMainnetUSDC, "eip155:8453")
+	if dec != 6 {
+		t.Errorf("Expected 6 decimals for USDC on Base mainnet, got %d", dec)
+	}
+
+	// Unknown valid address on any EVM network → 18 decimals (generic token default)
+	// GetAssetInfo succeeds but returns generic AssetInfo{Decimals: 18} for unknown addresses
+	dec = s.GetAssetDecimals("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "eip155:8453")
+	if dec != 18 {
+		t.Errorf("Expected 18 decimals for unknown EVM token, got %d", dec)
+	}
+}
+
+// TestParsePrice_IntAndInt64 verifies int and int64 prices are converted correctly.
+func TestParsePrice_IntAndInt64(t *testing.T) {
+	s := NewExactEvmScheme()
+
+	tests := []struct {
+		price          interface{}
+		expectedAmount string
+	}{
+		{int(1), "1000000"},
+		{int64(2), "2000000"},
+	}
+
+	for _, tt := range tests {
+		result, err := s.ParsePrice(tt.price, "eip155:8453")
+		if err != nil {
+			t.Errorf("price=%v: unexpected error: %v", tt.price, err)
+			continue
+		}
+		if result.Amount != tt.expectedAmount {
+			t.Errorf("price=%v: expected amount %s, got %s", tt.price, tt.expectedAmount, result.Amount)
+		}
+	}
+}
+
+// TestParsePrice_InvalidString verifies error on unparseable price string.
+func TestParsePrice_InvalidString(t *testing.T) {
+	s := NewExactEvmScheme()
+	_, err := s.ParsePrice("not-a-number", "eip155:8453")
+	if err == nil {
+		t.Error("Expected error for invalid price string")
+	}
+}
+
+// TestParsePrice_UnsupportedType verifies error on unsupported price type.
+func TestParsePrice_UnsupportedType(t *testing.T) {
+	s := NewExactEvmScheme()
+	_, err := s.ParsePrice([]int{1, 2, 3}, "eip155:8453")
+	if err == nil {
+		t.Error("Expected error for unsupported price type")
+	}
+}
+
+// TestParsePrice_AssetAmountPassthrough verifies direct AssetAmount map is returned unchanged.
+func TestParsePrice_AssetAmountPassthrough(t *testing.T) {
+	s := NewExactEvmScheme()
+
+	price := map[string]interface{}{
+		"amount": "1500000",
+		"asset":  baseSepoliaUSDC,
+		"extra":  map[string]interface{}{"name": "USD Coin"},
+	}
+
+	result, err := s.ParsePrice(price, "eip155:84532")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if result.Amount != "1500000" {
+		t.Errorf("Expected '1500000', got %s", result.Amount)
+	}
+	if result.Asset != baseSepoliaUSDC {
+		t.Errorf("Expected asset passthrough %s, got %s", baseSepoliaUSDC, result.Asset)
+	}
+	if result.Extra["name"] != "USD Coin" {
+		t.Errorf("Expected extra passthrough, got %v", result.Extra["name"])
+	}
+}
+
+// TestParsePrice_AssetAmountMissingAsset verifies error when asset key is absent.
+func TestParsePrice_AssetAmountMissingAsset(t *testing.T) {
+	s := NewExactEvmScheme()
+
+	price := map[string]interface{}{
+		"amount": "1000000",
+		// no "asset" key
+	}
+	_, err := s.ParsePrice(price, "eip155:8453")
+	if err == nil {
+		t.Error("Expected error for AssetAmount map missing 'asset'")
+	}
+}
+
+// TestParsePrice_AssetAmountNonStringAmount verifies error when amount is not a string.
+func TestParsePrice_AssetAmountNonStringAmount(t *testing.T) {
+	s := NewExactEvmScheme()
+
+	price := map[string]interface{}{
+		"amount": 1000000, // int instead of string
+		"asset":  baseMainnetUSDC,
+	}
+	_, err := s.ParsePrice(price, "eip155:8453")
+	if err == nil {
+		t.Error("Expected error for non-string amount in AssetAmount map")
+	}
+}
+
+// TestValidatePaymentRequirements_Valid verifies a fully valid set of requirements passes.
+func TestValidatePaymentRequirements_Valid(t *testing.T) {
+	s := NewExactEvmScheme()
+
+	req := x402.PaymentRequirements{
+		Scheme:  "exact",
+		Network: "eip155:8453",
+		Amount:  "1000000",
+		Asset:   baseMainnetUSDC,
+		PayTo:   validPayToAddress,
+	}
+	if err := s.ValidatePaymentRequirements(req); err != nil {
+		t.Errorf("Expected valid requirements to pass, got error: %v", err)
+	}
+}
+
+// TestValidatePaymentRequirements_InvalidPayTo verifies rejection of an invalid PayTo.
+func TestValidatePaymentRequirements_InvalidPayTo(t *testing.T) {
+	s := NewExactEvmScheme()
+
+	req := x402.PaymentRequirements{
+		Scheme:  "exact",
+		Network: "eip155:8453",
+		Amount:  "1000000",
+		PayTo:   "not-an-address",
+	}
+	if err := s.ValidatePaymentRequirements(req); err == nil {
+		t.Error("Expected error for invalid PayTo")
+	}
+}
+
+// TestValidatePaymentRequirements_EmptyAmount verifies rejection of empty amount.
+func TestValidatePaymentRequirements_EmptyAmount(t *testing.T) {
+	s := NewExactEvmScheme()
+
+	req := x402.PaymentRequirements{
+		Scheme:  "exact",
+		Network: "eip155:8453",
+		Amount:  "",
+		PayTo:   validPayToAddress,
+	}
+	if err := s.ValidatePaymentRequirements(req); err == nil {
+		t.Error("Expected error for empty amount")
+	}
+}
+
+// TestValidatePaymentRequirements_InvalidAmounts verifies rejection of non-positive amounts.
+func TestValidatePaymentRequirements_InvalidAmounts(t *testing.T) {
+	s := NewExactEvmScheme()
+
+	for _, amount := range []string{"0", "-1", "not-a-number"} {
+		req := x402.PaymentRequirements{
+			Scheme:  "exact",
+			Network: "eip155:8453",
+			Amount:  amount,
+			PayTo:   validPayToAddress,
+		}
+		if err := s.ValidatePaymentRequirements(req); err == nil {
+			t.Errorf("Expected error for amount %q", amount)
+		}
+	}
+}
+
+// TestEnhancePaymentRequirements_SetsAsset verifies that missing asset is filled in.
+func TestEnhancePaymentRequirements_SetsAsset(t *testing.T) {
+	s := NewExactEvmScheme()
+
+	req := x402.PaymentRequirements{
+		Scheme:  "exact",
+		Network: "eip155:8453",
+		Amount:  "1000000",
+		// no Asset
+		PayTo: validPayToAddress,
+	}
+
+	enhanced, err := s.EnhancePaymentRequirements(context.Background(), req, x402.SupportedKind{}, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if enhanced.Asset == "" {
+		t.Error("Expected asset to be filled in by EnhancePaymentRequirements")
+	}
+}
+
+// TestEnhancePaymentRequirements_ConvertDecimalAmount verifies decimal amounts are converted to integer units.
+func TestEnhancePaymentRequirements_ConvertDecimalAmount(t *testing.T) {
+	s := NewExactEvmScheme()
+
+	req := x402.PaymentRequirements{
+		Scheme:  "exact",
+		Network: "eip155:8453",
+		Amount:  "1.500000", // decimal
+		Asset:   baseMainnetUSDC,
+		PayTo:   validPayToAddress,
+	}
+
+	enhanced, err := s.EnhancePaymentRequirements(context.Background(), req, x402.SupportedKind{}, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if strings.Contains(enhanced.Amount, ".") {
+		t.Errorf("Expected integer amount after enhancement, got %s", enhanced.Amount)
+	}
+}
+
+// TestEnhancePaymentRequirements_ExtensionKeysCopied verifies extra fields from SupportedKind are copied.
+func TestEnhancePaymentRequirements_ExtensionKeysCopied(t *testing.T) {
+	s := NewExactEvmScheme()
+
+	req := x402.PaymentRequirements{
+		Scheme:  "exact",
+		Network: "eip155:8453",
+		Amount:  "1000000",
+		Asset:   baseMainnetUSDC,
+		PayTo:   validPayToAddress,
+	}
+
+	kind := x402.SupportedKind{
+		Scheme:  "exact",
+		Network: "eip155:8453",
+		Extra: map[string]interface{}{
+			"customExtension": "customValue",
+		},
+	}
+
+	enhanced, err := s.EnhancePaymentRequirements(context.Background(), req, kind, []string{"customExtension"})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if enhanced.Extra["customExtension"] != "customValue" {
+		t.Errorf("Expected customExtension='customValue', got %v", enhanced.Extra["customExtension"])
+	}
+}
+
+// TestGetDisplayAmount_Valid verifies human-readable amount formatting.
+func TestGetDisplayAmount_Valid(t *testing.T) {
+	s := NewExactEvmScheme()
+
+	display, err := s.GetDisplayAmount("1500000", "eip155:8453", baseMainnetUSDC)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if !strings.Contains(display, "1.5") {
+		t.Errorf("Expected '1.5' in display, got %q", display)
+	}
+	if !strings.Contains(display, "USDC") {
+		t.Errorf("Expected 'USDC' in display, got %q", display)
+	}
+}
+
+// TestGetDisplayAmount_InvalidAmount verifies error for non-numeric amount.
+func TestGetDisplayAmount_InvalidAmount(t *testing.T) {
+	s := NewExactEvmScheme()
+
+	_, err := s.GetDisplayAmount("not-a-number", "eip155:8453", baseMainnetUSDC)
+	if err == nil {
+		t.Error("Expected error for non-numeric amount string")
+	}
+}
+
+// TestConvertToTokenAmount_Valid verifies decimal → smallest unit conversion.
+func TestConvertToTokenAmount_Valid(t *testing.T) {
+	s := NewExactEvmScheme()
+
+	result, err := s.ConvertToTokenAmount("1.500000", "eip155:8453")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if result != "1500000" {
+		t.Errorf("Expected '1500000', got %s", result)
+	}
+}
+
+// TestConvertToTokenAmount_InvalidNetwork verifies error for unknown network.
+func TestConvertToTokenAmount_InvalidNetwork(t *testing.T) {
+	s := NewExactEvmScheme()
+
+	_, err := s.ConvertToTokenAmount("1.0", "eip155:99999999")
+	if err == nil {
+		t.Error("Expected error for unknown network")
+	}
+}
+
+// TestConvertFromTokenAmount_Valid verifies smallest-unit → decimal conversion.
+func TestConvertFromTokenAmount_Valid(t *testing.T) {
+	s := NewExactEvmScheme()
+
+	result, err := s.ConvertFromTokenAmount("1500000", "eip155:8453")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if result != "1.5" {
+		t.Errorf("Expected '1.5', got %s", result)
+	}
+}
+
+// TestConvertFromTokenAmount_InvalidAmount verifies error for a non-integer token amount.
+func TestConvertFromTokenAmount_InvalidAmount(t *testing.T) {
+	s := NewExactEvmScheme()
+
+	_, err := s.ConvertFromTokenAmount("1.5", "eip155:8453")
+	if err == nil {
+		t.Error("Expected error for decimal token amount (not a valid integer)")
+	}
+}
+
+// TestConvertFromTokenAmount_ZeroAmount verifies zero token amount formatting.
+func TestConvertFromTokenAmount_ZeroAmount(t *testing.T) {
+	s := NewExactEvmScheme()
+
+	result, err := s.ConvertFromTokenAmount("0", "eip155:8453")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if result != "0" {
+		t.Errorf("Expected '0', got %s", result)
+	}
+}
+
+// TestGetSupportedNetworks verifies the list is non-empty and includes Base mainnet.
+func TestGetSupportedNetworks(t *testing.T) {
+	s := NewExactEvmScheme()
+
+	networks := s.GetSupportedNetworks()
+	if len(networks) == 0 {
+		t.Fatal("Expected at least one supported network")
+	}
+
+	found := false
+	for _, n := range networks {
+		if n == "eip155:8453" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Expected 'eip155:8453' in supported networks, got %v", networks)
+	}
+}

--- a/go/mechanisms/evm/upto/facilitator/scheme_test.go
+++ b/go/mechanisms/evm/upto/facilitator/scheme_test.go
@@ -1,0 +1,318 @@
+package facilitator
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	x402 "github.com/x402-foundation/x402/go"
+	"github.com/x402-foundation/x402/go/mechanisms/evm"
+	"github.com/x402-foundation/x402/go/types"
+)
+
+// mockUptoFacilitatorSigner is a minimal stub satisfying evm.FacilitatorEvmSigner.
+type mockUptoFacilitatorSigner struct {
+	addresses []string
+}
+
+func (m *mockUptoFacilitatorSigner) GetAddresses() []string { return m.addresses }
+
+func (m *mockUptoFacilitatorSigner) ReadContract(_ context.Context, _ string, _ []byte, _ string, _ ...interface{}) (interface{}, error) {
+	return nil, nil
+}
+
+func (m *mockUptoFacilitatorSigner) VerifyTypedData(_ context.Context, _ string, _ evm.TypedDataDomain, _ map[string][]evm.TypedDataField, _ string, _ map[string]interface{}, _ []byte) (bool, error) {
+	return false, nil
+}
+
+func (m *mockUptoFacilitatorSigner) WriteContract(_ context.Context, _ string, _ []byte, _ string, _ ...interface{}) (string, error) {
+	return "", nil
+}
+
+func (m *mockUptoFacilitatorSigner) SendTransaction(_ context.Context, _ string, _ []byte) (string, error) {
+	return "", nil
+}
+
+func (m *mockUptoFacilitatorSigner) WaitForTransactionReceipt(_ context.Context, _ string) (*evm.TransactionReceipt, error) {
+	return nil, nil
+}
+
+func (m *mockUptoFacilitatorSigner) GetBalance(_ context.Context, _ string, _ string) (*big.Int, error) {
+	return big.NewInt(0), nil
+}
+
+func (m *mockUptoFacilitatorSigner) GetChainID(_ context.Context) (*big.Int, error) {
+	return big.NewInt(8453), nil
+}
+
+func (m *mockUptoFacilitatorSigner) GetCode(_ context.Context, _ string) ([]byte, error) {
+	return nil, nil
+}
+
+// ---------------------------------------------------------------------------
+// NewUptoEvmScheme
+// ---------------------------------------------------------------------------
+
+func TestNewUptoEvmScheme_NilConfig(t *testing.T) {
+	signer := &mockUptoFacilitatorSigner{addresses: []string{"0xABCD"}}
+	s := NewUptoEvmScheme(signer, nil)
+	if s == nil {
+		t.Fatal("expected non-nil scheme")
+	}
+	if s.config.SimulateInSettle {
+		t.Error("SimulateInSettle should default to false")
+	}
+}
+
+func TestNewUptoEvmScheme_NonNilConfig(t *testing.T) {
+	signer := &mockUptoFacilitatorSigner{}
+	cfg := &UptoEvmSchemeConfig{SimulateInSettle: true}
+	s := NewUptoEvmScheme(signer, cfg)
+	if !s.config.SimulateInSettle {
+		t.Error("SimulateInSettle should be true")
+	}
+}
+
+func TestNewUptoEvmScheme_ConfigIsCopied(t *testing.T) {
+	signer := &mockUptoFacilitatorSigner{}
+	cfg := &UptoEvmSchemeConfig{SimulateInSettle: true}
+	s := NewUptoEvmScheme(signer, cfg)
+	cfg.SimulateInSettle = false
+	if !s.config.SimulateInSettle {
+		t.Error("scheme config should be a copy, not a pointer")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scheme / CaipFamily / GetExtra / GetSigners
+// ---------------------------------------------------------------------------
+
+func TestUptoEvmScheme_GetExtra_NoAddresses_ReturnsNil(t *testing.T) {
+	s := NewUptoEvmScheme(&mockUptoFacilitatorSigner{addresses: nil}, nil)
+	extra := s.GetExtra(x402.Network("eip155:8453"))
+	if extra != nil {
+		t.Errorf("expected nil when signer has no addresses, got %v", extra)
+	}
+}
+
+func TestUptoEvmScheme_GetExtra_EmptyAddresses_ReturnsNil(t *testing.T) {
+	s := NewUptoEvmScheme(&mockUptoFacilitatorSigner{addresses: []string{}}, nil)
+	extra := s.GetExtra(x402.Network("eip155:8453"))
+	if extra != nil {
+		t.Errorf("expected nil for empty address list, got %v", extra)
+	}
+}
+
+func TestUptoEvmScheme_GetExtra_WithAddresses_ReturnsFacilitatorAddress(t *testing.T) {
+	addr := "0x1111111111111111111111111111111111111111"
+	s := NewUptoEvmScheme(&mockUptoFacilitatorSigner{addresses: []string{addr}}, nil)
+	extra := s.GetExtra(x402.Network("eip155:8453"))
+	if extra == nil {
+		t.Fatal("expected non-nil extra when addresses are available")
+	}
+	got, ok := extra["facilitatorAddress"].(string)
+	if !ok {
+		t.Fatalf("expected facilitatorAddress string, got %T", extra["facilitatorAddress"])
+	}
+	if got != addr {
+		t.Errorf("expected %q, got %q", addr, got)
+	}
+}
+
+func TestUptoEvmScheme_GetExtra_MultipleAddresses_ReturnsOneOfThem(t *testing.T) {
+	addrs := []string{
+		"0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+		"0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+	}
+	s := NewUptoEvmScheme(&mockUptoFacilitatorSigner{addresses: addrs}, nil)
+
+	seen := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		extra := s.GetExtra(x402.Network("eip155:8453"))
+		if extra == nil {
+			t.Fatal("unexpected nil extra")
+		}
+		addr, ok := extra["facilitatorAddress"].(string)
+		if !ok {
+			t.Fatal("facilitatorAddress not a string")
+		}
+		found := false
+		for _, a := range addrs {
+			if a == addr {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("returned address %q not in signer addresses", addr)
+		}
+		seen[addr] = true
+	}
+	// With 100 iterations over 3 addresses (rand.Intn), expect at least 2 distinct values.
+	if len(seen) < 2 {
+		t.Errorf("expected random selection across addresses, got only %d distinct value(s)", len(seen))
+	}
+}
+
+func TestUptoEvmScheme_GetSigners_ReturnsAddresses(t *testing.T) {
+	addrs := []string{"0x111", "0x222"}
+	s := NewUptoEvmScheme(&mockUptoFacilitatorSigner{addresses: addrs}, nil)
+	got := s.GetSigners(x402.Network("eip155:8453"))
+	if len(got) != 2 || got[0] != addrs[0] || got[1] != addrs[1] {
+		t.Errorf("expected %v, got %v", addrs, got)
+	}
+}
+
+func TestUptoEvmScheme_GetSigners_Empty(t *testing.T) {
+	s := NewUptoEvmScheme(&mockUptoFacilitatorSigner{addresses: nil}, nil)
+	got := s.GetSigners(x402.Network("eip155:1"))
+	if len(got) != 0 {
+		t.Errorf("expected empty slice, got %v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Verify routing — non-upto payload rejected immediately
+// ---------------------------------------------------------------------------
+
+func TestUptoEvmScheme_Verify_EmptyPayload_Rejected(t *testing.T) {
+	s := NewUptoEvmScheme(&mockUptoFacilitatorSigner{}, nil)
+	payload := types.PaymentPayload{
+		X402Version: 2,
+		Payload:     map[string]interface{}{},
+	}
+	_, err := s.Verify(context.Background(), payload, types.PaymentRequirements{}, nil)
+	if err == nil {
+		t.Fatal("expected error for empty payload")
+	}
+	var verr *x402.VerifyError
+	if !errors.As(err, &verr) {
+		t.Fatalf("expected VerifyError, got %T: %v", err, err)
+	}
+	if verr.InvalidReason != ErrUptoInvalidPayload {
+		t.Errorf("expected %q, got %q", ErrUptoInvalidPayload, verr.InvalidReason)
+	}
+}
+
+func TestUptoEvmScheme_Verify_ExactPermit2Payload_Rejected(t *testing.T) {
+	// An exact Permit2 payload has "permit2Authorization" but no "witness.facilitator"
+	// → IsUptoPermit2Payload returns false → rejected.
+	s := NewUptoEvmScheme(&mockUptoFacilitatorSigner{}, nil)
+	payload := types.PaymentPayload{
+		X402Version: 2,
+		Payload: map[string]interface{}{
+			"signature": "0xabc",
+			"permit2Authorization": map[string]interface{}{
+				"from":    "0x111",
+				"spender": "0x222",
+				// No "witness" with "facilitator" key
+			},
+		},
+	}
+	_, err := s.Verify(context.Background(), payload, types.PaymentRequirements{}, nil)
+	if err == nil {
+		t.Fatal("expected error for non-upto payload")
+	}
+	var verr *x402.VerifyError
+	if !errors.As(err, &verr) {
+		t.Fatalf("expected VerifyError, got %T: %v", err, err)
+	}
+	if verr.InvalidReason != ErrUptoInvalidPayload {
+		t.Errorf("expected %q, got %q", ErrUptoInvalidPayload, verr.InvalidReason)
+	}
+}
+
+func TestUptoEvmScheme_Verify_NilPayloadMap_Rejected(t *testing.T) {
+	s := NewUptoEvmScheme(&mockUptoFacilitatorSigner{}, nil)
+	payload := types.PaymentPayload{
+		X402Version: 2,
+		Payload:     nil,
+	}
+	_, err := s.Verify(context.Background(), payload, types.PaymentRequirements{}, nil)
+	if err == nil {
+		t.Fatal("expected error for nil payload map")
+	}
+	var verr *x402.VerifyError
+	if !errors.As(err, &verr) {
+		t.Fatalf("expected VerifyError, got %T: %v", err, err)
+	}
+	if verr.InvalidReason != ErrUptoInvalidPayload {
+		t.Errorf("expected %q, got %q", ErrUptoInvalidPayload, verr.InvalidReason)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Settle routing — non-upto payload rejected immediately
+// ---------------------------------------------------------------------------
+
+func TestUptoEvmScheme_Settle_EmptyPayload_Rejected(t *testing.T) {
+	s := NewUptoEvmScheme(&mockUptoFacilitatorSigner{}, nil)
+	payload := types.PaymentPayload{
+		X402Version: 2,
+		Accepted:    types.PaymentRequirements{Network: "eip155:8453"},
+		Payload:     map[string]interface{}{},
+	}
+	_, err := s.Settle(context.Background(), payload, types.PaymentRequirements{}, nil)
+	if err == nil {
+		t.Fatal("expected error for empty payload")
+	}
+	var serr *x402.SettleError
+	if !errors.As(err, &serr) {
+		t.Fatalf("expected SettleError, got %T: %v", err, err)
+	}
+	if serr.ErrorReason != ErrUptoInvalidPayload {
+		t.Errorf("expected %q, got %q", ErrUptoInvalidPayload, serr.ErrorReason)
+	}
+}
+
+func TestUptoEvmScheme_Settle_NilPayloadMap_Rejected(t *testing.T) {
+	s := NewUptoEvmScheme(&mockUptoFacilitatorSigner{}, nil)
+	payload := types.PaymentPayload{
+		X402Version: 2,
+		Accepted:    types.PaymentRequirements{Network: "eip155:1"},
+		Payload:     nil,
+	}
+	_, err := s.Settle(context.Background(), payload, types.PaymentRequirements{}, nil)
+	if err == nil {
+		t.Fatal("expected error for nil payload map")
+	}
+	var serr *x402.SettleError
+	if !errors.As(err, &serr) {
+		t.Fatalf("expected SettleError, got %T: %v", err, err)
+	}
+	if serr.ErrorReason != ErrUptoInvalidPayload {
+		t.Errorf("expected %q, got %q", ErrUptoInvalidPayload, serr.ErrorReason)
+	}
+}
+
+func TestUptoEvmScheme_Settle_ExactPermit2Payload_Rejected(t *testing.T) {
+	s := NewUptoEvmScheme(&mockUptoFacilitatorSigner{}, nil)
+	payload := types.PaymentPayload{
+		X402Version: 2,
+		Accepted:    types.PaymentRequirements{Network: "eip155:8453"},
+		Payload: map[string]interface{}{
+			"signature": "0xabc",
+			"permit2Authorization": map[string]interface{}{
+				"from":    "0x111",
+				"spender": "0x222",
+				// witness present but no facilitator field
+				"witness": map[string]interface{}{
+					"to": "0x333",
+				},
+			},
+		},
+	}
+	_, err := s.Settle(context.Background(), payload, types.PaymentRequirements{}, nil)
+	if err == nil {
+		t.Fatal("expected error for non-upto payload")
+	}
+	var serr *x402.SettleError
+	if !errors.As(err, &serr) {
+		t.Fatalf("expected SettleError, got %T: %v", err, err)
+	}
+	if serr.ErrorReason != ErrUptoInvalidPayload {
+		t.Errorf("expected %q, got %q", ErrUptoInvalidPayload, serr.ErrorReason)
+	}
+}


### PR DESCRIPTION
## Summary

Adds 27 unit tests covering the scheme-level methods on both `ExactEvmScheme` and `UptoEvmScheme` facilitators — the last two major facilitator structs with zero direct scheme-method test coverage.

### ExactEvmScheme (`go/mechanisms/evm/exact/facilitator/scheme_test.go`) — 11 tests

| Test | Coverage |
|------|---------|
| `TestNewExactEvmScheme_NilConfig` | nil config → zero-value defaults |
| `TestNewExactEvmScheme_NonNilConfig` | non-nil config → values applied |
| `TestNewExactEvmScheme_ConfigIsCopied` | mutating caller's config struct doesn't affect scheme |
| `TestExactEvmScheme_Scheme` | returns `"exact"` |
| `TestExactEvmScheme_CaipFamily` | returns `"eip155:*"` |
| `TestExactEvmScheme_GetExtra_ReturnsNil` | always nil (no extra data for exact scheme) |
| `TestExactEvmScheme_GetSigners_ReturnsSignerAddresses` | forwards signer addresses |
| `TestExactEvmScheme_GetSigners_EmptyWhenNoAddresses` | empty slice when signer has none |
| `TestExactEvmScheme_Verify_MalformedPermit2Payload` | malformed Permit2 payload → `VerifyError(ErrInvalidPayload)` |
| `TestExactEvmScheme_Verify_NonPermit2RoutesToEIP3009_FailsOnBadNetwork` | non-Permit2 routes to EIP-3009 path; fails on unknown network |
| `TestExactEvmScheme_Settle_MalformedPermit2Payload` | malformed Permit2 payload → `SettleError(ErrInvalidPayload)` |
| `TestExactEvmScheme_Settle_NonPermit2RoutesToEIP3009_FailsOnBadNetwork` | non-Permit2 routes to EIP-3009 path; fails on unknown network |

### UptoEvmScheme (`go/mechanisms/evm/upto/facilitator/scheme_test.go`) — 16 tests

| Test | Coverage |
|------|---------|
| `TestNewUptoEvmScheme_NilConfig` | nil config → zero-value defaults |
| `TestNewUptoEvmScheme_NonNilConfig` | non-nil config → values applied |
| `TestNewUptoEvmScheme_ConfigIsCopied` | mutating caller's config struct doesn't affect scheme |
| `TestUptoEvmScheme_GetExtra_NoAddresses_ReturnsNil` | nil addresses → nil extra |
| `TestUptoEvmScheme_GetExtra_EmptyAddresses_ReturnsNil` | empty addresses → nil extra |
| `TestUptoEvmScheme_GetExtra_WithAddresses_ReturnsFacilitatorAddress` | single address → correct map key |
| `TestUptoEvmScheme_GetExtra_MultipleAddresses_ReturnsOneOfThem` | 100 iterations confirm random selection from pool |
| `TestUptoEvmScheme_GetSigners_ReturnsAddresses` | forwards signer addresses |
| `TestUptoEvmScheme_GetSigners_Empty` | empty when signer has no addresses |
| `TestUptoEvmScheme_Verify_EmptyPayload_Rejected` | empty payload → `VerifyError(ErrUptoInvalidPayload)` |
| `TestUptoEvmScheme_Verify_ExactPermit2Payload_Rejected` | exact Permit2 (no witness.facilitator) rejected |
| `TestUptoEvmScheme_Verify_NilPayloadMap_Rejected` | nil payload map → `VerifyError(ErrUptoInvalidPayload)` |
| `TestUptoEvmScheme_Settle_EmptyPayload_Rejected` | empty payload → `SettleError(ErrUptoInvalidPayload)` |
| `TestUptoEvmScheme_Settle_NilPayloadMap_Rejected` | nil payload map → `SettleError(ErrUptoInvalidPayload)` |
| `TestUptoEvmScheme_Settle_ExactPermit2Payload_Rejected` | exact Permit2 (no witness.facilitator) → `SettleError(ErrUptoInvalidPayload)` |

## Test approach

- All tests use a minimal `mockFacilitatorSigner` stub (zero network calls)
- Error assertions use `errors.As` with typed `*x402.VerifyError` / `*x402.SettleError`
- GPG-signed commit, changeset fragment included

## Checklist

- [x] 27 new unit tests all pass
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] GPG-signed commit
- [x] Changeset fragment added