### PR TITLE
ecosystem: add dex-data (multi-chain DEX market data over x402)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/dex-data/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/dex-data/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "dex-data",
+  "description": "Live multi-chain DEX market data over x402: USD price for any ERC-20 by ticker or contract address, per-venue liquidity depth, raw pool reserves, best execution venue, liquidity-risk depth class and pre-trade price impact across BNB Chain, Polygon, Arbitrum, Base and Avalanche. Free tier needs no wallet; beyond it, x402 micropayments in USDC on Base. Also available as an MCP server.",
+  "logoUrl": "/logos/dex-data.svg",
+  "websiteUrl": "https://x402.donnyautomation.com/llms.txt",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/dex-data.svg
+++ b/typescript/site/public/logos/dex-data.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="dex-data">
+  <title>dex-data</title>
+  <rect width="64" height="64" rx="14" fill="#0B1220"/>
+  <!-- depth bars: the product is liquidity depth across venues -->
+  <rect x="13" y="36" width="7" height="15" rx="2" fill="#3B82F6"/>
+  <rect x="24" y="27" width="7" height="24" rx="2" fill="#60A5FA"/>
+  <rect x="35" y="19" width="7" height="32" rx="2" fill="#93C5FD"/>
+  <rect x="46" y="30" width="7" height="21" rx="2" fill="#3B82F6"/>
+  <!-- price line across them -->
+  <path d="M13 30 L28 22 L39 14 L51 24" fill="none" stroke="#F59E0B" stroke-width="3"
+        stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Adds **dex-data** to the ecosystem page under `Services/Endpoints`.

Live multi-chain DEX market data behind an x402 paywall: USD price for any
ERC-20 by ticker or contract address, per-venue liquidity depth, raw pool
reserves, best execution venue, liquidity-risk depth class, and pre-trade price
impact for a specific trade size — across BNB Chain, Polygon, Arbitrum, Base and
Avalanche.

- 30 paid routes, all listed in the CDP Bazaar under
  `payTo=0x2740651e046c59aB2A6510401140643292d3a96F`
- x402 V2, USDC on Base, CDP facilitator
- Free tier requires no wallet, so an agent can evaluate before paying
- `https://x402.donnyautomation.com/llms.txt` documents the free and paid routes
- MCP server: `npx -y github:donnywin85/dex-data-mcp`

Followed the instructions in `typescript/site/README.md`: metadata under
`app/ecosystem/partners-data/dex-data/`, logo added to `public/logos/` as SVG
(39 existing entries use SVG). `metadata.json` validated as parseable and the
category matches one of the four documented values.