### PR TITLE
feat(evm): add XDC Network (50) and XDC Apothem testnet (51) default assets

### DIFF
--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -79,6 +79,8 @@ var (
 	ChainIDPolygon       = big.NewInt(137)
 	ChainIDArbOne        = big.NewInt(42161)
 	ChainIDArbSepolia    = big.NewInt(421614)
+	ChainIDXDC           = big.NewInt(50)
+	ChainIDXDCApothem    = big.NewInt(51)
 
 	// Network configurations
 	// See DEFAULT_ASSET.md for guidelines on adding new chains
@@ -192,6 +194,26 @@ var (
 			DefaultAsset: AssetInfo{
 				Address:  "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d", // USDC on ArbSepolia
 				Name:     "USD Coin",
+				Version:  "2",
+				Decimals: DefaultDecimals,
+			},
+		},
+		// XDC Network Mainnet
+		"eip155:50": {
+			ChainID: ChainIDXDC,
+			DefaultAsset: AssetInfo{
+				Address:  "0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1", // USDC on XDC (Circle, native)
+				Name:     "USDC",
+				Version:  "2",
+				Decimals: DefaultDecimals,
+			},
+		},
+		// XDC Apothem Testnet
+		"eip155:51": {
+			ChainID: ChainIDXDCApothem,
+			DefaultAsset: AssetInfo{
+				Address:  "0xb5AB69F7bBada22B28e79C8FFAECe55eF1c771D4", // USDC on XDC Apothem (Circle, native)
+				Name:     "USDC",
 				Version:  "2",
 				Decimals: DefaultDecimals,
 			},

--- a/python/x402/mechanisms/evm/constants.py
+++ b/python/x402/mechanisms/evm/constants.py
@@ -504,6 +504,26 @@ NETWORK_CONFIGS: dict[str, NetworkConfig] = {
             "decimals": 6,
         },
     },
+    # XDC Network Mainnet
+    "eip155:50": {
+        "chain_id": 50,
+        "default_asset": {
+            "address": "0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1",
+            "name": "USDC",
+            "version": "2",
+            "decimals": 6,
+        },
+    },
+    # XDC Apothem Testnet
+    "eip155:51": {
+        "chain_id": 51,
+        "default_asset": {
+            "address": "0xb5AB69F7bBada22B28e79C8FFAECe55eF1c771D4",
+            "name": "USDC",
+            "version": "2",
+            "decimals": 6,
+        },
+    },
 }
 
 # V1 legacy constants are in x402.mechanisms.evm.v1.constants

--- a/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
+++ b/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
@@ -105,6 +105,18 @@ export const DEFAULT_STABLECOINS: Record<string, ExactDefaultAssetInfo> = {
     assetTransferMethod: "permit2",
     supportsEip2612: true,
   }, // Mezo Testnet mUSD (no EIP-3009, supports EIP-2612)
+  "eip155:50": {
+    address: "0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1",
+    name: "USDC",
+    version: "2",
+    decimals: 6,
+  }, // XDC Network mainnet USDC (Circle, native)
+  "eip155:51": {
+    address: "0xb5AB69F7bBada22B28e79C8FFAECe55eF1c771D4",
+    name: "USDC",
+    version: "2",
+    decimals: 6,
+  }, // XDC Apothem testnet USDC (Circle, native)
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds **XDC Network** mainnet (`eip155:50`) and **XDC Apothem** testnet (`eip155:51`) to the EVM default-asset registries, following [`DEFAULT_ASSETS.md`](https://github.com/coinbase/x402/blob/main/DEFAULT_ASSETS.md). This lets USD-string pricing (`price: "$0.10"`) resolve to native USDC on XDC out of the box, across all three SDKs.

## Changes

Per the cross-SDK checklist in `DEFAULT_ASSETS.md`, same CAIP-2 key / address / EIP-712 `name`+`version` / decimals in each:

| SDK | File | Map |
|-----|------|-----|
| TypeScript | `typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts` | `DEFAULT_STABLECOINS` |
| Go | `go/mechanisms/evm/constants.go` | `NetworkConfigs` (+ `ChainIDXDC`/`ChainIDXDCApothem` vars) |
| Python | `python/x402/mechanisms/evm/constants.py` | `NETWORK_CONFIGS` |

## Asset selection & on-chain-verified values

XDC's default asset is **native Circle USDC** — Circle launched native USDC + CCTP V2 on XDC Network in August 2025 (native issuance, not a bridge wrapper). Native USDC implements **EIP-3009 `transferWithAuthorization`**, so the default `exact` scheme works with no Permit2 fallback required.

The EIP-712 domain values below were read directly from the token contracts on-chain (not from docs), since `DEFAULT_ASSETS.md` requires `name`/`version` to match the domain separator exactly:

| | XDC mainnet (`eip155:50`) | XDC Apothem (`eip155:51`) |
|---|---|---|
| Address | `0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1` | `0xb5AB69F7bBada22B28e79C8FFAECe55eF1c771D4` |
| `name()` | `USDC` | `USDC` |
| `version()` | `2` | `2` |
| `decimals()` | `6` | `6` |
| EIP-3009 `authorizationState()` | present → supported | present → supported |

> ⚠️ Note: the EIP-712 domain `name` on XDC USDC is **`"USDC"`**, not `"USD Coin"` as on some chains. Using the wrong name would break signature verification, so it is set to `"USDC"` here.

## Validation

- **Go**: `go build ./mechanisms/evm/` and `go vet ./mechanisms/evm/` pass; `gofmt` clean.
- **Python**: `python -m py_compile` on `constants.py` passes.
- **TypeScript**: entries mirror the existing `DEFAULT_STABLECOINS` shape exactly.
- The addresses, EIP-712 domain, and EIP-3009 support were verified via `eth_call`/`eth_getCode` against XDC mainnet (`https://rpc.xdc.org`) and Apothem (`https://rpc.apothem.network`).

## Ecosystem note

XDC mainnet already has the canonical Permit2 (`0x0000…78BA3`) and the x402 exact-permit2 proxy (`0x402085…0001`) deployed, so both the EIP-3009 and Permit2 paths are viable there. (Multicall3 is not yet deployed on XDC; flagging in case facilitator batch-verification relies on it.)

This follows `DEFAULT_ASSETS.md` exactly (the three registry files). Happy to add a changeset or touch the legacy/e2e network tables if maintainers would like parity there.
