### PR TITLE
ecosystem: add DeFi Signal API (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/defi-signal-api/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/defi-signal-api/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "DeFi Signal API",
+  "description": "Live DeFi intelligence for AI agents — PoolTogether draw data, Morpho/Aave liquidation signals, cross-protocol yield comparisons, and funding-rate arbitrage radar. Pay per call in USDC on Base.",
+  "logoUrl": "/logos/defi-signal-api.png",
+  "websiteUrl": "https://wazir-x402.duckdns.org",
+  "category": "Services/Endpoints"
+}


### PR DESCRIPTION
## What

Adds **DeFi Signal API** to the x402 ecosystem as a Services/Endpoints entry.

## Service description

Live DeFi intelligence for AI agents, pay-per-call in USDC on Base mainnet:

- **PoolTogether draw data** — next draw schema, prize pool, timing for Base/Arb/OP/Scroll
- **Morpho/Aave liquidation signals** — cross-protocol yield comparisons and liquidation radar
- **Funding-rate arbitrage radar** — live perp funding rates across venues

**Endpoint:** `https://wazir-x402.duckdns.org/api/pt-next`
**Payment:** 0.001 USDC per call, Base mainnet (eip155:8453)
**x402 version:** 2
**Facilitator:** CDP (with on-chain exact EIP-3009 fallback)

## Verified live

```
curl -s https://wazir-x402.duckdns.org/api/pt-next
# → 402 Payment Required with x402v2 + extensions.bazaar
```

CDP validate: all 26 checks pass.