### PR TITLE
docs: warn that public facilitator returns 500 (not 402) when used with Base Mainnet

### DIFF
--- a/docs/getting-started/quickstart-for-sellers.mdx
+++ b/docs/getting-started/quickstart-for-sellers.mdx
@@ -89,6 +89,14 @@ Integrate the payment middleware into your application. You will need to provide
 
 * The Facilitator URL or facilitator client. For testing, use `https://x402.org/facilitator` which works on Base Sepolia and Solana devnet.
   * For mainnet setup, see [Running on Mainnet](#running-on-mainnet)
+
+  <Warning>
+    **Using the public facilitator on Base Mainnet causes a `500` error, not `402`.**
+
+    `https://x402.org/facilitator` only supports testnet networks (Base Sepolia `eip155:84532`, Solana Devnet). Pointing it at Base Mainnet (`eip155:8453`) causes the middleware to propagate an unhandled `"Route Configuration Errors"` response from the facilitator, surfacing as a `500 Internal Server Error` to the caller — not `402 Payment Required`.
+
+    For production, configure a self-hosted or CDP-backed facilitator. See [Running on Mainnet](#running-on-mainnet).
+  </Warning>
 * The routes you want to protect.
 * Your receiving wallet address.
 


### PR DESCRIPTION
### What

  Adds a `<Warning>` callout to the "Add Payment Middleware" section of the Quickstart for Sellers guide, immediately below the facilitator URL bullet.

  ### Why

  The public facilitator `https://x402.org/facilitator` only supports testnet networks (Base Sepolia `eip155:84532`, Solana Devnet). When developers configure the middleware with Base Mainnet (`eip155:8453`) — a natural step when moving to production — the middleware crashes with a generic `500 Internal Server Error` rather than returning `402 Payment Required`. There is no indication in the error or current docs that the issue is the facilitator configuration.

  Observed while building [BasePay](https://github.com/osr21/basepay-dapp), an open-source USDC payments dApp on Base Mainnet using `@x402/express`.

  **Error seen in server logs:**
  ```
  Error: Route Configuration Errors
      at verifyPayment (@x402/express/dist/index.js:...)
  ```

  ### Change

  Single doc edit: one `<Warning>` block inserted at the facilitator URL bullet in `docs/getting-started/quickstart-for-sellers.mdx`. No code changes.

  > Opened as Draft — leaving review of wording to maintainers.