### PR TITLE
Fail loudly when toClientEvmSigner gets a signer without an address

### DIFF
--- a/typescript/.changeset/tidy-buses-check.md
+++ b/typescript/.changeset/tidy-buses-check.md
@@ -1,0 +1,5 @@
+---
+"@x402/evm": patch
+---
+
+Made toClientEvmSigner resolve a hoisted account's address and throw a descriptive error when the signer has no address, instead of silently building payment authorizations for address "undefined" when handed a viem WalletClient

--- a/typescript/packages/mechanisms/evm/src/signer.ts
+++ b/typescript/packages/mechanisms/evm/src/signer.ts
@@ -140,10 +140,25 @@ export function toClientEvmSigner(
     estimateFeesPerGas?(): Promise<{ maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }>;
   },
 ): ClientEvmSigner {
+  // A viem WalletClient satisfies this shape structurally but keeps its
+  // address one level down at client.account.address, so copying
+  // signer.address blindly builds a payment authorization for address
+  // "undefined" and the failure only surfaces later, deep in payload
+  // creation, as a confusing viem InvalidAddressError. Resolve the
+  // hoisted-account shape, and fail loudly here when no address exists.
+  const address =
+    signer.address ??
+    (signer as { account?: { address?: `0x${string}` } }).account?.address;
+  if (!address) {
+    throw new Error(
+      "toClientEvmSigner: signer has no address. If you are passing a viem WalletClient, pass an account-shaped signer instead - e.g. { address, signTypedData: msg => walletClient.signTypedData({ account: address, ...msg }) } - or a LocalAccount from privateKeyToAccount().",
+    );
+  }
+
   const readContract = signer.readContract ?? publicClient?.readContract.bind(publicClient);
 
   const result: ClientEvmSigner = {
-    address: signer.address,
+    address,
     signTypedData: msg => signer.signTypedData(msg),
   };
 

--- a/typescript/packages/mechanisms/evm/test/unit/signer.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/signer.test.ts
@@ -41,6 +41,26 @@ describe("EVM Signer Converters", () => {
       expect(result.address).toBe(mockAccount.address);
       expect(result.readContract).toBeUndefined();
     });
+
+    it("should resolve the address from a hoisted account (viem WalletClient shape)", () => {
+      const walletClientLike = {
+        account: { address: "0x1234567890123456789012345678901234567890" as `0x${string}` },
+        signTypedData: async () => "0xsignature" as `0x${string}`,
+      };
+
+      const result = toClientEvmSigner(walletClientLike as unknown as ClientEvmSigner);
+      expect(result.address).toBe(walletClientLike.account.address);
+    });
+
+    it("should throw a descriptive error when the signer has no address at all", () => {
+      const addressless = {
+        signTypedData: async () => "0xsignature" as `0x${string}`,
+      };
+
+      expect(() => toClientEvmSigner(addressless as unknown as ClientEvmSigner)).toThrow(
+        /signer has no address/,
+      );
+    });
   });
 
   describe("toFacilitatorEvmSigner", () => {


### PR DESCRIPTION
## Summary

`toClientEvmSigner` copies `signer.address` without checking it exists. A viem
`WalletClient` satisfies the parameter shape structurally (it has
`signTypedData`), but a WalletClient keeps its address one level down at
`client.account.address` — so the composed signer silently carries
`address: undefined`, and every payment authorization is built for the literal
address `"undefined"`. The failure only surfaces much later, deep in payload
creation, as:

```
Failed to create payment payload: Address "undefined" is invalid.
- Address must be a hex value of 20 bytes (40 hex characters).
Version: viem@2.55.10
```

Nothing in that error points back at the real mistake, which makes this an
expensive footgun for anyone wiring a browser wallet into an x402 client. We
hit it in production integrating the payment flow of an x402 seller site
(every Node client passes a `LocalAccount`, which has `.address`, so only the
browser path broke) and the diagnosis took far longer than the fix.

## Change

- Resolve the hoisted-account shape: `signer.address ?? signer.account?.address`,
  so a WalletClient with a hoisted account now composes correctly.
- If no address can be resolved at all, throw at composition time with an
  error that names the problem and shows the account-shaped alternative,
  instead of deferring the failure to payload creation.

No API change for existing callers: a `LocalAccount` or any signer with a
top-level `address` behaves exactly as before.

## Tests

Two cases added to `test/unit/signer.test.ts`: the WalletClient-like shape
resolves its hoisted address, and an addressless signer throws with the
descriptive message. Changeset included (`@x402/evm`: patch).
