### PR TITLE
feat: add BountyTruth to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/bountytruth/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/bountytruth/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "BountyTruth",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/bountytruth.svg",
+  "description": "A five-cent Base USDC x402 API that audits public GitHub bounty issues for stale status, claimant signals, competing pull requests, and solver saturation.",
+  "websiteUrl": "https://sparky-works.vercel.app/bounty-truth"
+}

--- a/typescript/site/public/logos/bountytruth.svg
+++ b/typescript/site/public/logos/bountytruth.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">BountyTruth</title>
+  <desc id="desc">A stamped bounty document with a check mark.</desc>
+  <rect width="512" height="512" rx="72" fill="#f5f0df"/>
+  <rect x="54" y="54" width="404" height="404" rx="38" fill="#fffaf0" stroke="#1d1b16" stroke-width="18"/>
+  <rect x="92" y="92" width="328" height="74" rx="12" fill="#b8ff2c" stroke="#1d1b16" stroke-width="10"/>
+  <text x="256" y="140" text-anchor="middle" font-family="monospace" font-size="35" font-weight="700" fill="#1d1b16">BOUNTY TRUTH</text>
+  <path d="M122 238h188M122 290h136M122 342h96" stroke="#1d1b16" stroke-width="18" stroke-linecap="round"/>
+  <path d="M295 326l42 42 78-106" fill="none" stroke="#ff6b2d" stroke-width="28" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="91" y="390" width="180" height="48" rx="8" fill="#1d1b16"/>
+  <text x="181" y="422" text-anchor="middle" font-family="monospace" font-size="24" font-weight="700" fill="#fffaf0">x402 · 5¢</text>
+</svg>


### PR DESCRIPTION
## Summary

- add BountyTruth to the Services/Endpoints ecosystem category
- add a square SVG logo and link to the live API documentation

## Verification

- documentation page returns HTTP 200: https://sparky-works.vercel.app/bounty-truth
- production endpoint returns an x402 v2 HTTP 402 contract for 0.05 Base USDC
- paid mainnet smoke settled successfully: https://basescan.org/tx/0x2bfdaaa26c27e086acfce4cdd5cad7dd08e282b85abe5f65c2b41c85155061ef
- metadata JSON parses, SVG parses, and `git diff --check` passes

## AI usage

This submission and logo were produced with significant AI assistance and verified against the live service and on-chain receipt before opening this draft.
