### PR TITLE
Add AgentFeed to ecosystem (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/agentfeed/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/agentfeed/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "AgentFeed",
+  "description": "Live crypto market data for AI agents: liquidations across ~600 USDT perps, funding rates, positioning, spot prices and token rug-risk. Paid per call in USDC via x402 on Solana and Base. No API keys, no signup. Also available as an MCP server and an elizaOS plugin.",
+  "logoUrl": "/logos/agentfeed.svg",
+  "websiteUrl": "https://x402.ochinimus.app",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/agentfeed.svg
+++ b/typescript/site/public/logos/agentfeed.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="AgentFeed">
+  <rect width="64" height="64" rx="14" fill="#12141A"/>
+  <!-- liquidation tape: shorts above the line, longs below -->
+  <rect x="14" y="20" width="3.5" height="10" rx="1.5" fill="#5CD6A6"/>
+  <rect x="21" y="14" width="3.5" height="16" rx="1.5" fill="#5CD6A6"/>
+  <rect x="28" y="24" width="3.5" height="6"  rx="1.5" fill="#5CD6A6"/>
+  <rect x="35" y="17" width="3.5" height="13" rx="1.5" fill="#5CD6A6"/>
+  <rect x="42" y="22" width="3.5" height="8"  rx="1.5" fill="#5CD6A6"/>
+  <rect x="12" y="31" width="40" height="1.6" rx="0.8" fill="#3A414C"/>
+  <rect x="14" y="34" width="3.5" height="7"  rx="1.5" fill="#FF7A59"/>
+  <rect x="21" y="34" width="3.5" height="12" rx="1.5" fill="#FF7A59"/>
+  <rect x="28" y="34" width="3.5" height="16" rx="1.5" fill="#FF7A59"/>
+  <rect x="35" y="34" width="3.5" height="9"  rx="1.5" fill="#FF7A59"/>
+  <rect x="42" y="34" width="3.5" height="5"  rx="1.5" fill="#FF7A59"/>
+</svg>


### PR DESCRIPTION
Adds AgentFeed under Services/Endpoints.

AgentFeed is a live crypto market data API for agents, paid per call in USDC via x402 —
on Solana (exact/SVM, CDP facilitator) and Base (exact/EVM, eip155:8453). No API keys.

Meets the Services/Endpoints requirements:
- Working mainnet integration: 15 paid routes settling real USDC on Solana mainnet and Base.
- API documentation: full route catalog with per-call pricing at https://x402.ochinimus.app
- Bazaar discovery metadata is live, so the routes are machine-discoverable.

Also shipped as an MCP server and as @seekdaseek/plugin-agentfeed on npm (merged upstream
into elizaOS).

Source: https://github.com/seekdaseek/agentfeed