### PR TITLE
Add true402 to the ecosystem (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/true402/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/true402/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "true402",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/true402.svg",
+  "description": "Machine-native x402 marketplace on Base — agent-payable stalls for on-chain safety/DeFi (token rug + honeypot simulation, address safety), web/SEO tools, and LLM inference. No accounts, no API keys, no KYC; the wallet is identity.",
+  "websiteUrl": "https://true402.dev"
+}

--- a/typescript/site/public/logos/true402.svg
+++ b/typescript/site/public/logos/true402.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128" role="img" aria-label="true402">
+  <rect width="128" height="128" rx="26" fill="#0a0b0d"/>
+  <circle cx="36" cy="42" r="6.5" fill="#ffb02e"/>
+  <text x="64" y="83" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="48" font-weight="700" letter-spacing="-3" text-anchor="middle" fill="#e9e6dd">t<tspan fill="#ffb02e">402</tspan></text>
+</svg>


### PR DESCRIPTION
Adds **true402** under Services/Endpoints.

true402 is a machine-native x402 marketplace on Base — agent-payable stalls for on-chain safety/DeFi (token rug + buy/sell *honeypot simulation*, address safety + proxy detection, composite token report, liquidity-pull/whale feeds), web/SEO tools, and LLM inference. $0.0005–$0.015 USDC per call.

No accounts, no API keys, no KYC — the wallet is identity. Machine-readable throughout (OpenAPI, MCP server, `/.well-known/x402`, llms.txt).

- Website: https://true402.dev
- Discovery: https://true402.dev/.well-known/x402

Adds `partners-data/true402/metadata.json` + `public/logos/true402.svg` only.