### PR TITLE
fix(docs): remove duplicate @x402/svm in README install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ app.use(
 ```shell
 # All available reference sdks
 npm install @x402/core \
-  @x402/evm @x402/svm @x402/stellar @x402/svm \
+  @x402/evm @x402/svm @x402/stellar \
   @x402/axios @x402/fastify @x402/fetch @x402/express @x402/hono @x402/next @x402/paywall @x402/extensions
 ```
 


### PR DESCRIPTION
### What
Remove the duplicated `@x402/svm` package in the TypeScript "all available reference sdks" `npm install` command in `README.md`.

### Why
`@x402/svm` appears twice on the same line, which is misleading to anyone copying the command.

Small, scoped fix from kcolbchain contrib-bot.