### PR TITLE
Add x402 Paid Endpoint to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/x402-paid-endpoint/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-paid-endpoint/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402 Paid Endpoint",
+  "description": "Live $1 USDC endpoint on Base mainnet selling a machine-readable artifact via x402 v2 'exact'. MIT, with a reference buyer gated by a local signed-receipt policy layer.",
+  "logoUrl": "/logos/x402-paid-endpoint.svg",
+  "websiteUrl": "https://x402-paid-endpoint.selfradiance.workers.dev",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/x402-paid-endpoint.svg
+++ b/typescript/site/public/logos/x402-paid-endpoint.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512" role="img" aria-labelledby="title desc">
+  <title id="title">x402 Paid Endpoint</title>
+  <desc id="desc">Dark square logo with 402 and selfradiance wordmark.</desc>
+  <rect width="512" height="512" fill="#0a0a0a" />
+  <text x="256" y="256" text-anchor="middle" dominant-baseline="middle" fill="#2775CA" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace" font-size="176" font-weight="700">402</text>
+  <text x="256" y="340" text-anchor="middle" dominant-baseline="middle" fill="#ffffff" font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="30" font-weight="500">selfradiance</text>
+</svg>


### PR DESCRIPTION
This adds my project, x402 Paid Endpoint, to the x402 ecosystem page. It is a live $1 USDC endpoint on Base mainnet, MIT licensed, and includes a reference buyer gated by x402-spend-receipt.

Repo: https://github.com/selfradiance/x402-paid-endpoint
Endpoint: https://x402-paid-endpoint.selfradiance.workers.dev
