### PR TITLE
feat(evm): add Celo to default stablecoin registry

### DIFF
--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -79,6 +79,8 @@ var (
 	ChainIDPolygon       = big.NewInt(137)
 	ChainIDArbOne        = big.NewInt(42161)
 	ChainIDArbSepolia    = big.NewInt(421614)
+	ChainIDCelo          = big.NewInt(42220)
+	ChainIDCeloSepolia   = big.NewInt(11142220)
 
 	// Network configurations
 	// See DEFAULT_ASSET.md for guidelines on adding new chains
@@ -192,6 +194,26 @@ var (
 			DefaultAsset: AssetInfo{
 				Address:  "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d", // USDC on ArbSepolia
 				Name:     "USD Coin",
+				Version:  "2",
+				Decimals: DefaultDecimals,
+			},
+		},
+		// Celo Mainnet
+		"eip155:42220": {
+			ChainID: ChainIDCelo,
+			DefaultAsset: AssetInfo{
+				Address:  "0xcebA9300f2b948710d2653dD7B07f33A8B32118C", // USDC on Celo
+				Name:     "USDC",
+				Version:  "2",
+				Decimals: DefaultDecimals,
+			},
+		},
+		// Celo Sepolia Testnet
+		"eip155:11142220": {
+			ChainID: ChainIDCeloSepolia,
+			DefaultAsset: AssetInfo{
+				Address:  "0x01C5C0122039549AD1493B8220cABEdD739BC44E", // USDC on Celo Sepolia
+				Name:     "USDC",
 				Version:  "2",
 				Decimals: DefaultDecimals,
 			},

--- a/python/x402/mechanisms/evm/constants.py
+++ b/python/x402/mechanisms/evm/constants.py
@@ -504,6 +504,26 @@ NETWORK_CONFIGS: dict[str, NetworkConfig] = {
             "decimals": 6,
         },
     },
+    # Celo Mainnet
+    "eip155:42220": {
+        "chain_id": 42220,
+        "default_asset": {
+            "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+            "name": "USDC",
+            "version": "2",
+            "decimals": 6,
+        },
+    },
+    # Celo Sepolia (Testnet)
+    "eip155:11142220": {
+        "chain_id": 11142220,
+        "default_asset": {
+            "address": "0x01C5C0122039549AD1493B8220cABEdD739BC44E",
+            "name": "USDC",
+            "version": "2",
+            "decimals": 6,
+        },
+    },
 }
 
 # V1 legacy constants are in x402.mechanisms.evm.v1.constants

--- a/typescript/.changeset/add-celo-default-assets.md
+++ b/typescript/.changeset/add-celo-default-assets.md
@@ -1,0 +1,5 @@
+---
+"@x402/evm": patch
+---
+
+Added Celo mainnet (`eip155:42220`) and Celo Sepolia (`eip155:11142220`) to the default stablecoin registry, using USDC as the default asset (EIP-712 domain `name: "USDC"`, `version: "2"`, 6 decimals, EIP-3009).

--- a/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
+++ b/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
@@ -105,6 +105,18 @@ export const DEFAULT_STABLECOINS: Record<string, ExactDefaultAssetInfo> = {
     assetTransferMethod: "permit2",
     supportsEip2612: true,
   }, // Mezo Testnet mUSD (no EIP-3009, supports EIP-2612)
+  "eip155:42220": {
+    address: "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+    name: "USDC",
+    version: "2",
+    decimals: 6,
+  }, // Celo mainnet USDC
+  "eip155:11142220": {
+    address: "0x01C5C0122039549AD1493B8220cABEdD739BC44E",
+    name: "USDC",
+    version: "2",
+    decimals: 6,
+  }, // Celo Sepolia USDC
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds **Celo** to the default stablecoin registry across all three SDKs, following the process in [`DEFAULT_ASSETS.md`](https://github.com/coinbase/x402/blob/main/DEFAULT_ASSETS.md):

- **Celo mainnet** — `eip155:42220`
- **Celo Sepolia** (testnet) — `eip155:11142220`

Default asset is **USDC** on both, matching how Base/Polygon/Arbitrum are registered.

| Network | USDC address | EIP-712 `name` | `version` | decimals | transfer |
|---|---|---|---|---|---|
| Celo mainnet (42220) | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` | `USDC` | `2` | 6 | EIP-3009 |
| Celo Sepolia (11142220) | `0x01C5C0122039549AD1493B8220cABEdD739BC44E` | `USDC` | `2` | 6 | EIP-3009 |

## Files changed (per the Cross-SDK Checklist)

- `typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts` — `DEFAULT_STABLECOINS`
- `go/mechanisms/evm/constants.go` — `NetworkConfigs` (+ `ChainIDCelo` / `ChainIDCeloSepolia`)
- `python/x402/mechanisms/evm/constants.py` — `NETWORK_CONFIGS`
- `typescript/.changeset/add-celo-default-assets.md` — changeset (`@x402/evm` patch)

## Verification

The EIP-712 domain values are the part that must be exactly right (wrong `name`/`version` silently breaks EIP-3009 signature verification), so they were confirmed **on-chain** rather than assumed:

- `name()` / `version()` / `decimals()` read directly from both USDC contracts → `"USDC"`, `"2"`, `6`.
- Reconstructed each contract's `DOMAIN_SEPARATOR` from `name="USDC"`, `version="2"`, `chainId`, `verifyingContract` and confirmed it **matches the on-chain `DOMAIN_SEPARATOR()`** byte-for-byte.
- Both contracts implement EIP-3009 `transferWithAuthorization` (no Permit2 fallback needed).
- Addresses are checksum-valid in all three files.

There is a live x402 facilitator running on Celo (mainnet + Sepolia) that settles USDC/USDT via EIP-3009, so these defaults are in active use.

## Tests

- **Go**: `go test ./mechanisms/evm/` → `ok`
- **TypeScript**: `pnpm --filter @x402/evm build` + `test` → builds clean, **341 tests pass**
- **Python**: module parses; entries present in `NETWORK_CONFIGS`

## Rationale for asset selection

USDC is the natural default for Celo: it's a native (not bridged) EIP-3009 deployment on both mainnet and Sepolia, 6 decimals, and is the asset the Celo x402 facilitator already settles. (Celo USDT also supports EIP-3009 but uses a different domain — `name: "Tether USD"`, `version: "1"` — so USDC is the cleaner single default; USDT can be added later if desired.)

## AI usage disclosure

Per CONTRIBUTING.md: this PR was prepared with significant AI assistance (Claude). All addresses and EIP-712 domain values were verified on-chain as described above, and the SDK test suites were run locally — but reviewers may still wish to double-check the domain values against the contracts.
