### PR TITLE
Add x402watch to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/x402watch/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402watch/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402watch",
+  "description": "Wash-filtered intelligence for x402. 36k+ services indexed across Base, Solana, Polygon, and Arbitrum, classified into 33 categories with 8-label buyer detection (organic_user, suspected_wash, self_test, developer, ai_agent, analytics_bot, exchange_user, verifier). Free dashboard, daily CC0 datasets, x402-native paid endpoints, and an MCP server.",
+  "logoUrl": "/logos/x402watch.svg",
+  "websiteUrl": "https://x402.printmoneylab.com",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/x402watch.svg
+++ b/typescript/site/public/logos/x402watch.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="x402watch">
+  <rect width="512" height="512" rx="64" fill="#07080a"/>
+  <g font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif" text-anchor="middle">
+    <text x="256" y="256" font-size="156" font-weight="700" fill="#e7e9ee" letter-spacing="-6">x402</text>
+    <text x="256" y="338" font-size="60" font-weight="500" fill="#3ee0a3" letter-spacing="6">watch</text>
+  </g>
+  <g transform="translate(256 410)">
+    <circle cx="-40" cy="0" r="10" fill="#3ee0a3"/>
+    <circle cx="0"   cy="0" r="10" fill="#fbbf24"/>
+    <circle cx="40"  cy="0" r="10" fill="#f43f5e"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

Adds x402watch to the ecosystem partners directory.

x402watch is a wash-filtered intelligence layer for the x402 ecosystem — read-only dashboard, daily CC0 datasets, x402-native paid endpoints, and a remote MCP server.

## Differentiation

- **Wash filter**: 8-label buyer detection (organic_user, suspected_wash, self_test, developer, ai_agent, analytics_bot, exchange_user, verifier) with daily live recomputation
- **Open data**: All datasets daily commit to CC0-licensed GitHub repo (printmoneylab/x402watch-data)
- **AI native**: Remote MCP server (streamable-http) at https://api.x402.printmoneylab.com/mcp + 5 paid endpoints settling in USDC
- **Coverage**: 36k+ services indexed across Base, Solana, Polygon, and Arbitrum, AI-classified into 33 categories

## MCP server

x402watch also exposes a Model Context Protocol server over **streamable HTTP**:

- **Endpoint:** `https://api.x402.printmoneylab.com/mcp`
- **Transport:** streamable-http (not SSE, not stdio)
- **Handshake:** the endpoint requires `Accept: application/json, text/event-stream`. A plain `GET /mcp` without that `Accept` returns `406 Not Acceptable` — this is expected; it is not an outage. Initialise with a standard MCP `initialize` request over a POST carrying both Accept types.
- **Tools:** 5 read-only wrappers over the public API (`x402_get_categories`, `x402_get_service`, `x402_check_wash`, `x402_search_services`, `x402_get_trends`) — all free.

Example probe that a listing crawler can use without a false negative:

```​bash
curl -sS https://api.x402.printmoneylab.com/mcp \
  -H "Accept: application/json, text/event-stream" \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"0"}}}'
```

## Live URLs

- Site: https://x402.printmoneylab.com
- API: https://api.x402.printmoneylab.com
- MCP: https://api.x402.printmoneylab.com/mcp
- GitHub: https://github.com/printmoneylab/x402watch
- Open data: https://github.com/printmoneylab/x402watch-data
- License: Apache 2.0 (code), CC0 (data)

## Settlement Wallet

`0xcF9223eCe895258dEa8D288AEBcf846Ab8E342fB` — already running successful settlements on Base mainnet via the CDP facilitator. The same wallet has 4 endpoints from a sister project (kr-crypto-intelligence) already indexed in CDP Bazaar discovery.

## Submitting

This PR is submitted on behalf of the `printmoneylab` organization (https://github.com/printmoneylab). @bakyang2 is the maintainer and primary contributor.

## Category

Listed under **Services/Endpoints**. Happy to move to **Infrastructure & Tooling** or **Web3 Application & Infrastructure** if maintainers prefer.

## Files

- `typescript/site/app/ecosystem/partners-data/x402watch/metadata.json` — partner metadata
- `typescript/site/public/logos/x402watch.svg` — 512x512 SVG logo (no external dependencies)