### PR TITLE
Add AG Pay Server to x402 ecosystem partners (ag-pay)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/ag-pay/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/ag-pay/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "AG Pay Server",
+  "description": "Hermes + NVIDIA NIM AI endpoints, paid per request via x402 on Base mainnet (eip155:8453) through the PayAI facilitator. Three endpoints: /api/chat ($0.01) quick conversational replies, /api/reason ($0.02) deep structured chain-of-thought analysis for agent-builders, /api/review ($0.05) AI code review returning structured JSON. Free /health and / for directory listings and uptime monitors.",
+  "logoUrl": "/logos/ag-pay.png",
+  "websiteUrl": "https://ivory-gradually-collaborative-fingers.trycloudflare.com",
+  "category": "Services/Endpoints"
+}


### PR DESCRIPTION
## AG Pay Server - monetized AI endpoints via x402

Adds `ag-pay` to the x402 ecosystem directory. A self-hosted Hermes + NVIDIA NIM (minimax-m3) pay-per-request server settling through the PayAI facilitator on Base mainnet (eip155:8453).

### Endpoints
- **POST /api/chat** ($0.01) - quick conversational replies
- **POST /api/reason** ($0.02) - deep structured chain-of-thought analysis for agent pipelines
- **POST /api/review** ($0.05) - AI code review returning structured JSON (0-10 score + top-5 issues by security/quality/performance/style)

Free `/health` and `/` for directory listings and uptime monitors.

### x402 compliance
- 402 responses with payment options on first request
- PayAI facilitator (https://facilitator.payai.network) for settlement
- Exact server scheme (ExactEvmServerScheme) on Base mainnet

Self-hosted on Ubuntu. Public URL: https://ivory-gradually-collaborative-fingers.trycloudflare.com
