### PR TITLE
Add Solana Trading Data API to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/solana-trading-data/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/solana-trading-data/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "Solana Trading Data API",
-  "description": "Real-time Solana memecoin trading data for AI agents — trending tokens, token analysis, and momentum signals from GeckoTerminal. Pay-per-request (0.01 USDC) via x402 on Solana mainnet.",
+  "description": "Real-time Solana memecoin trading data for AI agents. Trending tokens, token analysis, momentum signals. 0.01 USDC per request via x402 on Solana mainnet.",
   "logoUrl": "/logos/solana-trading-data.png",
-  "websiteUrl": "https://overnight-enormous-calling-beliefs.trycloudflare.com",
+  "websiteUrl": "https://x402-solana-data.onrender.com",
   "category": "Services/Endpoints"
 }

--- a/typescript/site/app/ecosystem/partners-data/solana-trading-data/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/solana-trading-data/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Solana Trading Data API",
+  "description": "Real-time Solana memecoin trading data for AI agents — trending tokens, token analysis, and momentum signals from GeckoTerminal. Pay-per-request (0.01 USDC) via x402 on Solana mainnet.",
+  "logoUrl": "/logos/solana-trading-data.png",
+  "websiteUrl": "https://overnight-enormous-calling-beliefs.trycloudflare.com",
+  "category": "Services/Endpoints"
+}


### PR DESCRIPTION
## Add Solana Trading Data API

Adds a new **Services/Endpoints** entry to the x402 ecosystem.

**What it does:**
- Real-time Solana memecoin trading data for AI agents
- 3 endpoints: trending tokens, token analysis, momentum signals
- Data sourced from GeckoTerminal
- 0.01 USDC per request via x402 on Solana mainnet

**Endpoints:**
- `GET /api/trending` — Top 20 trending Solana tokens
- `GET /api/token/:mint` — Detailed analysis for a specific token
- `GET /api/momentum` — Current momentum signals and breakout detection

**Discovery:**
- `/.well-known/x402` — x402 payment discovery
- `/.well-known/agent-card.json` — A2A agent card

**Note:** Logo file not included yet — happy to add one if the team has format/size preferences.