### PR TITLE
ecosystem: add eltociear Security APIs (tokenguard, skill-audit, contract-guard)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/eltociear-security-apis/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/eltociear-security-apis/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "eltociear Security APIs",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/eltociear-security-apis.svg",
+  "description": "Three pay-per-call security endpoints for the agent economy, settled in USDC on Base via x402 (no signup — your agent's wallet pays per call). skill-audit: scans AI agent skills, plugins, and prompts for malicious patterns. tokenguard: heuristic ERC-20 rug/safety check over public RPC, flagging mint/blacklist/tax/proxy powers a token owner can use. contract-guard: pre-interaction risk signals for any EVM contract or token address. Deterministic checks, machine-readable JSON responses.",
+  "websiteUrl": "https://eltociear-tokenguard.hf.space"
+}

--- a/typescript/site/public/logos/eltociear-security-apis.svg
+++ b/typescript/site/public/logos/eltociear-security-apis.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256" role="img" aria-label="eltociear Security APIs">
+  <rect width="256" height="256" rx="48" fill="#0B1020"/>
+  <path d="M128 40 L196 68 V128 C196 172 166 200 128 216 C90 200 60 172 60 128 V68 Z"
+        fill="none" stroke="#3DD68C" stroke-width="10" stroke-linejoin="round"/>
+  <path d="M100 130 L120 150 L160 104" fill="none" stroke="#3DD68C" stroke-width="12"
+        stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="128" y="244" text-anchor="middle" font-family="Arial, Helvetica, sans-serif"
+        font-size="26" font-weight="700" fill="#E6EDF3">eltociear</text>
+</svg>


### PR DESCRIPTION
Adds a **Services/Endpoints** ecosystem entry for three live, pay-per-call x402 APIs (USDC on Base — no signup, the calling agent's wallet is the auth):

- **tokenguard** — heuristic ERC-20 rug/safety scan over public RPC (flags mint / blacklist / pausable / tax / upgradeable-proxy / ownership powers a token owner *can* use) plus wallet-intel and price endpoints. $0.005/call.
- **skill-audit** — scans AI agent skills, plugins, and prompts for malicious patterns (68-pattern scanner). $0.01/call, $0.03 for fetch-URL-and-audit.
- **contract-guard** — pre-interaction risk signals for any EVM contract/token address. $0.005/call.

All three return deterministic, machine-readable JSON and are live behind a valid HTTP 402 handshake (Dexter facilitator, 0% fee). Includes an SVG logo.

_Supersedes #211, which was accidentally closed when its branch was recreated; this version also adds the logo asset that #211 was missing._
