### PR TITLE
chore(go/http): remove unused extractPayment/createHTTPResponse

### DIFF
--- a/go/http/server.go
+++ b/go/http/server.go
@@ -806,25 +806,6 @@ func (s *x402HTTPResourceServer) extractPaymentV2(adapter HTTPAdapter) (*types.P
 	return payload, nil
 }
 
-// extractPayment extracts payment from headers (legacy method, now calls extractPaymentV2)
-//
-//nolint:unused // Legacy method kept for API compatibility
-func (s *x402HTTPResourceServer) extractPayment(adapter HTTPAdapter) *x402.PaymentPayload {
-	payload, err := s.extractPaymentV2(adapter)
-	if err != nil || payload == nil {
-		return nil
-	}
-
-	// Convert V2 to generic PaymentPayload for compatibility
-	return &x402.PaymentPayload{
-		X402Version: payload.X402Version,
-		Payload:     payload.Payload,
-		Accepted:    x402.PaymentRequirements{}, // TODO: Convert
-		Resource:    nil,
-		Extensions:  payload.Extensions,
-	}
-}
-
 // decodeBase64Header decodes a base64 header to JSON bytes
 func decodeBase64Header(header string) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(header)
@@ -881,20 +862,6 @@ func (s *x402HTTPResourceServer) createHTTPResponseV2(paymentRequired types.Paym
 		},
 		Body: body,
 	}, nil
-}
-
-// createHTTPResponse creates response instructions (legacy method)
-//
-//nolint:unused // Legacy method kept for API compatibility
-func (s *x402HTTPResourceServer) createHTTPResponse(paymentRequired x402.PaymentRequired, isWebBrowser bool, paywallConfig *PaywallConfig, customHTML string) (*HTTPResponseInstructions, error) {
-	// Convert to V2 and call V2 method
-	v2Required := types.PaymentRequired{
-		X402Version: 2,
-		Error:       paymentRequired.Error,
-		Resource:    nil, // TODO: convert
-		Extensions:  paymentRequired.Extensions,
-	}
-	return s.createHTTPResponseV2(v2Required, isWebBrowser, paywallConfig, customHTML, nil)
 }
 
 // createSettlementHeaders creates settlement response headers


### PR DESCRIPTION
## Description

`go/http/server.go` carries two unexported methods on `*x402HTTPResourceServer` flagged with `//nolint:unused` and comments claiming they are "kept for API compatibility":

- `extractPayment(adapter HTTPAdapter) *x402.PaymentPayload`
- `createHTTPResponse(paymentRequired x402.PaymentRequired, ...) (*HTTPResponseInstructions, error)`

Both claims are wrong, and the methods are pure dead duplication of the V2 equivalents:

1. **Not part of the public API.** Both names start with a lowercase letter; they are unexported. Nothing outside the package can call them.

2. **The "V1 to V2 conversion" inside them is illusory.** `go/types.go:65-74` declares the bare names `x402.PaymentPayload`, `x402.PaymentRequired`, `x402.PaymentRequirements`, and `x402.ResourceInfo` as Go type aliases of the V2 types:

   ```go
   type (
       PaymentRequirements = types.PaymentRequirements
       PaymentPayload      = types.PaymentPayload
       PaymentRequired     = types.PaymentRequired
       ResourceInfo        = types.ResourceInfo
   )
   ```

   So `extractPayment` takes a V2 struct, re-wraps it field-by-field into the identical struct, and zeros `Accepted` with `// TODO: Convert`. `createHTTPResponse` does the same shape of work and zeros `Resource` with `// TODO: convert`. There is no V1 type involved on either side of the "conversion." The TODOs document field-dropping that is unfixable as written (you would either have to re-introduce V1 types that nothing in this code path uses, or write a no-op identity transform, which is what the methods already are once you remove the field-zeroing).

3. **Zero callers in Go.** Repo-wide grep finds no `.extractPayment(` or `.createHTTPResponse(` call sites in any Go file, and no string-literal references that might be reached via reflection.

This PR deletes both methods and their `//nolint:unused` suppressions. The V2 methods (`extractPaymentV2`, `createHTTPResponseV2`) remain and are unaffected.

**Disclosure**: this change was prepared with assistance from Claude Code. The deletion was independently verified by grep, by reading the type-alias declarations, and by running the full `go test -cover ./...` and golangci-lint v2 suite locally before commit.

## Tests

Local verification with Go 1.23.4 on Windows:

- `go build ./...`: exit 0
- `go vet ./...`: exit 0
- `go test -cover ./...`: exit 0. All 25 packages report `ok`. The `go/http` package coverage is 77.6%.
- `golangci-lint run --config .golangci.yml ./http/...` (v2.12.2): 0 issues
- Caller search: 0 matches for `.extractPayment(`, `.createHTTPResponse(`, `"extractPayment"`, `"createHTTPResponse"` anywhere in `go/`
- No `//go:generate` directives, no `reflect.MethodByName` usage, no build tags referencing the deleted symbols

`-race` was not exercised locally (no CGO toolchain on this host); CI's race build will catch any (unlikely) race introduced by a pure deletion.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (skipped: deletion is purely internal/unexported, no Go API change)
