### PR TITLE
Add x402-saas to ecosystem (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/x402-saas/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-saas/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402-saas",
+  "description": "Hosted x402 facilitator + onboarding proxy. Sign in with a wallet, point at any backend URL, get a paywalled URL in 60 seconds — no SDK to integrate. MIT-licensed core (x402-kit) anyone can self-host. 1% of routed USDC volume to operate the SaaS, 99% straight to the developer.",
+  "logoUrl": "/logos/x402-saas.svg",
+  "websiteUrl": "https://x402-saas.surge.sh",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/x402-saas.svg
+++ b/typescript/site/public/logos/x402-saas.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" fill="none">
+  <rect width="200" height="200" rx="32" fill="#0B0F19"/>
+  <path d="M48 70 L88 70 L88 130 L72 130 L72 86 L48 86 Z" fill="#7CFFB2"/>
+  <path d="M112 70 L152 70 L152 86 L128 86 L128 92 L152 92 L152 130 L112 130 L112 114 L136 114 L136 108 L112 108 Z" fill="#7CFFB2"/>
+  <text x="100" y="170" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="20" font-weight="600" fill="#7CFFB2">x402-saas</text>
+</svg>


### PR DESCRIPTION
## What

Adds `x402-saas` to the ecosystem partners list under Services/Endpoints.

x402-saas is a hosted productization of the protocol — sign in with a wallet, point at any backend URL, get a paywalled proxy URL in ~60s. No SDK to integrate. MIT-licensed core ([x402-kit](https://github.com/kite-builds-erik/x402-kit)) is the open-source toolkit anyone can self-host instead. The SaaS takes 1% of routed USDC volume; the dev keeps 99%.

## Live evidence

- Landing: https://x402-saas.surge.sh
- Backend health: https://x402-saas.onrender.com/__x402/health → `{"ok":true,...}`
- SIWE challenge: `POST https://x402-saas.onrender.com/api/v1/auth/challenge`
- Source: https://github.com/kite-builds-erik/x402-saas (38/38 tests, MIT)
- One-click clone: [`render.yaml`](https://github.com/kite-builds-erik/x402-saas/blob/main/render.yaml)

## Files

- `typescript/site/app/ecosystem/partners-data/x402-saas/metadata.json`
- `typescript/site/public/logos/x402-saas.svg` (simple monogram)

## AI disclosure

Per CONTRIBUTING.md: this PR was built with AI-assisted development. Content (description, logo, JSON) reviewed by the operator before submission.