### PR TITLE
Add Lazarus Long Healthspan ROI Advisor to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/lazarus-long-healthspan-roi-advisor/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/lazarus-long-healthspan-roi-advisor/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Lazarus Long Healthspan ROI Advisor",
+  "description": "Evidence-based longevity interventions ranked by ROI for adults in their 60s–80s. Returns top 5 personalized interventions by age cohort, health concerns, time, and budget. $0.05 USDC via x402 on Base.",
+  "logoUrl": "",
+  "websiteUrl": "https://roi-advisor-pi.vercel.app/api/highest-roi",
+  "category": "Services/Endpoints"
+}


### PR DESCRIPTION
## New ecosystem listing

**Service:** Lazarus Long Healthspan ROI Advisor
**Category:** Services/Endpoints
**Endpoint:** https://roi-advisor-pi.vercel.app/api/highest-roi
**Price:** $0.05 USDC per call via x402 on Base mainnet

### Description
Evidence-based longevity interventions ranked by ROI for adults in their 60s–80s. POST a user profile (age cohort, health concerns, time availability, budget tier) and receive the top 5 personalized interventions ranked by cost-effectiveness. Interventions are graded by evidence quality (A/B/C) and cover exercise, nutrition, sleep, cognitive health, supplementation, and metabolic health.

### x402 details
- Network: Base mainnet (eip155:8453)
- Asset: USDC (0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913)
- Facilitator: https://x402.org/facilitator
- Discovery: /.well-known/x402.json and /.well-known/ai-catalog.json published

Note: logoUrl is left empty — happy to add a logo file in a follow-up if preferred.