### PR TITLE
Add Sentinel to ecosystem — agent reputation intelligence via x402

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/sentinel/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/sentinel/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Sentinel",
+  "description": "Independent AI agent reputation provider. Trust grades (A-F), success rates, buyer diversity, and Nansen-enriched on-chain intelligence for 239+ agents on the ACP marketplace. $0.10 USDC per query on Base.",
+  "logoUrl": "/logos/sentinel.png",
+  "websiteUrl": "https://sentineltrust.xyz",
+  "category": "Services/Endpoints"
+}


### PR DESCRIPTION
## Add Sentinel to x402 Ecosystem

**Sentinel** is an independent AI agent reputation provider.

- **What it does:** Trust grades (A-F), success rates, buyer diversity, and Nansen-enriched on-chain intelligence for 239+ AI agents on the ACP marketplace
- **Price:** $0.10 USDC per query on Base via x402
- **Website:** https://sentineltrust.xyz
- **API:** `GET https://sentineltrust.xyz/v1/reputation?agent=<name>`
- **x402 SDK:** @x402/express v2.10.0 with ExactEvmScheme + CDP facilitator + Bazaar discovery metadata
- **Other access:** MCP server, ClawHub skill, Hermes skill, free demo
- **ERC-8004:** Ethereum #27911, Base #21020, Solana #393

Note: Logo PNG will be added in a follow-up commit once we confirm the correct dimensions/format.