### PR TITLE
feat(python): add on_payment_required hook to x402HTTPClient

### DIFF
--- a/docs/advanced-concepts/lifecycle-hooks.mdx
+++ b/docs/advanced-concepts/lifecycle-hooks.mdx
@@ -258,7 +258,39 @@ Register hooks for HTTP-specific payment required handling. Use cases include tr
     ```
   </Tab>
   <Tab title="Python">
-    *Coming soon.*
+    ```python
+    from x402 import x402Client
+    from x402.http import x402HTTPClient
+
+    client = x402Client()
+    http_client = x402HTTPClient(client)
+
+    def try_api_key(payment_required):
+        api_key = os.environ.get("API_KEY")
+        if api_key:
+            return {"Authorization": f"Bearer {api_key}"}
+        # Return None to fall through to payment
+
+    http_client.on_payment_required(try_api_key)
+    ```
+
+    For asynchronous applications:
+
+    ```python
+    from x402 import x402Client
+    from x402.http import x402HTTPClient
+
+    client = x402Client()
+    http_client = x402HTTPClient(client)
+
+    async def try_api_key(payment_required):
+        api_key = os.environ.get("API_KEY")
+        if api_key:
+            return {"Authorization": f"Bearer {api_key}"}
+        # Return None to fall through to payment
+
+    http_client.on_payment_required(try_api_key)
+    ```
   </Tab>
   <Tab title="Go">
     *Coming soon.*

--- a/python/x402/changelog.d/120.feature.md
+++ b/python/x402/changelog.d/120.feature.md
@@ -1,0 +1,7 @@
+Add `on_payment_required` hook to `x402HTTPClient` and `x402HTTPClientSync`.
+
+Hooks run before x402 payment processing when a 402 response is received.
+Return a `dict[str, str]` of headers to retry with those headers (e.g. an
+API key) instead of paying, or `None` to proceed with the normal payment
+flow. Mirrors the existing TypeScript `x402HTTPClient.onPaymentRequired`
+API. Method chaining is supported.

--- a/python/x402/http/x402_http_client.py
+++ b/python/x402/http/x402_http_client.py
@@ -16,11 +16,36 @@ from .x402_http_client_base import x402HTTPClientBase
 if TYPE_CHECKING:
     from ..client import x402Client, x402ClientSync
 
+# ---------------------------------------------------------------------------
+# Hook type aliases
+# ---------------------------------------------------------------------------
+
+#: Return type for on_payment_required hooks.  Return a dict of headers to
+#: retry with those headers *before* attempting payment, or ``None``/nothing
+#: to fall through to the normal payment flow.
+PaymentRequiredHookResult = dict[str, str] | None
+
+#: Async hook called when a 402 response is received.
+#: Mirrors the TypeScript ``PaymentRequiredHook`` type.
+AsyncPaymentRequiredHook = Callable[
+    [PaymentRequired | PaymentRequiredV1],
+    Any,  # Awaitable[PaymentRequiredHookResult]
+]
+
+#: Sync hook called when a 402 response is received.
+SyncPaymentRequiredHook = Callable[
+    [PaymentRequired | PaymentRequiredV1],
+    PaymentRequiredHookResult,
+]
+
 # Re-export for external use
 __all__ = [
     "x402HTTPClient",
     "x402HTTPClientSync",
     "PaymentRoundTripper",
+    "AsyncPaymentRequiredHook",
+    "SyncPaymentRequiredHook",
+    "PaymentRequiredHookResult",
 ]
 
 
@@ -43,6 +68,63 @@ class x402HTTPClient(x402HTTPClientBase):
             client: Underlying x402Client for payment logic.
         """
         self._client = client
+        self._payment_required_hooks: list[AsyncPaymentRequiredHook] = []
+
+    # =========================================================================
+    # Lifecycle Hooks
+    # =========================================================================
+
+    def on_payment_required(
+        self,
+        hook: AsyncPaymentRequiredHook,
+    ) -> x402HTTPClient:
+        """Register a hook to run when a 402 response is received.
+
+        The hook runs *before* x402 payment processing.  If the hook returns a
+        dict, the request is retried with those headers (e.g. an API key) and
+        payment is skipped.  Return ``None`` or nothing to fall through to the
+        normal payment flow.
+
+        Multiple hooks are tried in registration order; the first one that
+        returns a non-``None`` result wins.
+
+        Supports method chaining::
+
+            client.on_payment_required(try_api_key).on_payment_required(log_request)
+
+        Args:
+            hook: Async callable that receives the
+                :class:`~x402.schemas.PaymentRequired` object and returns
+                either a ``dict[str, str]`` of headers or ``None``.
+
+        Returns:
+            ``self`` for method chaining.
+        """
+        self._payment_required_hooks.append(hook)
+        return self
+
+    async def handle_payment_required(
+        self,
+        payment_required: PaymentRequired | PaymentRequiredV1,
+    ) -> dict[str, str] | None:
+        """Run registered hooks for a 402 response.
+
+        Iterates through hooks in order and returns the headers from the first
+        hook that returns a non-``None`` result.  Returns ``None`` if no hook
+        provides headers, which signals the caller to proceed with payment.
+
+        Args:
+            payment_required: Parsed payment-required object from the server.
+
+        Returns:
+            Headers to use for a pre-payment retry, or ``None`` to proceed
+            with the normal x402 payment flow.
+        """
+        for hook in self._payment_required_hooks:
+            result = await hook(payment_required)
+            if result is not None:
+                return result
+        return None
 
     # =========================================================================
     # Payment Creation (async, delegates to x402Client)
@@ -72,10 +154,17 @@ class x402HTTPClient(x402HTTPClientBase):
         self,
         headers: dict[str, str],
         body: bytes | None,
-    ) -> tuple[dict[str, str], PaymentPayload | PaymentPayloadV1]:
+    ) -> tuple[dict[str, str], PaymentPayload | PaymentPayloadV1 | None]:
         """Handle a 402 response and create payment headers.
 
-        Convenience method that:
+        First runs any registered ``on_payment_required`` hooks.  If a hook
+        returns headers, those headers are returned *without* creating a
+        payment payload (the second element of the tuple will be ``None``).
+        This allows callers to retry with, e.g., an API key before paying.
+
+        If no hook provides headers the method falls through to the normal
+        x402 payment flow:
+
         1. Detects protocol version
         2. Parses PaymentRequired
         3. Creates PaymentPayload
@@ -86,16 +175,20 @@ class x402HTTPClient(x402HTTPClientBase):
             body: Response body bytes.
 
         Returns:
-            Tuple of (headers_to_add, payment_payload).
+            Tuple of (headers_to_add, payment_payload_or_none).  The second
+            element is ``None`` when a hook short-circuited the payment flow.
         """
-        # Get payment required
         get_header, body_data = self._handle_402_common(headers, body)
         payment_required = self.get_payment_required_response(get_header, body_data)
-        # Create payment
-        payment_payload = await self.create_payment_payload(payment_required)
-        # Encode headers
-        payment_headers = self.encode_payment_signature_header(payment_payload)
 
+        # Run on_payment_required hooks first
+        hook_headers = await self.handle_payment_required(payment_required)
+        if hook_headers is not None:
+            return hook_headers, None
+
+        # Normal payment flow
+        payment_payload = await self.create_payment_payload(payment_required)
+        payment_headers = self.encode_payment_signature_header(payment_payload)
         return payment_headers, payment_payload
 
 
@@ -131,6 +224,63 @@ class x402HTTPClientSync(x402HTTPClientBase):
             )
 
         self._client = client
+        self._payment_required_hooks: list[SyncPaymentRequiredHook] = []
+
+    # =========================================================================
+    # Lifecycle Hooks
+    # =========================================================================
+
+    def on_payment_required(
+        self,
+        hook: SyncPaymentRequiredHook,
+    ) -> x402HTTPClientSync:
+        """Register a hook to run when a 402 response is received.
+
+        The hook runs *before* x402 payment processing.  If the hook returns a
+        dict, the request is retried with those headers (e.g. an API key) and
+        payment is skipped.  Return ``None`` or nothing to fall through to the
+        normal payment flow.
+
+        Multiple hooks are tried in registration order; the first one that
+        returns a non-``None`` result wins.
+
+        Supports method chaining::
+
+            client.on_payment_required(try_api_key).on_payment_required(log_request)
+
+        Args:
+            hook: Sync callable that receives the
+                :class:`~x402.schemas.PaymentRequired` object and returns
+                either a ``dict[str, str]`` of headers or ``None``.
+
+        Returns:
+            ``self`` for method chaining.
+        """
+        self._payment_required_hooks.append(hook)
+        return self
+
+    def handle_payment_required(
+        self,
+        payment_required: PaymentRequired | PaymentRequiredV1,
+    ) -> dict[str, str] | None:
+        """Run registered hooks for a 402 response.
+
+        Iterates through hooks in order and returns the headers from the first
+        hook that returns a non-``None`` result.  Returns ``None`` if no hook
+        provides headers, which signals the caller to proceed with payment.
+
+        Args:
+            payment_required: Parsed payment-required object from the server.
+
+        Returns:
+            Headers to use for a pre-payment retry, or ``None`` to proceed
+            with the normal x402 payment flow.
+        """
+        for hook in self._payment_required_hooks:
+            result = hook(payment_required)
+            if result is not None:
+                return result
+        return None
 
     def create_payment_payload(
         self,
@@ -152,10 +302,17 @@ class x402HTTPClientSync(x402HTTPClientBase):
         self,
         headers: dict[str, str],
         body: bytes | None,
-    ) -> tuple[dict[str, str], PaymentPayload | PaymentPayloadV1]:
+    ) -> tuple[dict[str, str], PaymentPayload | PaymentPayloadV1 | None]:
         """Handle a 402 response and create payment headers.
 
-        Convenience method that:
+        First runs any registered ``on_payment_required`` hooks.  If a hook
+        returns headers, those headers are returned *without* creating a
+        payment payload (the second element of the tuple will be ``None``).
+        This allows callers to retry with, e.g., an API key before paying.
+
+        If no hook provides headers the method falls through to the normal
+        x402 payment flow:
+
         1. Detects protocol version
         2. Parses PaymentRequired
         3. Creates PaymentPayload
@@ -166,17 +323,20 @@ class x402HTTPClientSync(x402HTTPClientBase):
             body: Response body bytes.
 
         Returns:
-            Tuple of (headers_to_add, payment_payload).
+            Tuple of (headers_to_add, payment_payload_or_none).  The second
+            element is ``None`` when a hook short-circuited the payment flow.
         """
-        # Get payment required
         get_header, body_data = self._handle_402_common(headers, body)
         payment_required = self.get_payment_required_response(get_header, body_data)
-        # Create payment
+
+        # Run on_payment_required hooks first
+        hook_headers = self.handle_payment_required(payment_required)
+        if hook_headers is not None:
+            return hook_headers, None
+
+        # Normal payment flow
         payment_payload = self.create_payment_payload(payment_required)
-
-        # Encode headers
         payment_headers = self.encode_payment_signature_header(payment_payload)
-
         return payment_headers, payment_payload
 
 

--- a/python/x402/tests/unit/http/test_x402_http_client.py
+++ b/python/x402/tests/unit/http/test_x402_http_client.py
@@ -442,3 +442,365 @@ class TestPaymentRoundTripper:
                 body=None,
                 retry_func=lambda h: "should not happen",
             )
+
+
+# =============================================================================
+# on_payment_required Hook Tests — Async (x402HTTPClient)
+# =============================================================================
+
+
+class TestX402HTTPClientPaymentRequiredHooks:
+    """Tests for on_payment_required lifecycle hooks (async)."""
+
+    @pytest.mark.asyncio
+    async def test_no_hooks_proceeds_to_payment(self):
+        """With no hooks registered, handle_payment_required returns None."""
+        mock_client = MockX402Client()
+        http_client = x402HTTPClient(mock_client)
+
+        payment_required = PaymentRequired(
+            x402_version=2,
+            accepts=[make_payment_requirements()],
+        )
+
+        result = await http_client.handle_payment_required(payment_required)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_hook_returning_headers_short_circuits_payment(self):
+        """Hook that returns headers should prevent payment creation."""
+        mock_client = MockX402Client()
+        http_client = x402HTTPClient(mock_client)
+
+        api_key_headers = {"Authorization": "Bearer my-api-key"}
+
+        async def try_api_key(pr):
+            return api_key_headers
+
+        http_client.on_payment_required(try_api_key)
+
+        payment_required = PaymentRequired(
+            x402_version=2,
+            accepts=[make_payment_requirements()],
+        )
+
+        result = await http_client.handle_payment_required(payment_required)
+
+        assert result == api_key_headers
+        assert len(mock_client.create_payment_calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_hook_returning_none_falls_through_to_payment(self):
+        """Hook that returns None should fall through to normal payment flow."""
+        mock_client = MockX402Client()
+        http_client = x402HTTPClient(mock_client)
+
+        async def no_op_hook(pr):
+            return None
+
+        http_client.on_payment_required(no_op_hook)
+
+        payment_required = PaymentRequired(
+            x402_version=2,
+            accepts=[make_payment_requirements()],
+        )
+
+        result = await http_client.handle_payment_required(payment_required)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_first_hook_with_headers_wins(self):
+        """First hook to return headers wins; subsequent hooks are not called."""
+        mock_client = MockX402Client()
+        http_client = x402HTTPClient(mock_client)
+
+        first_headers = {"X-First": "1"}
+        second_called = []
+
+        async def first_hook(pr):
+            return first_headers
+
+        async def second_hook(pr):
+            second_called.append(True)
+            return {"X-Second": "2"}
+
+        http_client.on_payment_required(first_hook)
+        http_client.on_payment_required(second_hook)
+
+        payment_required = PaymentRequired(
+            x402_version=2,
+            accepts=[make_payment_requirements()],
+        )
+
+        result = await http_client.handle_payment_required(payment_required)
+
+        assert result == first_headers
+        assert len(second_called) == 0
+
+    @pytest.mark.asyncio
+    async def test_second_hook_runs_when_first_returns_none(self):
+        """Second hook runs when first returns None."""
+        mock_client = MockX402Client()
+        http_client = x402HTTPClient(mock_client)
+
+        second_headers = {"X-Second": "2"}
+
+        async def first_hook(pr):
+            return None
+
+        async def second_hook(pr):
+            return second_headers
+
+        http_client.on_payment_required(first_hook)
+        http_client.on_payment_required(second_hook)
+
+        payment_required = PaymentRequired(
+            x402_version=2,
+            accepts=[make_payment_requirements()],
+        )
+
+        result = await http_client.handle_payment_required(payment_required)
+
+        assert result == second_headers
+
+    @pytest.mark.asyncio
+    async def test_on_payment_required_returns_self_for_chaining(self):
+        """on_payment_required should return self to support method chaining."""
+        mock_client = MockX402Client()
+        http_client = x402HTTPClient(mock_client)
+
+        async def hook(pr):
+            return None
+
+        returned = http_client.on_payment_required(hook)
+
+        assert returned is http_client
+
+    @pytest.mark.asyncio
+    async def test_handle_402_response_uses_hook_headers(self):
+        """handle_402_response should use hook headers and skip payment when hook fires."""
+        mock_client = MockX402Client()
+        http_client = x402HTTPClient(mock_client)
+
+        api_key_headers = {"Authorization": "Bearer test-key"}
+
+        async def try_api_key(pr):
+            return api_key_headers
+
+        http_client.on_payment_required(try_api_key)
+
+        payment_required = PaymentRequired(
+            x402_version=2,
+            accepts=[make_payment_requirements()],
+        )
+        encoded = encode_payment_required_header(payment_required)
+        headers = {PAYMENT_REQUIRED_HEADER: encoded}
+
+        returned_headers, payload = await http_client.handle_402_response(headers, None)
+
+        assert returned_headers == api_key_headers
+        assert payload is None
+        assert len(mock_client.create_payment_calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_handle_402_response_proceeds_to_payment_when_no_hook_fires(self):
+        """handle_402_response falls through to payment when hooks return None."""
+        mock_client = MockX402Client()
+        http_client = x402HTTPClient(mock_client)
+
+        async def no_op_hook(pr):
+            return None
+
+        http_client.on_payment_required(no_op_hook)
+
+        payment_required = PaymentRequired(
+            x402_version=2,
+            accepts=[make_payment_requirements()],
+        )
+        encoded = encode_payment_required_header(payment_required)
+        headers = {PAYMENT_REQUIRED_HEADER: encoded}
+
+        returned_headers, payload = await http_client.handle_402_response(headers, None)
+
+        assert PAYMENT_SIGNATURE_HEADER in returned_headers
+        assert payload is not None
+        assert len(mock_client.create_payment_calls) == 1
+
+
+# =============================================================================
+# on_payment_required Hook Tests — Sync (x402HTTPClientSync)
+# =============================================================================
+
+
+class TestX402HTTPClientSyncPaymentRequiredHooks:
+    """Tests for on_payment_required lifecycle hooks (sync)."""
+
+    def test_no_hooks_proceeds_to_payment(self):
+        """With no hooks registered, handle_payment_required returns None."""
+        mock_client = MockX402ClientSync()
+        http_client = x402HTTPClientSync(mock_client)
+
+        payment_required = PaymentRequired(
+            x402_version=2,
+            accepts=[make_payment_requirements()],
+        )
+
+        result = http_client.handle_payment_required(payment_required)
+
+        assert result is None
+
+    def test_hook_returning_headers_short_circuits_payment(self):
+        """Hook that returns headers should prevent payment creation."""
+        mock_client = MockX402ClientSync()
+        http_client = x402HTTPClientSync(mock_client)
+
+        api_key_headers = {"Authorization": "Bearer my-api-key"}
+
+        def try_api_key(pr):
+            return api_key_headers
+
+        http_client.on_payment_required(try_api_key)
+
+        payment_required = PaymentRequired(
+            x402_version=2,
+            accepts=[make_payment_requirements()],
+        )
+
+        result = http_client.handle_payment_required(payment_required)
+
+        assert result == api_key_headers
+        assert len(mock_client.create_payment_calls) == 0
+
+    def test_hook_returning_none_falls_through(self):
+        """Hook that returns None should fall through to normal payment flow."""
+        mock_client = MockX402ClientSync()
+        http_client = x402HTTPClientSync(mock_client)
+
+        def no_op_hook(pr):
+            return None
+
+        http_client.on_payment_required(no_op_hook)
+
+        payment_required = PaymentRequired(
+            x402_version=2,
+            accepts=[make_payment_requirements()],
+        )
+
+        result = http_client.handle_payment_required(payment_required)
+
+        assert result is None
+
+    def test_first_hook_with_headers_wins(self):
+        """First hook to return headers wins; subsequent hooks are not called."""
+        mock_client = MockX402ClientSync()
+        http_client = x402HTTPClientSync(mock_client)
+
+        first_headers = {"X-First": "1"}
+        second_called = []
+
+        def first_hook(pr):
+            return first_headers
+
+        def second_hook(pr):
+            second_called.append(True)
+            return {"X-Second": "2"}
+
+        http_client.on_payment_required(first_hook)
+        http_client.on_payment_required(second_hook)
+
+        payment_required = PaymentRequired(
+            x402_version=2,
+            accepts=[make_payment_requirements()],
+        )
+
+        result = http_client.handle_payment_required(payment_required)
+
+        assert result == first_headers
+        assert len(second_called) == 0
+
+    def test_second_hook_runs_when_first_returns_none(self):
+        """Second hook runs when first returns None."""
+        mock_client = MockX402ClientSync()
+        http_client = x402HTTPClientSync(mock_client)
+
+        second_headers = {"X-Second": "2"}
+
+        def first_hook(pr):
+            return None
+
+        def second_hook(pr):
+            return second_headers
+
+        http_client.on_payment_required(first_hook)
+        http_client.on_payment_required(second_hook)
+
+        payment_required = PaymentRequired(
+            x402_version=2,
+            accepts=[make_payment_requirements()],
+        )
+
+        result = http_client.handle_payment_required(payment_required)
+
+        assert result == second_headers
+
+    def test_on_payment_required_returns_self_for_chaining(self):
+        """on_payment_required should return self to support method chaining."""
+        mock_client = MockX402ClientSync()
+        http_client = x402HTTPClientSync(mock_client)
+
+        def hook(pr):
+            return None
+
+        returned = http_client.on_payment_required(hook)
+
+        assert returned is http_client
+
+    def test_handle_402_response_uses_hook_headers(self):
+        """handle_402_response should use hook headers and skip payment when hook fires."""
+        mock_client = MockX402ClientSync()
+        http_client = x402HTTPClientSync(mock_client)
+
+        api_key_headers = {"Authorization": "Bearer test-key"}
+
+        def try_api_key(pr):
+            return api_key_headers
+
+        http_client.on_payment_required(try_api_key)
+
+        payment_required = PaymentRequired(
+            x402_version=2,
+            accepts=[make_payment_requirements()],
+        )
+        encoded = encode_payment_required_header(payment_required)
+        headers = {PAYMENT_REQUIRED_HEADER: encoded}
+
+        returned_headers, payload = http_client.handle_402_response(headers, None)
+
+        assert returned_headers == api_key_headers
+        assert payload is None
+        assert len(mock_client.create_payment_calls) == 0
+
+    def test_handle_402_response_proceeds_to_payment_when_no_hook_fires(self):
+        """handle_402_response falls through to payment when hooks return None."""
+        mock_client = MockX402ClientSync()
+        http_client = x402HTTPClientSync(mock_client)
+
+        def no_op_hook(pr):
+            return None
+
+        http_client.on_payment_required(no_op_hook)
+
+        payment_required = PaymentRequired(
+            x402_version=2,
+            accepts=[make_payment_requirements()],
+        )
+        encoded = encode_payment_required_header(payment_required)
+        headers = {PAYMENT_REQUIRED_HEADER: encoded}
+
+        returned_headers, payload = http_client.handle_402_response(headers, None)
+
+        assert PAYMENT_SIGNATURE_HEADER in returned_headers
+        assert payload is not None
+        assert len(mock_client.create_payment_calls) == 1


### PR DESCRIPTION
## Summary

Implements `on_payment_required` lifecycle hooks for Python's `x402HTTPClient` and `x402HTTPClientSync`, matching the existing TypeScript `x402HTTPClient.onPaymentRequired` API that was previously missing from Python (marked *"Coming soon"* in the docs).

## What Changed

**`python/x402/http/x402_http_client.py`**
- Added `on_payment_required(hook)` and `handle_payment_required(payment_required)` to both `x402HTTPClient` (async) and `x402HTTPClientSync`
- Hook receives the parsed `PaymentRequired` object; returning `dict[str, str]` retries with those headers (skipping payment), returning `None` falls through to normal payment flow
- First hook to return non-`None` wins; subsequent hooks are skipped
- Method chaining supported on `on_payment_required()`
- `handle_402_response` now runs hooks before creating a payment payload; returns `(headers, None)` when a hook short-circuits

**`python/x402/tests/unit/http/test_x402_http_client.py`**
- 16 new unit tests covering: no-hook fall-through, hook short-circuit, hook ordering (first wins), second-hook fallback, chaining, and integration with `handle_402_response`

**`docs/advanced-concepts/lifecycle-hooks.mdx`**
- Replaced *Coming soon* placeholder with working Python sync and async examples

**`python/x402/changelog.d/120.feature.md`**
- Towncrier changelog fragment

## Testing

```
827 passed, 1 warning in 1.10s
```

All existing tests continue to pass. 16 new tests added.

## Notes

AI-assisted contribution (0xAxiom / OpenClaw). Output reviewed for correctness against the TypeScript reference implementation and existing Python patterns.