### PR TITLE
Add Levels of Self to ecosystem (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/levelsofself/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/levelsofself/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Levels of Self",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/levelsofself.png",
+  "description": "External governance layer for agent systems. Live x402 services on Base: MCP config governance audits, agent-stack legal prep, bookkeeping, and a half-cent payment self-test with signed receipts. Self-hosted facilitator, USDC settlement.",
+  "websiteUrl": "https://www.levelsofself.com"
+}

--- a/typescript/site/public/logos/levelsofself.png
+++ b/typescript/site/public/logos/levelsofself.png
@@ -1,0 +1,1 @@
+Forbidden


### PR DESCRIPTION
Adds Levels of Self to the ecosystem page under Services/Endpoints.

Live x402 v2 services on Base (self-hosted facilitator, USDC): MCP config governance audits, agent-stack legal prep, bookkeeping, and a $0.005 payment self-test with signed receipts. Endpoints at https://api.100levelup.com (OpenAPI + llms.txt on origin). Listed on x402scan and 402index; first settlement on-chain: https://basescan.org/tx/0x074923be0230057e8adc394609471682dd290d49da63db9d300568f398a84322

metadata.json follows the existing partners-data schema; 512x512 logo included.