### PR TITLE
feat(ecosystem): add 24K Labs — AI services via x402

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/24klabs/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/24klabs/metadata.json
@@ -1,0 +1,1 @@
+{"name":"24K Labs","description":"Eleven AI-powered developer services on x402 — code review, security audit, debug assist, document extraction, image analysis, and more. Pay per request in USDC on Base. No API keys, no subscriptions.","logoUrl":"/logos/24klabs.svg","websiteUrl":"https://24klabs.ai","category":"Services/Endpoints"}

--- a/typescript/site/public/logos/24klabs.svg
+++ b/typescript/site/public/logos/24klabs.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64"><rect width="64" height="64" rx="12" fill="#0a0a0f"/><polygon points="32,8 56,32 32,56 8,32" fill="#c9a84c"/><polygon points="32,16 48,32 32,48 16,32" fill="#0a0a0f"/><polygon points="32,22 42,32 32,42 22,32" fill="#c9a84c" opacity="0.7"/></svg>


### PR DESCRIPTION
## Summary

Adds 24K Labs to the x402 ecosystem.

**24K Labs** runs eleven AI-powered developer services on x402 — code review, security audit, debug assist, explain code, web reader, document extractor, image analyzer, and more. Each service accepts USDC payments on Base via x402. No API keys or subscriptions required.

- Website: https://24klabs.ai
- API: https://api.24klabs.ai
- Quickstart: https://24klabs.ai/developers/quickstart
- Category: Services/Endpoints