### PR TITLE
Add Countersign to the ecosystem (Infrastructure & Tooling)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/countersign/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/countersign/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Countersign",
+  "description": "Spend governance for agents that pay over x402: parse a 402 challenge, check it against policy before paying (caps, allowlists, decoy-resistant asset pinning), pay only on allow — with a sub-second kill switch and a signed audit ledger behind it.",
+  "logoUrl": "/logos/countersign.svg",
+  "websiteUrl": "https://countersign.network/docs/x402.html",
+  "category": "Infrastructure & Tooling"
+}

--- a/typescript/site/public/logos/countersign.svg
+++ b/typescript/site/public/logos/countersign.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="7" fill="#07080b"/><path d="M16 6 L25 10 V17 C25 22 21 25.5 16 27 C11 25.5 7 22 7 17 V10 Z" fill="none" stroke="#7c9cff" stroke-width="2"/><path d="M12.5 16.5 l2.5 2.5 l5 -6" fill="none" stroke="#5cf2a9" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>


### PR DESCRIPTION
Adds **Countersign** to the ecosystem page under Infrastructure & Tooling, per the site README's submission instructions (metadata.json + logo).

**What it is:** spend governance for AI agents that pay over x402 — a neutral control plane holding one declarative policy (per-tx/daily caps, allow/denylists), a pre-flight guard that checks each 402 charge against policy before payment (`@countersign/x402`: decimals-normalized option selection, decoy-resistant asset pinning), a sub-second cross-vendor kill switch, and an append-only signed audit ledger of every allow/deny.

**x402 relevance:** `parseX402` → `withX402Guard` wraps the pay step so an agent only pays a 402 challenge its policy allows; the same guard is exposed as an MCP tool (`countersign_guard_x402`). Docs: https://countersign.network/docs/x402.html · Apache-2.0 open core: https://github.com/countersign-network/packages

Testnet-only today; no custody. Happy to adjust category or copy to fit.