### PR TITLE
Add eucompliance.tools to the ecosystem page

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/eucompliance-tools/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/eucompliance-tools/metadata.json
@@ -2,6 +2,6 @@
   "name": "eucompliance.tools",
   "category": "Services",
   "logoUrl": "/logos/eucompliance-tools.png",
-  "description": "EU compliance and on-chain pre-flight checks, priced per call. Transaction pre-flight (gas, simulation with decoded revert reason, stuck nonces, allowance, sanctions screen of the counterparty), ERC-20 allowance and balance on five chains, transaction status with revert reason, plus sanctions screening (EU/UN/UK), VAT ID and IBAN validation, EU VAT treatment with EN 16931 codes, e-invoice validation and agent spend bookkeeping. From $0.002 per call, no account. Every answer carries an EIP-191 signed receipt that verifies offline. Also an MCP server.",
+  "description": "EU compliance and on-chain pre-flight checks, priced per call. Transaction pre-flight (gas, simulation with decoded revert reason, stuck nonces, allowance, sanctions screen of the counterparty), ERC-20 allowance and balance on five chains, transaction status with revert reason, plus sanctions screening (EU/UN/UK), VAT ID and IBAN validation, EU VAT treatment with EN 16931 codes, e-invoice validation and agent spend bookkeeping. From $0.002 per call, no account. Every answer carries an EIP-191 signed receipt that verifies offline. Also an MCP server. Operated from Vienna, Austria.",
   "websiteUrl": "https://eucompliance.tools"
 }

--- a/typescript/site/app/ecosystem/partners-data/eucompliance-tools/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/eucompliance-tools/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "eucompliance.tools",
+  "category": "Services",
+  "logoUrl": "/logos/eucompliance-tools.png",
+  "description": "EU compliance and on-chain pre-flight checks, priced per call. Transaction pre-flight (gas, simulation with decoded revert reason, stuck nonces, allowance, sanctions screen of the counterparty), ERC-20 allowance and balance on five chains, transaction status with revert reason, plus sanctions screening (EU/UN/UK), VAT ID and IBAN validation, EU VAT treatment with EN 16931 codes, e-invoice validation and agent spend bookkeeping. From $0.002 per call, no account. Every answer carries an EIP-191 signed receipt that verifies offline. Also an MCP server.",
+  "websiteUrl": "https://eucompliance.tools"
+}


### PR DESCRIPTION
Adds an entry under **Services** for `eucompliance.tools`.

## What it is

Compliance and pre-transaction checks priced per call over x402 (`exact`, `eip155:8453`, USDC), from **$0.002**, no account and no API key. Also exposed as an MCP server.

The set that is probably most relevant to this ecosystem is the on-chain pre-flight group, because it addresses a failure mode every paying agent hits:

- **Pre-flight** — one call answers whether a transaction will go through: native balance vs. estimated gas, a full simulation with the **revert reason decoded into plain text**, stuck pending nonces, whether the recipient is a contract or a wallet, ERC-20 allowance for the amount, and a sanctions screen of the counterparty. Returns `send` / `do not send` with every blocking reason.
- **Transaction status** — what happened, and if it failed, *why*, recovered by replaying the call against the block it was mined in. The receipt alone does not carry that reason.
- **Allowance & balance** — Base, Ethereum, Arbitrum, Optimism, Polygon.

Plus the EU compliance side: sanctions screening (EU/UN/UK, re-indexed daily), VAT ID validation against VIES, IBAN, counterparty due diligence with GLEIF LEI, EU VAT treatment with EN 16931 codes, e-invoice validation, and bookkeeping for an agent'"'"'s own USDC spending (chain → EUR at the ECB rate of the payment date → CSV).

## Notes for review

- Every response carries an EIP-191 signed receipt with the result hash. Verification is offline and needs no trust in us: `pip install eucompliance-verify` ([MIT source](https://github.com/PatrickPi1312/eucompliance-verify)).
- Discovery at `/.well-known/x402` and `/llms.txt`; already listed in the Bazaar and the MCP registry.
- Free to try without signing up: `curl "https://api.eucompliance.tools/free/vat-rules?supplier=AT&customer=DE&b2b=true&type=service"`
- Operated as an Austrian sole proprietorship with a VAT ID, so an ordinary invoice is possible alongside per-call USDC.

I could not add a logo file in this PR — happy to follow up with one in the convention used under `typescript/site/public/logos/`, or to drop the `logoUrl` field if an entry without a logo is preferred.
