### PR TITLE
Add Fleet x402 Microservices to ecosystem (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/fleet-x402/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/fleet-x402/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Fleet x402 Microservices",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/fleet-x402.png",
+  "description": "Agent-payable AI services on Base: SEO Audit ($0.05 USDC) and Competitive Intel Pack ($0.50 USDC). Discoverable via /.well-known/x402-listing. Zero auth, instant response.",
+  "websiteUrl": "https://fleet-x402-audit.fly.dev"
+}


### PR DESCRIPTION
## What this adds

**Fleet x402 Microservices** — two production x402-payable services running on Base mainnet.

**Category**: Services/Endpoints

### Services

| Name | Endpoint | Price | Network |
|------|----------|-------|---------|
| SEO Audit | `POST /audit` | $0.05 USDC | Base |
| Competitive Intel Pack | `POST /intel-pack` | $0.50 USDC | Base |

**Live URL**: https://fleet-x402-audit.fly.dev  
**Discovery manifest**: https://fleet-x402-audit.fly.dev/.well-known/x402-listing

### Technical Details
- Scheme: `exact`
- Asset: USDC (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`)
- Response: immediate JSON, no API key required
- Fully agent-native: any x402-compatible buyer agent can call without human intervention

> **Note**: Logo file (`fleet-x402.png`) can be added — happy to provide one on request, or maintainers can use the service favicon at https://fleet-x402-audit.fly.dev/favicon.ico