### PR TITLE
feat(ecosystem): add NLP & Crypto Research API — pay-per-use NLP+crypto on Base

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/nlp-crypto-api/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/nlp-crypto-api/metadata.json
@@ -1,0 +1,6 @@
+{
+  "name": "NLP & Crypto Research API",
+  "category": "Services/Endpoints",
+  "description": "Pay-per-use NLP and crypto research for AI agents — sentiment analysis ($0.05), extractive summarization ($0.08), keyword extraction ($0.05), crypto protocol briefs ($0.10), and live crypto prices ($0.02). USDC on Base mainnet via x402 v2. No auth, no API keys, instant response.",
+  "websiteUrl": "https://695995eb457b2055-201-170-130-122.serveousercontent.com"
+}


### PR DESCRIPTION
## Description

NLP & Crypto Research API is a pay-per-use service for AI agents built on x402 v2 on Base mainnet. Agents pay in USDC with no accounts, no API keys, no subscriptions — just the x402 payment flow.

**5 endpoints:**
- `POST /api/sentiment` — Sentiment analysis with word-level attribution ($0.05 USDC)
- `POST /api/summarize` — Extractive text summarization, 1-5 sentences ($0.08 USDC)
- `POST /api/keywords` — Keyword extraction with TF frequency counts ($0.05 USDC)
- `POST /api/crypto-brief` — Structured crypto protocol research brief ($0.10 USDC)
- `POST /api/price` — Live crypto prices via CoinGecko — USD, 24h change, market cap ($0.02 USDC)

All GET and POST variants supported. Bazaar discovery extension active.

**Payment:** USDC on Base mainnet (eip155:8453), x402 v2 protocol, `@x402/express` 2.13.0

**Discovery:** `/.well-known/x402` and `/openapi.json` available. Listed on x402scan.

## Test plan
- [ ] Verify metadata.json renders correctly in ecosystem directory
- [ ] Confirm websiteUrl returns 200: `https://695995eb457b2055-201-170-130-122.serveousercontent.com`
- [ ] Verify x402 returns 402 on paid endpoints: `curl -I https://695995eb457b2055-201-170-130-122.serveousercontent.com/api/sentiment`