### PR TITLE
Add stipend.sh to the ecosystem (Client-Side Integrations)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/stipend-sh/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/stipend-sh/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "stipend.sh",
+  "description": "A non-custodial USDC wallet on Base that an AI agent installs by itself, with spending limits enforced in the signing path rather than in a prompt.",
+  "logoUrl": "/logos/stipend-sh.svg",
+  "websiteUrl": "https://stipend.sh",
+  "category": "Client-Side Integrations"
+}

--- a/typescript/site/public/logos/stipend-sh.svg
+++ b/typescript/site/public/logos/stipend-sh.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="256" height="256" role="img" aria-label="stipend.sh">
+  <title>stipend.sh</title>
+  <desc>Square brackets enclosing a ring: the zero of HTTP 402, bounded.</desc>
+  <path d="M22 8H10v48h12" fill="none" stroke="#16a34a" stroke-width="8" stroke-linecap="square"/>
+  <circle cx="32" cy="32" r="13" fill="none" stroke="#16a34a" stroke-width="8"/>
+  <path d="M42 8h12v48H42" fill="none" stroke="#16a34a" stroke-width="8" stroke-linecap="square"/>
+</svg>


### PR DESCRIPTION
Adding stipend.sh under Client-Side Integrations.

stipend.sh is a non-custodial USDC wallet on Base built so an AI agent can install it without a human opening a developer account first. The key is generated on the agent's own machine and never leaves it, and spending limits — per transaction, per day, per counterparty, plus a destination allowlist — are enforced in code between the decision and the signature, rather than written in a prompt the agent could be argued out of.

It pays 402s automatically via `x402.fetch()`, and it sells gas credits at `https://stipend.sh/api/topup` so an agent holding no ETH can still send.

Source: https://github.com/stipend-sh/stipend — Apache-2.0. Not audited, and the listing says so.

Logo is a single-colour SVG so it renders on either background.