### PR TITLE
feat(ecosystem): add extract.dkta.dev — LLM-ready content extraction …

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/extract-dkta/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/extract-dkta/metadata.json
@@ -1,0 +1,6 @@
+{
+  "name": "extract.dkta.dev",
+  "category": "Services/Endpoints",
+  "description": "Extract clean, LLM-ready markdown from any URL. No account or API key required \u2014 agents pay per request using x402 on Base.",
+  "websiteUrl": "https://extract.dkta.dev"
+}


### PR DESCRIPTION
## Description

extract.dkta.dev is a content extraction API built for AI agents. It returns clean, LLM-ready markdown from any URL — stripped of nav, ads, and boilerplate. Agents integrate via x402 on Base: no account, no API key, no subscription. The x402 payment flow is handled automatically by any x402-compatible client.

## Test plan
- [ ] Verify metadata.json renders correctly in the ecosystem directory
- [ ] Confirm websiteUrl is live: https://extract.dkta.dev