### PR TITLE
Add VDM Nexus to ecosystem (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/vdm-nexus/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/vdm-nexus/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "VDM Nexus",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/vdm-nexus.svg",
+  "description": "Signed-inference rail for autonomous agents: pay-per-call, OpenAI-compatible LLM access via x402 on Solana and Base. Every response carries an Ed25519-signed receipt that anyone can re-verify.",
+  "websiteUrl": "https://vdmnexus.com"
+}

--- a/typescript/site/public/logos/vdm-nexus.svg
+++ b/typescript/site/public/logos/vdm-nexus.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" role="img" aria-label="VDM Nexus">
+  <!-- guardrails: the two fixed limits the agent operates between -->
+  <path d="M7 6.5V25.5" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+  <path d="M25 6.5V25.5" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+  <!-- the rein: a line under tension, passing through the node -->
+  <path d="M7 6.5C9.6 10 11.2 12.2 12.6 13.9" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+  <path d="M19.4 18.1C20.8 19.8 22.4 22 25 25.5" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+  <!-- the nexus: where the decision happens, and where it gets signed -->
+  <circle cx="16" cy="16" r="3.4" stroke="currentColor" stroke-width="2.6"/>
+</svg>


### PR DESCRIPTION
Adds VDM Nexus to the ecosystem directory under Services/Endpoints.

VDM Nexus is a signed-inference rail for autonomous agents: pay-per-call, OpenAI-compatible LLM access via x402 on Solana mainnet and Base mainnet (plus devnet/Sepolia). Every response carries an Ed25519-signed SIR v2 receipt that anyone can re-verify against the operator key — so an agent's inference history is provable, not claimed.

- Endpoint: https://nexus.vdmnexus.com/api/v1/chat/completions (x402 challenge on unpaid requests)
- Docs: https://docs.vdmnexus.com
- Receipt verification: https://verify.vdmnexus.com
- Receipt spec: https://docs.vdmnexus.com/docs/spec/sir-v2

Two files: partners-data/vdm-nexus/metadata.json + logo SVG, following the existing format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)