### PR TITLE
Add a TypeScript client example that runs against a real deployed x402 endpoint

### DIFF
--- a/examples/typescript/clients/live-api-buyer/.env-local
+++ b/examples/typescript/clients/live-api-buyer/.env-local
@@ -1,2 +1,5 @@
 EVM_PRIVATE_KEY=
+
+# Point RESOURCE_URL at any live x402 endpoint (discover them in Coinbase Bazaar:
+# https://docs.cdp.coinbase.com/x402/bazaar). Example:
 RESOURCE_URL=https://api.stelardigital.com/pricecheck?asset=BTC

--- a/examples/typescript/clients/live-api-buyer/.env-local
+++ b/examples/typescript/clients/live-api-buyer/.env-local
@@ -1,0 +1,2 @@
+EVM_PRIVATE_KEY=
+RESOURCE_URL=https://api.stelardigital.com/pricecheck?asset=BTC

--- a/examples/typescript/clients/live-api-buyer/.prettierignore
+++ b/examples/typescript/clients/live-api-buyer/.prettierignore
@@ -1,0 +1,8 @@
+docs/
+dist/
+node_modules/
+coverage/
+.github/
+src/client
+**/**/*.json
+*.md

--- a/examples/typescript/clients/live-api-buyer/.prettierrc
+++ b/examples/typescript/clients/live-api-buyer/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "avoid",
+  "printWidth": 100,
+  "proseWrap": "never"
+}

--- a/examples/typescript/clients/live-api-buyer/README.md
+++ b/examples/typescript/clients/live-api-buyer/README.md
@@ -1,13 +1,19 @@
 # Live API Buyer Example
 
-An x402 client example that calls a **live, production** x402-protected API instead of a
-local demo server — so you can see the real 402 → pay → 200 flow end to end.
+An x402 client example that buys from **any live, production** x402-protected API instead
+of a local demo server — so you can see the real 402 → pay → 200 flow end to end, against
+real infrastructure, real facilitator verification, and real settlement.
+
+This example is bring-your-own-endpoint: set `RESOURCE_URL` to whatever x402-protected API
+you want to call. To find live endpoints to try, browse
+[Coinbase Bazaar](https://docs.cdp.coinbase.com/x402/bazaar), a directory of deployed x402
+services.
 
 ## What this demonstrates
 
 Most x402 examples run against `localhost` servers started for the demo. This one targets
-a real endpoint already running in production on Base mainnet, so every step — the 402
-challenge, the payment signature, the settlement — is the real thing:
+a real, already-deployed endpoint on Base mainnet, so every step — the 402 challenge, the
+payment signature, the settlement — is the real thing:
 
 1. **Request** — the client calls the resource URL with `fetch`.
 2. **402 Payment Required** — the server returns `402` with a `PAYMENT-REQUIRED` header
@@ -19,9 +25,9 @@ challenge, the payment signature, the settlement — is the real thing:
 5. **200 OK** — the server (via its facilitator) verifies and settles the payment onchain,
    then returns the actual response body plus a `PAYMENT-RESPONSE` settlement receipt.
 
-The demo target is `https://api.stelardigital.com/pricecheck` (a live x402 API returning
-crypto price/signal data) — used here only because it's a real, working endpoint. Point
-`RESOURCE_URL` at any x402-protected API and the flow is identical.
+`.env-local` ships with one illustrative default (`https://api.stelardigital.com/pricecheck`,
+a live x402 endpoint returning crypto price/signal data) purely as a working example URL —
+swap in any live x402 endpoint via `RESOURCE_URL` and the flow is identical.
 
 ## Prerequisites
 
@@ -52,7 +58,9 @@ Required environment variables:
 
 Optional environment variables:
 
-- `RESOURCE_URL` - the x402-protected URL to call (defaults to the live demo endpoint above)
+- `RESOURCE_URL` - the x402-protected URL to call. Defaults to one illustrative live
+  endpoint; browse [Coinbase Bazaar](https://docs.cdp.coinbase.com/x402/bazaar) to find
+  others to try.
 
 3. Run the client:
 

--- a/examples/typescript/clients/live-api-buyer/README.md
+++ b/examples/typescript/clients/live-api-buyer/README.md
@@ -1,0 +1,75 @@
+# Live API Buyer Example
+
+An x402 client example that calls a **live, production** x402-protected API instead of a
+local demo server — so you can see the real 402 → pay → 200 flow end to end.
+
+## What this demonstrates
+
+Most x402 examples run against `localhost` servers started for the demo. This one targets
+a real endpoint already running in production on Base mainnet, so every step — the 402
+challenge, the payment signature, the settlement — is the real thing:
+
+1. **Request** — the client calls the resource URL with `fetch`.
+2. **402 Payment Required** — the server returns `402` with a `PAYMENT-REQUIRED` header
+   encoding the price, network, asset, and payee for this specific resource.
+3. **Sign** — `@x402/fetch`'s `wrapFetchWithPayment` decodes those requirements and has
+   the registered scheme (`ExactEvmScheme`) sign a USDC payment authorization for them.
+4. **Retry with payment** — the client retries the same request with a
+   `PAYMENT-SIGNATURE` header attached.
+5. **200 OK** — the server (via its facilitator) verifies and settles the payment onchain,
+   then returns the actual response body plus a `PAYMENT-RESPONSE` settlement receipt.
+
+The demo target is `https://api.stelardigital.com/pricecheck` (a live x402 API returning
+crypto price/signal data) — used here only because it's a real, working endpoint. Point
+`RESOURCE_URL` at any x402-protected API and the flow is identical.
+
+## Prerequisites
+
+- Node.js v20+ (install via [nvm](https://github.com/nvm-sh/nvm))
+- pnpm v10 (install via [pnpm.io/installation](https://pnpm.io/installation))
+- An EVM wallet funded with a small amount of USDC on Base mainnet (this example spends
+  real money — a few cents per request)
+
+## Setup
+
+1. Install and build all packages from the typescript examples root:
+
+```bash
+cd ../../
+pnpm install && pnpm build
+cd clients/live-api-buyer
+```
+
+2. Copy `.env-local` to `.env` and add your private key:
+
+```bash
+cp .env-local .env
+```
+
+Required environment variables:
+
+- `EVM_PRIVATE_KEY` - Ethereum private key for the wallet paying on Base mainnet
+
+Optional environment variables:
+
+- `RESOURCE_URL` - the x402-protected URL to call (defaults to the live demo endpoint above)
+
+3. Run the client:
+
+```bash
+pnpm start
+```
+
+You should see the request go out, the 402 challenge get resolved automatically, and the
+final JSON response with a settlement receipt.
+
+## Next Steps
+
+See [`fetch/`](../fetch/) for the general-purpose `@x402/fetch` example (EVM + SVM, run
+against a localhost server) and [`custom/`](../custom/) for a manual, header-by-header
+implementation of the same flow using only `@x402/core`.
+
+---
+
+**Note:** this example spends real USDC on Base mainnet. Use a wallet with a small balance
+dedicated to testing, never a wallet holding significant funds.

--- a/examples/typescript/clients/live-api-buyer/eslint.config.js
+++ b/examples/typescript/clients/live-api-buyer/eslint.config.js
@@ -1,0 +1,72 @@
+import js from "@eslint/js";
+import ts from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+import prettier from "eslint-plugin-prettier";
+import jsdoc from "eslint-plugin-jsdoc";
+import importPlugin from "eslint-plugin-import";
+
+export default [
+  {
+    ignores: ["dist/**", "node_modules/**"],
+  },
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      sourceType: "module",
+      ecmaVersion: 2020,
+      globals: {
+        process: "readonly",
+        __dirname: "readonly",
+        module: "readonly",
+        require: "readonly",
+        Buffer: "readonly",
+        exports: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly",
+      },
+    },
+    plugins: {
+      "@typescript-eslint": ts,
+      prettier: prettier,
+      jsdoc: jsdoc,
+      import: importPlugin,
+    },
+    rules: {
+      ...ts.configs.recommended.rules,
+      "import/first": "error",
+      "prettier/prettier": "error",
+      "@typescript-eslint/member-ordering": "error",
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_$" }],
+      "jsdoc/tag-lines": ["error", "any", { startLines: 1 }],
+      "jsdoc/check-alignment": "error",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/check-param-names": "error",
+      "jsdoc/check-tag-names": "error",
+      "jsdoc/check-types": "error",
+      "jsdoc/implements-on-classes": "error",
+      "jsdoc/require-description": "error",
+      "jsdoc/require-jsdoc": [
+        "error",
+        {
+          require: {
+            FunctionDeclaration: true,
+            MethodDefinition: true,
+            ClassDeclaration: true,
+            ArrowFunctionExpression: false,
+            FunctionExpression: false,
+          },
+        },
+      ],
+      "jsdoc/require-param": "error",
+      "jsdoc/require-param-description": "error",
+      "jsdoc/require-param-type": "off",
+      "jsdoc/require-returns": "error",
+      "jsdoc/require-returns-description": "error",
+      "jsdoc/require-returns-type": "off",
+      "jsdoc/require-hyphen-before-param-description": ["error", "always"],
+    },
+  },
+];

--- a/examples/typescript/clients/live-api-buyer/index.ts
+++ b/examples/typescript/clients/live-api-buyer/index.ts
@@ -10,13 +10,14 @@ const resourceUrl =
   process.env.RESOURCE_URL || "https://api.stelardigital.com/pricecheck?asset=BTC";
 
 /**
- * Example demonstrating how to call a LIVE, production x402 API from a TypeScript client.
+ * Example demonstrating how to buy from ANY live x402 endpoint with a TypeScript client.
  *
- * Unlike most x402 examples, this one does not spin up a local server — it targets a real
- * endpoint running on Base mainnet, so you see the full 402 -> pay -> 200 flow against
- * actual infrastructure instead of localhost. The demo endpoint used here
- * (api.stelardigital.com/pricecheck) is just one live x402 API among many; point
- * RESOURCE_URL at any x402-protected URL and the flow is identical.
+ * Unlike most x402 examples, this one does not spin up a local server — it targets a real,
+ * already-deployed endpoint on Base mainnet, so you see the full 402 -> pay -> 200 flow
+ * against actual infrastructure instead of localhost. RESOURCE_URL is bring-your-own: point
+ * it at any live x402-protected URL and the flow is identical. Browse Coinbase Bazaar
+ * (https://docs.cdp.coinbase.com/x402/bazaar) to discover live endpoints to try. The default
+ * below is just one illustrative example of a live endpoint.
  *
  * How it works:
  * 1. wrapFetchWithPayment sends the initial request.
@@ -33,7 +34,8 @@ const resourceUrl =
  *   Base mainnet)
  *
  * Optional environment variables:
- * - RESOURCE_URL: the x402-protected URL to call (defaults to a live demo endpoint)
+ * - RESOURCE_URL: the x402-protected URL to call (defaults to one illustrative live
+ *   endpoint; point it at any live x402 endpoint, e.g. one found via Coinbase Bazaar)
  */
 async function main(): Promise<void> {
   const evmSigner = privateKeyToAccount(evmPrivateKey);

--- a/examples/typescript/clients/live-api-buyer/index.ts
+++ b/examples/typescript/clients/live-api-buyer/index.ts
@@ -1,0 +1,60 @@
+import { config } from "dotenv";
+import { x402Client, wrapFetchWithPayment, x402HTTPClient } from "@x402/fetch";
+import { ExactEvmScheme } from "@x402/evm/exact/client";
+import { privateKeyToAccount } from "viem/accounts";
+
+config();
+
+const evmPrivateKey = process.env.EVM_PRIVATE_KEY as `0x${string}`;
+const resourceUrl =
+  process.env.RESOURCE_URL || "https://api.stelardigital.com/pricecheck?asset=BTC";
+
+/**
+ * Example demonstrating how to call a LIVE, production x402 API from a TypeScript client.
+ *
+ * Unlike most x402 examples, this one does not spin up a local server — it targets a real
+ * endpoint running on Base mainnet, so you see the full 402 -> pay -> 200 flow against
+ * actual infrastructure instead of localhost. The demo endpoint used here
+ * (api.stelardigital.com/pricecheck) is just one live x402 API among many; point
+ * RESOURCE_URL at any x402-protected URL and the flow is identical.
+ *
+ * How it works:
+ * 1. wrapFetchWithPayment sends the initial request.
+ * 2. The server responds 402 with a PAYMENT-REQUIRED header describing price, network,
+ *    and asset for this resource.
+ * 3. The registered scheme (ExactEvmScheme) signs a USDC payment authorization for that
+ *    requirement — no gas needed, the facilitator settles it — and retries the request
+ *    with a PAYMENT-SIGNATURE header.
+ * 4. The server verifies and settles the payment, then returns 200 with the real response
+ *    body and a PAYMENT-RESPONSE settlement receipt.
+ *
+ * Required environment variables:
+ * - EVM_PRIVATE_KEY: private key of the EVM wallet paying for the request (needs USDC on
+ *   Base mainnet)
+ *
+ * Optional environment variables:
+ * - RESOURCE_URL: the x402-protected URL to call (defaults to a live demo endpoint)
+ */
+async function main(): Promise<void> {
+  const evmSigner = privateKeyToAccount(evmPrivateKey);
+
+  const client = new x402Client();
+  client.register("eip155:*", new ExactEvmScheme(evmSigner));
+
+  const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+
+  console.log(`Requesting: ${resourceUrl}\n`);
+  const response = await fetchWithPayment(resourceUrl, { method: "GET" });
+  const body = await response.json();
+  console.log("Response body:", body);
+
+  const paymentResponse = new x402HTTPClient(client).getPaymentSettleResponse(name =>
+    response.headers.get(name),
+  );
+  console.log("\nSettlement:", JSON.stringify(paymentResponse, null, 2));
+}
+
+main().catch(error => {
+  console.error(error?.response?.data?.error ?? error);
+  process.exit(1);
+});

--- a/examples/typescript/clients/live-api-buyer/package.json
+++ b/examples/typescript/clients/live-api-buyer/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@x402/live-api-buyer-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts",
+    "format": "prettier -c .prettierrc --write \"**/*.{ts,js,cjs,json,md}\"",
+    "format:check": "prettier -c .prettierrc --check \"**/*.{ts,js,cjs,json,md}\"",
+    "lint": "eslint . --ext .ts --fix",
+    "lint:check": "eslint . --ext .ts"
+  },
+  "dependencies": {
+    "@x402/evm": "workspace:*",
+    "@x402/fetch": "workspace:*",
+    "dotenv": "^16.4.7",
+    "viem": "^2.39.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.24.0",
+    "@types/node": "^20.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.29.1",
+    "@typescript-eslint/parser": "^8.29.1",
+    "eslint": "^9.24.0",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-jsdoc": "^50.6.9",
+    "eslint-plugin-prettier": "^5.2.6",
+    "prettier": "3.5.2",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/examples/typescript/clients/live-api-buyer/tsconfig.json
+++ b/examples/typescript/clients/live-api-buyer/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "types": ["node"]
+  },
+  "include": ["index.ts"]
+}

--- a/examples/typescript/pnpm-lock.yaml
+++ b/examples/typescript/pnpm-lock.yaml
@@ -1258,6 +1258,55 @@ importers:
         specifier: ^5.3.0
         version: 5.9.2
 
+  clients/live-api-buyer:
+    dependencies:
+      '@x402/evm':
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/mechanisms/evm
+      '@x402/fetch':
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/http/fetch
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.6.1
+      viem:
+        specifier: ^2.39.0
+        version: 2.43.5(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.13)
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.24.0
+        version: 9.33.0
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.11
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.29.1
+        version: 8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/parser':
+        specifier: ^8.29.1
+        version: 8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2)
+      eslint:
+        specifier: ^9.24.0
+        version: 9.33.0(jiti@2.6.1)
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.33.0(jiti@2.6.1))
+      eslint-plugin-jsdoc:
+        specifier: ^50.6.9
+        version: 50.8.0(eslint@9.33.0(jiti@2.6.1))
+      eslint-plugin-prettier:
+        specifier: ^5.2.6
+        version: 5.5.4(eslint-config-prettier@10.1.8(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1))(prettier@3.5.2)
+      prettier:
+        specifier: 3.5.2
+        version: 3.5.2
+      tsx:
+        specifier: ^4.7.0
+        version: 4.20.4
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.2
+
   clients/mcp:
     dependencies:
       '@modelcontextprotocol/sdk':
@@ -8737,11 +8786,6 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.7.2:
-    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
@@ -9434,6 +9478,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   valtio@1.13.2:
@@ -10303,7 +10348,7 @@ snapshots:
   '@es-joy/jsdoccomment@0.50.2':
     dependencies:
       '@types/estree': 1.0.8
-      '@typescript-eslint/types': 8.40.0
+      '@typescript-eslint/types': 8.48.0
       comment-parser: 1.4.1
       esquery: 1.6.0
       jsdoc-type-pratt-parser: 4.1.0
@@ -16517,7 +16562,7 @@ snapshots:
       espree: 10.4.0
       esquery: 1.6.0
       parse-imports-exports: 0.2.4
-      semver: 7.7.2
+      semver: 7.7.3
       spdx-expression-parse: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -18615,8 +18660,6 @@ snapshots:
   secure-json-parse@4.1.0: {}
 
   semver@6.3.1: {}
-
-  semver@7.7.2: {}
 
   semver@7.7.3: {}
 


### PR DESCRIPTION
## What

Adds `examples/typescript/clients/live-api-buyer/`, a small `@x402/fetch`-based client example that calls a real, already-deployed x402 endpoint (Base mainnet, `exact` scheme) instead of spinning up a localhost demo server.

## Why

Every existing TypeScript client example (`fetch/`, `axios/`, `custom/`, `advanced/`) targets `http://localhost:4021` against a demo server started for the walkthrough. That's the right default for most examples, but it means a reader never actually sees the 402 -> pay -> 200 flow resolve against real infrastructure - real facilitator verification, real settlement, a real `PAYMENT-RESPONSE` receipt. This example fills that gap: it's bring-your-own-endpoint - point `RESOURCE_URL` at any live x402-protected URL and it runs the exact same flow the other examples demonstrate, just against something that's actually deployed. The README points readers to [Coinbase Bazaar](https://docs.cdp.coinbase.com/x402/bazaar) to discover live endpoints to try.

`.env-local` ships with one illustrative default (`https://api.stelardigital.com/pricecheck`) purely as a working example URL to run against out of the box - any live x402 endpoint works identically.

## Notes for reviewers

- Structurally this mirrors `clients/fetch/`, scoped down to a single `ExactEvmScheme` registration since the illustrative endpoint only advertises the `exact` scheme on `eip155:8453` (no SVM needed, keeps the example minimal).
- Verified: lint (`eslint . --ext .ts`) and `prettier --check` pass. Also ran the client against the live default endpoint with an unfunded throwaway wallet to confirm the full request -> 402 -> decode -> sign -> retry flow executes correctly end-to-end (it correctly reaches the facilitator's verify step and fails only on insufficient balance, as expected for an unfunded test key).
- Was not able to fully build/typecheck the whole workspace locally (`pnpm build` at the `typescript/` root) - the DTS generation step for `@x402/core` and `@x402/evm` OOMs on the available build memory. `eslint`, `prettier`, and a `--no-dts` JS-only build all succeeded, and the compiled example was run live as described above, but a full `tsc --noEmit` against the built `.d.ts` output wasn't possible in this environment. Happy to have CI double check or to rerun with more memory if that's a concern.
- Majority of this PR (code + docs) was written with AI assistance (Claude), reviewed and tested against a live endpoint before opening this as ready for review. Flagging per the AI-assisted contribution guidance in CONTRIBUTING.md.
- Open to feedback on the framing - happy to adjust the illustrative default endpoint, generalize further, or fold this into an existing example directory if that's preferred over a new one.
