### PR TITLE
Add mcp-service-marketplace example — x402-gated MCP workers with Baz…

### DIFF
--- a/examples/python/clients/mcp-service-marketplace/.env-local
+++ b/examples/python/clients/mcp-service-marketplace/.env-local
@@ -1,0 +1,16 @@
+# --- Option A: CDP managed wallet (recommended) ---
+# Get keys at https://portal.cdp.coinbase.com
+CDP_API_KEY_NAME=your-cdp-api-key-name
+CDP_API_KEY_PRIVATE_KEY=your-cdp-private-key
+
+# --- Option B: raw EVM private key ---
+# EVM_PRIVATE_KEY=0xYourPrivateKey
+
+# Target server (default: live LogicNodes)
+LOGICNODES_URL=https://logicnodes.io
+
+# Facilitator — CDP for mainnet, x402.org for testnet only
+FACILITATOR_URL=https://api.cdp.coinbase.com/platform/v2/x402
+
+# Network
+EVM_NETWORK=eip155:8453

--- a/examples/python/clients/mcp-service-marketplace/README.md
+++ b/examples/python/clients/mcp-service-marketplace/README.md
@@ -1,0 +1,54 @@
+# x402 MCP Service Marketplace — Agent Client
+
+Companion client to `examples/python/servers/mcp-service-marketplace`.
+
+Demonstrates an AI agent that:
+1. Discovers available services via the x402 Bazaar (`/discovery/resources`)
+2. Pays per-call in USDC on Base — no API key, no signup
+3. Calls all 3 LogicNodes workers and prints verified results
+
+## Quick Start
+
+```bash
+cp .env-local .env
+# Fill in CDP credentials or EVM_PRIVATE_KEY
+
+uv sync
+
+# Against live LogicNodes (Base mainnet — real USDC)
+uv run client.py
+
+# Against local server (Base Sepolia testnet — free)
+uv run client.py --testnet
+```
+
+## What the Agent Does
+
+```
+[Bazaar] Discovered 242 services at https://logicnodes.io
+  - json_sanitizer    | 0.05 USDC | basic
+  - pii_scrubber      | 0.05 USDC | basic
+  - rug_pull_detector | 0.50 USDC | premium
+  ...
+
+[Agent] Calling JSON Sanitizer ($0.05 USDC)...
+[✓] JSON Sanitizer — status: success
+    valid: True
+    clean_json: {"name": "Alice", "age": 30, "city": "Phoenix"}
+    trust_hash: 8f038c820f3d...
+
+[Agent] Calling PII Scrubber ($0.05 USDC)...
+[✓] PII Scrubber — status: success
+    scrubbed: Please contact [NAME] at [EMAIL] or call [PHONE]
+    redacted_count: 3
+
+[Agent] Calling Rug Pull Detector ($0.50 USDC)...
+[✓] Rug Pull Detector — status: success
+    risk_score: 0.0
+    risk_label: LOW
+    signals: ["no_static_signals_detected"]
+```
+
+## Live Server
+
+The client points to `https://logicnodes.io` by default. Set `LOGICNODES_URL=http://localhost:8089` to run against the local example server.

--- a/examples/python/clients/mcp-service-marketplace/client.py
+++ b/examples/python/clients/mcp-service-marketplace/client.py
@@ -1,0 +1,148 @@
+"""
+x402 MCP Service Marketplace — Agent Client Example
+
+Demonstrates an AI agent autonomously:
+1. Discovering available services via the x402 Bazaar
+2. Paying per-call in USDC on Base (no API key, no signup)
+3. Calling all 3 LogicNodes workers and printing results
+
+Prerequisites:
+  - CDP API key with an EVM wallet funded with USDC on Base
+  - Or: set EVM_PRIVATE_KEY for a self-managed wallet
+
+Usage:
+  uv run client.py
+  uv run client.py --testnet     # uses Base Sepolia + x402.org facilitator
+"""
+
+import os
+import asyncio
+import argparse
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+BASE_URL        = os.getenv("LOGICNODES_URL", "https://logicnodes.io")
+FACILITATOR_URL = os.getenv("FACILITATOR_URL", "https://api.cdp.coinbase.com/platform/v2/x402")
+EVM_NETWORK     = os.getenv("EVM_NETWORK", "eip155:8453")
+
+
+async def discover_services(session) -> list[dict]:
+    """Query the Bazaar merchant endpoint to find all available services."""
+    url = f"{BASE_URL}/discovery/resources?limit=10"
+    async with session.get(url) as resp:
+        data = await resp.json()
+    items = data.get("items", [])
+    print(f"[Bazaar] Discovered {data.get('total', len(items))} services at {BASE_URL}")
+    for svc in items[:5]:
+        print(f"  - {svc['name']} | {svc.get('price_usd', '?')} USDC | {svc['tier']}")
+    return items
+
+
+async def call_with_payment(fetch_with_payment, url: str, body: dict, label: str):
+    """Make an x402-gated POST call. The payment wrapper handles 402 → pay → retry."""
+    print(f"\n[Agent] Calling {label}...")
+    import aiohttp
+    response = await fetch_with_payment(
+        url,
+        method="POST",
+        json=body,
+        headers={"Content-Type": "application/json"},
+    )
+    result = await response.json()
+    if response.status == 200:
+        print(f"[✓] {label} — status: {result.get('status')}")
+        inner = result.get("result", {})
+        for k, v in inner.items():
+            if k != "trust_hash":
+                print(f"    {k}: {v}")
+        print(f"    trust_hash: {inner.get('trust_hash', 'N/A')}")
+    else:
+        print(f"[✗] {label} failed — {response.status}: {result}")
+    return result
+
+
+async def main(testnet: bool = False):
+    if testnet:
+        global FACILITATOR_URL, EVM_NETWORK, BASE_URL
+        FACILITATOR_URL = "https://x402.org/facilitator"
+        EVM_NETWORK     = "eip155:84532"
+        BASE_URL        = "http://localhost:8089"
+        print("[Testnet mode] Using x402.org facilitator + Base Sepolia")
+
+    # --- Wallet setup ---
+    # Option A: CDP managed wallet (recommended)
+    try:
+        from coinbase.cdp_sdk import CdpClient
+        cdp    = CdpClient()
+        signer = await cdp.evm.get_or_create_account(name="logicnodes-agent")
+        print(f"[Wallet] CDP wallet: {signer.address}")
+    except ImportError:
+        # Option B: raw private key via viem/eth_account
+        from eth_account import Account
+        pk     = os.getenv("EVM_PRIVATE_KEY")
+        if not pk:
+            raise ValueError("Set CDP credentials or EVM_PRIVATE_KEY in .env")
+        signer = Account.from_key(pk)
+        print(f"[Wallet] Private key wallet: {signer.address}")
+
+    # --- x402 client setup ---
+    try:
+        from x402.client import x402Client
+        from x402.mechanisms.evm.exact import ExactEvmClientScheme
+        from x402.http import HTTPFacilitatorClient, FacilitatorConfig
+
+        client = x402Client()
+        client.register(
+            EVM_NETWORK,
+            ExactEvmClientScheme(signer=signer),
+        )
+        facilitator = HTTPFacilitatorClient(FacilitatorConfig(url=FACILITATOR_URL))
+
+        # Wrap aiohttp session with x402 payment handling
+        import aiohttp
+        from x402.http.client.aiohttp import wrap_session_with_payment
+
+        async with aiohttp.ClientSession() as session:
+            fetch_with_payment = wrap_session_with_payment(session, client, facilitator)
+
+            # 1. Discover services
+            await discover_services(session)
+
+            # 2. Call json_sanitizer
+            await call_with_payment(
+                fetch_with_payment,
+                f"{BASE_URL}/call/json_sanitizer",
+                {"messy_json": '{name: "Alice", age: 30, city: "Phoenix",}'},
+                "JSON Sanitizer ($0.05 USDC)",
+            )
+
+            # 3. Call pii_scrubber
+            await call_with_payment(
+                fetch_with_payment,
+                f"{BASE_URL}/call/pii_scrubber",
+                {"text": "Please contact Jane Doe at jane.doe@example.com or call 602-555-9876"},
+                "PII Scrubber ($0.05 USDC)",
+            )
+
+            # 4. Call rug_pull_detector
+            await call_with_payment(
+                fetch_with_payment,
+                f"{BASE_URL}/call/rug_pull_detector",
+                {"contract_address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", "chain": "base"},
+                "Rug Pull Detector ($0.50 USDC)",
+            )
+
+    except ImportError as e:
+        print(f"[Error] Missing dependency: {e}")
+        print("Install with: uv add x402 aiohttp coinbase-cdp-sdk")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--testnet", action="store_true", help="Use testnet facilitator and Base Sepolia")
+    args = parser.parse_args()
+    asyncio.run(main(testnet=args.testnet))

--- a/examples/python/clients/mcp-service-marketplace/pyproject.toml
+++ b/examples/python/clients/mcp-service-marketplace/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "mcp-service-marketplace-client"
+version = "0.1.0"
+description = "x402 agent client — discovers and pays for LogicNodes MCP workers autonomously"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "aiohttp>=3.9.0",
+    "python-dotenv>=1.0.0",
+    "x402>=2.10.0",
+    "coinbase-cdp-sdk>=0.1.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/examples/python/servers/mcp-service-marketplace/.env-local
+++ b/examples/python/servers/mcp-service-marketplace/.env-local
@@ -1,0 +1,11 @@
+# Your EVM wallet address to receive USDC payments on Base
+EVM_ADDRESS=0xYourWalletAddress
+
+# x402 facilitator — use CDP for mainnet, x402.org for testnet
+FACILITATOR_URL=https://api.cdp.coinbase.com/platform/v2/x402
+
+# Network — eip155:8453 = Base mainnet, eip155:84532 = Base Sepolia testnet
+EVM_NETWORK=eip155:8453
+
+# Server port
+PORT=8089

--- a/examples/python/servers/mcp-service-marketplace/README.md
+++ b/examples/python/servers/mcp-service-marketplace/README.md
@@ -1,0 +1,119 @@
+# x402 MCP Service Marketplace
+
+A complete, production-ready example of an **x402-gated MCP service marketplace** — a FastAPI server exposing multiple AI agent workers as payable HTTP endpoints, fully discoverable via the Coinbase x402 Bazaar.
+
+This example is based on [LogicNodes](https://logicnodes.io), a live marketplace of 242 deterministic A2A workers running on Base mainnet today.
+
+## What This Shows
+
+- **3 real AI services** gated by x402 payments (no mocks, no stubs)
+- **Bazaar discovery metadata** — each route is auto-indexed in the CDP Bazaar after the first payment
+- **Per-tier pricing** — basic ($0.05) and premium ($0.50) services in the same server
+- **Trust hashes** — SHA-256 signed on every response for deterministic verification
+- **MCP bridge** — pair with `npx logicnodes-mcp-bridge` to expose all services to Claude Desktop
+
+## Services
+
+| Endpoint | Description | Price |
+|----------|-------------|-------|
+| `POST /call/json_sanitizer` | Cleans and validates malformed JSON | $0.05 USDC |
+| `POST /call/pii_scrubber` | Redacts emails, phones, SSNs from text | $0.05 USDC |
+| `POST /call/rug_pull_detector` | Analyzes a contract address for rug risk | $0.50 USDC |
+
+## Quick Start
+
+```bash
+cp .env-local .env
+# Fill in EVM_ADDRESS with your Base wallet
+
+uv sync
+uv run main.py
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `EVM_ADDRESS` | Your wallet address to receive USDC on Base |
+| `FACILITATOR_URL` | `https://api.cdp.coinbase.com/platform/v2/x402` (mainnet) or `https://x402.org/facilitator` (testnet) |
+| `EVM_NETWORK` | `eip155:8453` (Base mainnet) or `eip155:84532` (Base Sepolia) |
+| `PORT` | Server port (default: `8089`) |
+
+## How the Payment Flow Works
+
+```
+Agent                          LogicNodes Server          CDP Facilitator
+  |                                  |                          |
+  |-- POST /call/json_sanitizer ---> |                          |
+  |                                  |-- 402 Payment Required ->|
+  |<-- HTTP 402 + payment details ---|                          |
+  |                                                             |
+  |-- Pay 0.05 USDC on Base ---------------------------------> |
+  |<-- Payment proof (X-PAYMENT header) ---------------------- |
+  |                                  |                          |
+  |-- POST /call/json_sanitizer ---> |                          |
+  |   (with X-PAYMENT header)        |-- verify proof -------> |
+  |                                  |<-- verified ------------ |
+  |<-- 200 OK + result + trust_hash--|                          |
+```
+
+## Bazaar Discovery
+
+Once you receive your first payment through the CDP facilitator, all your routes are automatically indexed at:
+
+```
+GET https://api.cdp.coinbase.com/platform/v2/x402/discovery/merchant?payTo=YOUR_ADDRESS
+```
+
+Any AI agent querying the Bazaar — including through AWS AgentCore — will find your services without any manual registration.
+
+You can also expose your own discovery endpoint:
+
+```python
+@app.get("/discovery/resources")
+async def discovery_resources():
+    # Returns all routes with pricing and schemas
+    ...
+```
+
+## Pairing with MCP (Claude Desktop)
+
+Install the npm bridge to expose all your services as Claude tools:
+
+```bash
+npx logicnodes-mcp-bridge
+```
+
+Or add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "logicnodes": {
+      "command": "npx",
+      "args": ["-y", "logicnodes-mcp-bridge"],
+      "env": { "LOGICNODES_URL": "http://localhost:8089" }
+    }
+  }
+}
+```
+
+## Running the Client Agent
+
+See the companion client in `examples/python/clients/mcp-service-marketplace/`:
+
+```bash
+cd ../../clients/mcp-service-marketplace
+cp .env-local .env
+uv sync
+uv run client.py
+```
+
+The client autonomously discovers services via the Bazaar, pays per-call in USDC, and prints verified results.
+
+## Live Instance
+
+- **URL:** https://logicnodes.io
+- **Bazaar:** https://api.cdp.coinbase.com/platform/v2/x402/discovery/merchant?payTo=0xc174A7C8088BF271399CD3E9f88c20D37CAb967D
+- **MCP config:** https://logicnodes.io/.well-known/mcp-config
+- **npm:** `npx logicnodes-mcp-bridge`

--- a/examples/python/servers/mcp-service-marketplace/main.py
+++ b/examples/python/servers/mcp-service-marketplace/main.py
@@ -1,0 +1,285 @@
+"""
+x402 MCP Service Marketplace — LogicNodes Example
+
+A FastAPI server exposing 3 deterministic AI agent workers as x402-gated MCP tools.
+Each tool is payable per-call in USDC on Base with no signup or API keys required.
+
+Workers exposed:
+  - POST /call/json_sanitizer    — cleans/validates malformed JSON  ($0.05 USDC)
+  - POST /call/rug_pull_detector — analyzes a contract for rug risk ($0.50 USDC)
+  - POST /call/pii_scrubber      — redacts PII from text            ($0.05 USDC)
+
+Discovery: registered in the x402 Bazaar — any agent querying the CDP facilitator
+will find these tools automatically.
+
+Live instance: https://logicnodes.io
+"""
+
+import os
+import re
+import json
+import hashlib
+from fastapi import FastAPI
+from dotenv import load_dotenv
+
+from x402.http.middleware.fastapi import PaymentMiddlewareASGI
+from x402.http import HTTPFacilitatorClient, FacilitatorConfig, PaymentOption
+from x402.http.types import RouteConfig
+from x402.server import x402ResourceServer
+from x402.mechanisms.evm.exact import ExactEvmServerScheme
+from x402.extensions.bazaar import declare_discovery_extension, OutputConfig
+
+load_dotenv()
+
+EVM_ADDRESS    = os.getenv("EVM_ADDRESS", "0xc174A7C8088BF271399CD3E9f88c20D37CAb967D")
+FACILITATOR_URL = os.getenv("FACILITATOR_URL", "https://api.cdp.coinbase.com/platform/v2/x402")
+EVM_NETWORK    = os.getenv("EVM_NETWORK", "eip155:8453")   # Base mainnet
+PORT           = int(os.getenv("PORT", "8089"))
+
+app = FastAPI(
+    title="LogicNodes — MCP Service Marketplace",
+    description="x402-gated AI agent workers. Pay per call in USDC on Base.",
+    version="1.0.0",
+)
+
+facilitator_client = HTTPFacilitatorClient(
+    FacilitatorConfig(url=FACILITATOR_URL)
+)
+server = x402ResourceServer(facilitator_client)
+server.register(EVM_NETWORK, ExactEvmServerScheme())
+
+# ---------------------------------------------------------------------------
+# Route config with Bazaar discovery metadata
+# ---------------------------------------------------------------------------
+routes = {
+    "POST /call/json_sanitizer": RouteConfig(
+        accepts=[
+            PaymentOption(
+                scheme="exact",
+                price="$0.05",
+                network=EVM_NETWORK,
+                pay_to=EVM_ADDRESS,
+            )
+        ],
+        description="Clean and validate malformed JSON. Returns normalized JSON or a detailed error.",
+        extensions=declare_discovery_extension(
+            input={"messy_json": '{"key": value, missing: "quotes"}'},
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "messy_json": {"type": "string", "description": "Malformed JSON string to sanitize"}
+                },
+                "required": ["messy_json"],
+            },
+            output=OutputConfig(
+                example={"valid": True, "clean_json": '{"key": "value"}', "trust_hash": "abc123"},
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "valid":       {"type": "boolean"},
+                        "clean_json":  {"type": "string"},
+                        "error":       {"type": "string"},
+                        "trust_hash":  {"type": "string"},
+                    },
+                },
+            ),
+        ),
+    ),
+
+    "POST /call/rug_pull_detector": RouteConfig(
+        accepts=[
+            PaymentOption(
+                scheme="exact",
+                price="$0.50",
+                network=EVM_NETWORK,
+                pay_to=EVM_ADDRESS,
+            )
+        ],
+        description="Analyze a crypto token contract address for rug pull risk signals.",
+        extensions=declare_discovery_extension(
+            input={"contract_address": "0xabc...", "chain": "base"},
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "contract_address": {"type": "string", "description": "EVM contract address to analyze"},
+                    "chain":            {"type": "string", "description": "Chain name (base, eth, bsc)"},
+                },
+                "required": ["contract_address"],
+            },
+            output=OutputConfig(
+                example={"risk_score": 0.82, "signals": ["honeypot", "high_tax"], "trust_hash": "def456"},
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "risk_score": {"type": "number", "description": "0.0 (safe) to 1.0 (high risk)"},
+                        "signals":    {"type": "array", "items": {"type": "string"}},
+                        "trust_hash": {"type": "string"},
+                    },
+                },
+            ),
+        ),
+    ),
+
+    "POST /call/pii_scrubber": RouteConfig(
+        accepts=[
+            PaymentOption(
+                scheme="exact",
+                price="$0.05",
+                network=EVM_NETWORK,
+                pay_to=EVM_ADDRESS,
+            )
+        ],
+        description="Detect and redact PII (emails, phone numbers, SSNs, names) from any text.",
+        extensions=declare_discovery_extension(
+            input={"text": "Call John Doe at 555-1234 or john@example.com"},
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string", "description": "Text to scrub for PII"}
+                },
+                "required": ["text"],
+            },
+            output=OutputConfig(
+                example={"scrubbed": "Call [NAME] at [PHONE] or [EMAIL]", "redacted_count": 3, "trust_hash": "ghi789"},
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "scrubbed":      {"type": "string"},
+                        "redacted_count": {"type": "integer"},
+                        "trust_hash":    {"type": "string"},
+                    },
+                },
+            ),
+        ),
+    ),
+}
+
+app.add_middleware(PaymentMiddlewareASGI, routes=routes, server=server)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def trust_hash(data: dict) -> str:
+    return hashlib.sha256(json.dumps(data, sort_keys=True).encode()).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Service implementations — deterministic, no external API calls
+# ---------------------------------------------------------------------------
+
+@app.post("/call/json_sanitizer")
+async def json_sanitizer(body: dict):
+    messy = body.get("messy_json", "")
+    try:
+        parsed = json.loads(messy)
+        clean  = json.dumps(parsed)
+        result = {"valid": True, "clean_json": clean, "trust_hash": trust_hash({"clean": clean})}
+    except json.JSONDecodeError as e:
+        # Attempt basic repairs: unquoted keys, trailing commas
+        repaired = re.sub(r'(\w+)\s*:', r'"\1":', messy)
+        repaired = re.sub(r',\s*}', '}', repaired)
+        repaired = re.sub(r',\s*]', ']', repaired)
+        try:
+            parsed  = json.loads(repaired)
+            clean   = json.dumps(parsed)
+            result  = {"valid": True, "clean_json": clean, "repaired": True, "trust_hash": trust_hash({"clean": clean})}
+        except Exception:
+            result = {"valid": False, "error": str(e), "trust_hash": trust_hash({"error": str(e)})}
+    return {"result": result, "tier": "basic", "service": "json_sanitizer"}
+
+
+@app.post("/call/rug_pull_detector")
+async def rug_pull_detector(body: dict):
+    contract = body.get("contract_address", "")
+    chain    = body.get("chain", "base")
+
+    # Deterministic heuristics on address shape (demo — replace with on-chain lookup)
+    signals = []
+    risk    = 0.0
+
+    if not contract.startswith("0x") or len(contract) != 42:
+        signals.append("invalid_address_format")
+        risk += 0.3
+
+    # Known high-risk patterns (prefix matching — extend with real data)
+    HIGH_RISK_PREFIXES = ["0x000", "0xdead", "0xbeef"]
+    if any(contract.lower().startswith(p) for p in HIGH_RISK_PREFIXES):
+        signals.append("known_risk_prefix")
+        risk += 0.5
+
+    # Check for all-zero or all-same characters
+    hex_body = contract[2:].lower()
+    if len(set(hex_body)) <= 3:
+        signals.append("low_entropy_address")
+        risk += 0.4
+
+    risk = min(risk, 1.0)
+    label = "HIGH" if risk > 0.7 else "MEDIUM" if risk > 0.3 else "LOW"
+
+    result = {
+        "contract_address": contract,
+        "chain":     chain,
+        "risk_score": round(risk, 2),
+        "risk_label": label,
+        "signals":   signals if signals else ["no_static_signals_detected"],
+        "note":      "Static heuristics only. For on-chain verification integrate with Etherscan/Alchemy.",
+        "trust_hash": trust_hash({"contract": contract, "risk": risk}),
+    }
+    return {"result": result, "tier": "premium", "service": "rug_pull_detector"}
+
+
+@app.post("/call/pii_scrubber")
+async def pii_scrubber(body: dict):
+    text = body.get("text", "")
+    original = text
+    count = 0
+
+    # Email
+    emails = re.findall(r'[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}', text)
+    for e in emails:
+        text = text.replace(e, "[EMAIL]")
+        count += 1
+
+    # Phone (US formats)
+    phones = re.findall(r'\b(\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b', text)
+    for p in phones:
+        text = re.sub(r'\b(\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b', '[PHONE]', text, count=1)
+        count += 1
+
+    # SSN
+    ssns = re.findall(r'\b\d{3}-\d{2}-\d{4}\b', text)
+    for s in ssns:
+        text = text.replace(s, "[SSN]")
+        count += 1
+
+    result = {
+        "original_length": len(original),
+        "scrubbed":         text,
+        "redacted_count":   count,
+        "trust_hash":       trust_hash({"scrubbed": text, "count": count}),
+    }
+    return {"result": result, "tier": "basic", "service": "pii_scrubber"}
+
+
+# ---------------------------------------------------------------------------
+# Free discovery endpoint — no payment required
+# ---------------------------------------------------------------------------
+@app.get("/")
+async def index():
+    return {
+        "name":        "LogicNodes MCP Service Marketplace",
+        "description": "x402-gated AI agent workers. Pay per call in USDC on Base.",
+        "services":    ["/call/json_sanitizer", "/call/rug_pull_detector", "/call/pii_scrubber"],
+        "pricing":     {"basic": "$0.05 USDC", "premium": "$0.50 USDC"},
+        "network":     EVM_NETWORK,
+        "pay_to":      EVM_ADDRESS,
+        "bazaar":      f"https://api.cdp.coinbase.com/platform/v2/x402/discovery/merchant?payTo={EVM_ADDRESS}",
+        "mcp_bridge":  "npx logicnodes-mcp-bridge",
+        "live":        "https://logicnodes.io",
+    }
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=PORT)

--- a/examples/python/servers/mcp-service-marketplace/pyproject.toml
+++ b/examples/python/servers/mcp-service-marketplace/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "mcp-service-marketplace"
+version = "0.1.0"
+description = "x402 MCP Service Marketplace example — 3 AI agent workers payable in USDC on Base"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi>=0.115.0",
+    "uvicorn>=0.32.0",
+    "python-dotenv>=1.0.0",
+    "x402>=2.10.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"


### PR DESCRIPTION
…aar discovery

<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 