### PR TITLE
feat: add arbitrum and arbitrum-sepolia to NetworkSchema

### DIFF
--- a/typescript/packages/legacy/x402/src/types/shared/network.ts
+++ b/typescript/packages/legacy/x402/src/types/shared/network.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 export const NetworkSchema = z.enum([
   "abstract",
   "abstract-testnet",
+  "arbitrum",
+  "arbitrum-sepolia",
   "base-sepolia",
   "base",
   "avalanche-fuji",
@@ -26,6 +28,8 @@ export const SupportedEVMNetworks: Network[] = [
   "abstract",
   "abstract-testnet",
   "base-sepolia",
+  "arbitrum",
+  "arbitrum-sepolia",
   "base",
   "avalanche-fuji",
   "avalanche",
@@ -42,6 +46,8 @@ export const SupportedEVMNetworks: Network[] = [
 export const EvmNetworkToChainId = new Map<Network, number>([
   ["abstract", 2741],
   ["abstract-testnet", 11124],
+  ["arbitrum", 42161],
+  ["arbitrum-sepolia", 421614],
   ["base-sepolia", 84532],
   ["base", 8453],
   ["avalanche-fuji", 43113],


### PR DESCRIPTION
## Description

Adds `arbitrum` (chain ID 42161) and `arbitrum-sepolia` (chain ID 421614) to the TypeScript `NetworkSchema` enum, `SupportedEVMNetworks` array, and `EvmNetworkToChainId` map in `typescript/packages/legacy/x402/src/types/shared/network.ts`.

**Why Arbitrum:** Second-largest EVM chain by TVL. Circle issues native USDC on Arbitrum One (`0xaf88d065e77c8cC2239327C5EDb3A432268e5831`) with full EIP-3009 (`transferWithAuthorization`) support — the same transfer method used by Base and Polygon. No Permit2 fallback needed.

**What was already in the repo (this PR completes the picture):**
- `typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts` — `eip155:42161` and `eip155:421614` already defined ✅
- `go/mechanisms/evm/constants.go` — `ChainIDArbOne` and `ChainIDArbSepolia` already defined ✅

This PR adds the missing network shortname entries so that clients and servers can reference `"arbitrum"` by name, consistent with how `"polygon"`, `"avalanche"`, and other chains are registered.

## Tests

Verified end-to-end against a live x402 infrastructure with real USDC settlement on Arbitrum One using the native `0xaf88d065e77c8cC2239327C5EDb3A432268e5831` token contract. EIP-3009 `transferWithAuthorization` signatures produce valid on-chain USDC transfers on Arbitrum One, confirming the chain is fully compatible with the existing exact-evm scheme.

The TypeScript change is additive only (new enum values, no logic changes), so existing tests for other networks are unaffected.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)