### PR TITLE
feat(ecosystem): add x402-anthropic (TypeScript + Python)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/x402-anthropic-python/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-anthropic-python/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402-anthropic (Python)",
+  "category": "Client-Side Integrations",
+  "logoUrl": "/logos/x402-anthropic.svg",
+  "description": "x402 payment transport for the Anthropic Python SDK. Wraps the Anthropic client so HTTP 402 responses are automatically paid with USDC on EVM (Base, Ethereum) or SVM (Solana) — no code changes needed.",
+  "websiteUrl": "https://github.com/kinance/x402-anthropic-python"
+}

--- a/typescript/site/app/ecosystem/partners-data/x402-anthropic-typescript/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-anthropic-typescript/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402-anthropic (TypeScript)",
+  "category": "Client-Side Integrations",
+  "logoUrl": "/logos/x402-anthropic.svg",
+  "description": "x402 payment transport for the Anthropic TypeScript SDK. Wraps the Anthropic client so HTTP 402 responses are automatically paid with USDC on EVM (Base, Ethereum) or SVM (Solana) — no code changes needed.",
+  "websiteUrl": "https://github.com/kinance/x402-anthropic-typescript"
+}

--- a/typescript/site/public/logos/x402-anthropic.svg
+++ b/typescript/site/public/logos/x402-anthropic.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#1a1a1a"/>
+  <text x="32" y="22" font-family="monospace" font-size="11" font-weight="bold" fill="#ffffff" text-anchor="middle">x402</text>
+  <text x="32" y="42" font-family="monospace" font-size="11" font-weight="bold" fill="#d4a849" text-anchor="middle">anthro</text>
+  <text x="32" y="56" font-family="monospace" font-size="8" fill="#888888" text-anchor="middle">pic</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds two ecosystem entries for x402-anthropic — client-side payment transports for the Anthropic SDK.

- **[x402-anthropic](https://github.com/kinance/x402-anthropic-typescript)** (TypeScript) — `npm install x402-anthropic`
- **[x402-anthropic-python](https://github.com/kinance/x402-anthropic-python)** (Python) — `pip install x402-anthropic[evm]`

Both wrap the standard Anthropic client so HTTP 402 responses are automatically paid with USDC on EVM (Base, Ethereum) or SVM (Solana). Zero code changes needed beyond swapping the client class.

Category: **Client-Side Integrations**