### PR TITLE
ecosystem: add eltociear Security APIs (tokenguard, skill-audit, contract-guard)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/eltociear-security-apis/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/eltociear-security-apis/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "eltociear Security APIs",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/eltociear-security-apis.svg",
+  "description": "Pay-per-call security & onchain-intelligence APIs over x402 (USDC on Base): tokenguard (ERC-20 rug/safety scan), skill-audit (MCP & AI-agent skill malicious-pattern scan), and contract-guard (EVM contract risk check). No signup — wallet is auth.",
+  "websiteUrl": "https://github.com/eltociear/skill-audit-mcp"
+}

--- a/typescript/site/public/logos/eltociear-security-apis.svg
+++ b/typescript/site/public/logos/eltociear-security-apis.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200"><rect width="200" height="200" rx="32" fill="#0B0E14"/><path d="M100 28l54 20v44c0 38-24 64-54 80-30-16-54-42-54-80V48z" fill="#1F6FEB"/><text x="100" y="116" font-family="Arial,Helvetica,sans-serif" font-size="40" font-weight="700" fill="#fff" text-anchor="middle">x402</text></svg>


### PR DESCRIPTION
Adds a **Services/Endpoints** ecosystem entry for three live, pay-per-call x402 APIs (USDC on Base, no signup — wallet is auth):

- **tokenguard** — ERC-20 rug/safety scanner (mint, blacklist, pausable, tax, upgradeable-proxy, ownership) + onchain-intelligence suite. $0.005/call.
- **skill-audit** — scans MCP servers & AI-agent skills for 68 malicious patterns (prompt injection, exfiltration, unsafe exec). $0.01/call.
- **contract-guard** — EVM contract/token risk check across 6 chains. $0.005/call.

All return HTTP 402 with x402 v2 payment requirements and are indexed on x402scan / CDP Bazaar. Adds `partners-data/eltociear-security-apis/metadata.json` + logo. Verified live at submission time.