### PR TITLE
fix(java): correct version in README Maven dependency snippet

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -60,7 +60,7 @@ Then add the dependency to your Maven project:
 <dependency>
     <groupId>org.x402</groupId>
     <artifactId>x402</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Summary

The Java README installation example referenced `0.1.0-SNAPSHOT` but `java/pom.xml` is already at `1.0.0-SNAPSHOT`. This one-line fix aligns the snippet with the actual artifact version so new users copy the correct dependency.

### Change

```diff
- <version>0.1.0-SNAPSHOT</version>
+ <version>1.0.0-SNAPSHOT</version>
```

Fixes #2059 (reported by @Nihal4777)

> AI-assisted contribution (OpenClaw / Claude). Single-line doc fix, verified against pom.xml.