### PR TITLE
test(ts/avm): add unit tests for AVM utility functions

### DIFF
--- a/typescript/.changeset/test-avm-utils-unit-tests.md
+++ b/typescript/.changeset/test-avm-utils-unit-tests.md
@@ -1,0 +1,15 @@
+---
+"@x402/avm": patch
+---
+
+test(ts/avm): add unit tests for AVM utility functions
+
+Add 38 unit tests for pure utility functions in `typescript/packages/mechanisms/avm/src/utils.ts` that previously had no dedicated test file:
+
+- `encodeTransaction` / `decodeTransaction`: round-trip, empty array, large array, single-byte
+- `getNetworkFromCaip2`: mainnet, testnet, unknown hash, non-algorand namespaces, empty string
+- `isAlgorandNetwork`: prefixed/non-prefixed, wrong-case, EVM/Solana inputs
+- `isTestnetNetwork`: mainnet vs testnet CAIP-2, non-algorand input
+- `convertFromTokenAmount`: whole, fractional, sub-unit, zero, bigint, trailing-zero strip, large amounts
+- `getGenesisHashFromTransaction`: mainnet/testnet round-trip, undefined/missing genesisHash throws
+- `validateGroupId`: empty array and single-element short-circuit paths

--- a/typescript/packages/mechanisms/avm/test/unit/utils.test.ts
+++ b/typescript/packages/mechanisms/avm/test/unit/utils.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect } from "vitest";
+import {
+  encodeTransaction,
+  decodeTransaction,
+  getNetworkFromCaip2,
+  isAlgorandNetwork,
+  isTestnetNetwork,
+  convertFromTokenAmount,
+  getGenesisHashFromTransaction,
+  validateGroupId,
+} from "../../src/utils";
+import {
+  ALGORAND_MAINNET_CAIP2,
+  ALGORAND_TESTNET_CAIP2,
+  ALGORAND_MAINNET_GENESIS_HASH,
+  ALGORAND_TESTNET_GENESIS_HASH,
+} from "../../src/constants";
+
+// ---------------------------------------------------------------------------
+// encodeTransaction / decodeTransaction
+// ---------------------------------------------------------------------------
+
+describe("encodeTransaction / decodeTransaction", () => {
+  it("should produce a base64 string from Uint8Array", () => {
+    const bytes = new Uint8Array([0x01, 0x02, 0x03, 0xff]);
+    const encoded = encodeTransaction(bytes);
+    expect(typeof encoded).toBe("string");
+    expect(encoded).toBe(Buffer.from(bytes).toString("base64"));
+  });
+
+  it("should round-trip arbitrary bytes", () => {
+    const original = new Uint8Array([10, 20, 30, 40, 50, 200, 255, 0]);
+    const encoded = encodeTransaction(original);
+    const decoded = decodeTransaction(encoded);
+    expect(decoded).toEqual(original);
+  });
+
+  it("should handle an empty Uint8Array", () => {
+    const bytes = new Uint8Array([]);
+    const encoded = encodeTransaction(bytes);
+    expect(encoded).toBe("");
+    const decoded = decodeTransaction(encoded);
+    expect(decoded).toEqual(bytes);
+  });
+
+  it("should handle single-byte payload", () => {
+    const bytes = new Uint8Array([0xab]);
+    const decoded = decodeTransaction(encodeTransaction(bytes));
+    expect(decoded).toEqual(bytes);
+  });
+
+  it("should handle large byte arrays", () => {
+    const large = new Uint8Array(256).map((_, i) => i % 256);
+    const decoded = decodeTransaction(encodeTransaction(large));
+    expect(decoded).toEqual(large);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getNetworkFromCaip2
+// ---------------------------------------------------------------------------
+
+describe("getNetworkFromCaip2", () => {
+  it("should return 'mainnet' for Algorand mainnet CAIP-2", () => {
+    expect(getNetworkFromCaip2(ALGORAND_MAINNET_CAIP2)).toBe("mainnet");
+  });
+
+  it("should return 'testnet' for Algorand testnet CAIP-2", () => {
+    expect(getNetworkFromCaip2(ALGORAND_TESTNET_CAIP2)).toBe("testnet");
+  });
+
+  it("should return null for an unknown algorand network", () => {
+    expect(getNetworkFromCaip2("algorand:unknownHash=")).toBeNull();
+  });
+
+  it("should return null for a non-algorand CAIP-2 (EVM)", () => {
+    expect(getNetworkFromCaip2("eip155:8453")).toBeNull();
+  });
+
+  it("should return null for a Solana CAIP-2", () => {
+    expect(getNetworkFromCaip2("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp")).toBeNull();
+  });
+
+  it("should return null for an empty string", () => {
+    expect(getNetworkFromCaip2("")).toBeNull();
+  });
+
+  it("should return null for a plain genesis hash without namespace", () => {
+    expect(getNetworkFromCaip2(ALGORAND_MAINNET_GENESIS_HASH)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isAlgorandNetwork
+// ---------------------------------------------------------------------------
+
+describe("isAlgorandNetwork", () => {
+  it("should return true for Algorand mainnet CAIP-2", () => {
+    expect(isAlgorandNetwork(ALGORAND_MAINNET_CAIP2)).toBe(true);
+  });
+
+  it("should return true for Algorand testnet CAIP-2", () => {
+    expect(isAlgorandNetwork(ALGORAND_TESTNET_CAIP2)).toBe(true);
+  });
+
+  it("should return true for any 'algorand:' prefixed string", () => {
+    expect(isAlgorandNetwork("algorand:someHash")).toBe(true);
+  });
+
+  it("should return false for EVM network", () => {
+    expect(isAlgorandNetwork("eip155:8453")).toBe(false);
+  });
+
+  it("should return false for Solana network", () => {
+    expect(isAlgorandNetwork("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp")).toBe(false);
+  });
+
+  it("should return false for empty string", () => {
+    expect(isAlgorandNetwork("")).toBe(false);
+  });
+
+  it("should return false for 'Algorand:' (wrong case)", () => {
+    expect(isAlgorandNetwork("Algorand:mainnet")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isTestnetNetwork
+// ---------------------------------------------------------------------------
+
+describe("isTestnetNetwork", () => {
+  it("should return true for Algorand testnet CAIP-2", () => {
+    expect(isTestnetNetwork(ALGORAND_TESTNET_CAIP2)).toBe(true);
+  });
+
+  it("should return false for Algorand mainnet CAIP-2", () => {
+    expect(isTestnetNetwork(ALGORAND_MAINNET_CAIP2)).toBe(false);
+  });
+
+  it("should return false for EVM network", () => {
+    expect(isTestnetNetwork("eip155:84532")).toBe(false);
+  });
+
+  it("should return false for empty string", () => {
+    expect(isTestnetNetwork("")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// convertFromTokenAmount
+// ---------------------------------------------------------------------------
+
+describe("convertFromTokenAmount", () => {
+  it("should convert whole-number atomic amount with 6 decimals", () => {
+    // 1_000_000 µUSDC = 1 USDC
+    expect(convertFromTokenAmount("1000000", 6)).toBe("1");
+  });
+
+  it("should convert fractional atomic amount", () => {
+    // 1_500_000 µUSDC = 1.5 USDC
+    expect(convertFromTokenAmount("1500000", 6)).toBe("1.5");
+  });
+
+  it("should convert sub-unit amount", () => {
+    // 100 µUSDC = 0.0001 USDC
+    expect(convertFromTokenAmount("100", 6)).toBe("0.0001");
+  });
+
+  it("should handle zero amount", () => {
+    expect(convertFromTokenAmount("0", 6)).toBe("0");
+  });
+
+  it("should handle bigint input", () => {
+    expect(convertFromTokenAmount(BigInt(2000000), 6)).toBe("2");
+  });
+
+  it("should strip trailing decimal zeros", () => {
+    // 1_100_000 µUSDC = 1.1 USDC (not 1.100000)
+    expect(convertFromTokenAmount("1100000", 6)).toBe("1.1");
+  });
+
+  it("should handle 2 decimal places", () => {
+    // 150 cents = 1.50 → "1.5"
+    expect(convertFromTokenAmount("150", 2)).toBe("1.5");
+  });
+
+  it("should handle large amounts", () => {
+    // 1_000_000_000_000 µUSDC = 1_000_000 USDC
+    expect(convertFromTokenAmount("1000000000000", 6)).toBe("1000000");
+  });
+
+  it("should handle 1 µUSDC", () => {
+    expect(convertFromTokenAmount("1", 6)).toBe("0.000001");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getGenesisHashFromTransaction
+// ---------------------------------------------------------------------------
+
+describe("getGenesisHashFromTransaction", () => {
+  it("should return base64-encoded genesis hash for a transaction with genesisHash", () => {
+    const genesisBytes = Buffer.from(ALGORAND_MAINNET_GENESIS_HASH, "base64");
+    const txn = { genesisHash: new Uint8Array(genesisBytes) };
+    const result = getGenesisHashFromTransaction(txn);
+    expect(result).toBe(ALGORAND_MAINNET_GENESIS_HASH);
+  });
+
+  it("should return base64-encoded testnet genesis hash", () => {
+    const genesisBytes = Buffer.from(ALGORAND_TESTNET_GENESIS_HASH, "base64");
+    const txn = { genesisHash: new Uint8Array(genesisBytes) };
+    const result = getGenesisHashFromTransaction(txn);
+    expect(result).toBe(ALGORAND_TESTNET_GENESIS_HASH);
+  });
+
+  it("should throw when genesisHash is undefined", () => {
+    const txn = { genesisHash: undefined };
+    expect(() => getGenesisHashFromTransaction(txn)).toThrow(
+      "Transaction does not have a genesis hash",
+    );
+  });
+
+  it("should throw when transaction is empty object", () => {
+    const txn = {};
+    expect(() => getGenesisHashFromTransaction(txn)).toThrow(
+      "Transaction does not have a genesis hash",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateGroupId (edge cases that don't require real transaction bytes)
+// ---------------------------------------------------------------------------
+
+describe("validateGroupId", () => {
+  it("should return true for empty array", () => {
+    expect(validateGroupId([])).toBe(true);
+  });
+
+  it("should return true for single-element array", () => {
+    // validateGroupId short-circuits at length <= 1
+    const fakeTxnBytes = new Uint8Array([0x01]);
+    expect(validateGroupId([fakeTxnBytes])).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `utils.test.ts` file for `typescript/packages/mechanisms/avm/src/utils.ts` — the only source file in the AVM package without a dedicated unit test file.

**38 tests** covering pure/deterministic functions that require no network connection:

| Function | Tests |
|---|---|
| `encodeTransaction` / `decodeTransaction` | round-trip, empty array, single-byte, large array (256 bytes) |
| `getNetworkFromCaip2` | mainnet, testnet, unknown hash, non-algorand (EVM/Solana), empty string, bare hash |
| `isAlgorandNetwork` | prefixed inputs, wrong-case rejection, EVM, Solana, empty string |
| `isTestnetNetwork` | mainnet vs testnet CAIP-2, non-algorand |
| `convertFromTokenAmount` | whole numbers, fractional, sub-unit, zero, bigint input, trailing-zero strip, large amounts, 1 µUSDC |
| `getGenesisHashFromTransaction` | mainnet round-trip, testnet round-trip, undefined throws, empty object throws |
| `validateGroupId` | empty array (short-circuit), single-element (short-circuit) |

## Test run

```
✓ test/unit/utils.test.ts (38 tests) 4ms
✓ test/unit/types.test.ts (14 tests) 2ms
✓ test/unit/index.test.ts (12 tests) 3ms
✓ test/unit/signer.test.ts (25 tests) 21ms

Test Files  4 passed (4)
     Tests  89 passed (89)
  Duration  462ms
```

## Checklist
- [x] Tests pass locally
- [x] Changeset fragment added (`@x402/avm` patch)
- [x] GPG-signed commit
- [x] No network calls — all tests are pure/deterministic