### PR TITLE
fix: validate Bazaar schema formats

### DIFF
--- a/typescript/.changeset/validate-bazaar-schema-formats.md
+++ b/typescript/.changeset/validate-bazaar-schema-formats.md
@@ -1,0 +1,5 @@
+---
+"@x402/extensions": patch
+---
+
+Validate standard JSON Schema formats in Bazaar discovery declarations.

--- a/typescript/packages/extensions/package.json
+++ b/typescript/packages/extensions/package.json
@@ -47,6 +47,7 @@
     "@scure/base": "^1.2.6",
     "@x402/core": "workspace:~",
     "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "jose": "^5.9.6",
     "@signinwithethereum/siwe": "^4.1.0",
     "tweetnacl": "^1.0.3",

--- a/typescript/packages/extensions/src/bazaar/facilitator.ts
+++ b/typescript/packages/extensions/src/bazaar/facilitator.ts
@@ -8,6 +8,7 @@
  */
 
 import Ajv from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
 import type { PaymentPayload, PaymentRequirements, PaymentRequirementsV1 } from "@x402/core/types";
 import type { DiscoveryExtension, DiscoveryInfo } from "./types";
 import type { McpDiscoveryInfo } from "./mcp/types";
@@ -99,6 +100,7 @@ export interface ValidationResult {
 export function validateDiscoveryExtension(extension: DiscoveryExtension): ValidationResult {
   try {
     const ajv = new Ajv({ strict: false, allErrors: true });
+    addFormats(ajv);
     const validate = ajv.compile(extension.schema);
 
     // The schema describes the structure of info directly

--- a/typescript/packages/extensions/test/bazaar.test.ts
+++ b/typescript/packages/extensions/test/bazaar.test.ts
@@ -253,6 +253,56 @@ describe("Bazaar Discovery Extension", () => {
       expect(result.errors).toBeDefined();
       expect(result.errors!.length).toBeGreaterThan(0);
     });
+
+    it("should reject invalid URI and date-time formats", () => {
+      const declared = declareDiscoveryExtension({
+        method: "GET",
+        input: { source: "not a uri" },
+        inputSchema: {
+          properties: {
+            source: { type: "string", format: "uri" },
+          },
+          required: ["source"],
+        },
+        output: {
+          example: { updatedAt: "not a date" },
+          schema: {
+            properties: {
+              updatedAt: { type: "string", format: "date-time" },
+            },
+            required: ["updatedAt"],
+          },
+        },
+      });
+
+      const result = validateDiscoveryExtension(declared.bazaar);
+      expect(result.valid).toBe(false);
+      expect(result.errors?.some(error => error.includes("format"))).toBe(true);
+    });
+
+    it("should accept valid URI and date-time formats", () => {
+      const declared = declareDiscoveryExtension({
+        method: "GET",
+        input: { source: "https://example.com/data" },
+        inputSchema: {
+          properties: {
+            source: { type: "string", format: "uri" },
+          },
+          required: ["source"],
+        },
+        output: {
+          example: { updatedAt: "2026-08-12T22:00:00Z" },
+          schema: {
+            properties: {
+              updatedAt: { type: "string", format: "date-time" },
+            },
+            required: ["updatedAt"],
+          },
+        },
+      });
+
+      expect(validateDiscoveryExtension(declared.bazaar)).toEqual({ valid: true });
+    });
   });
 
   describe("extractDiscoveryInfoFromExtension", () => {

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.17.1)
       jose:
         specifier: ^5.9.6
         version: 5.10.0


### PR DESCRIPTION
## Description

`validateDiscoveryExtension()` compiled Bazaar schemas without standard JSON
Schema format handlers. AJV therefore ignored declarations such as
`format: "uri"` and `format: "date-time"`, accepted invalid values, and printed
warnings while validating otherwise machine-readable discovery data.

This patch registers `ajv-formats` on the existing AJV instance and adds invalid
and valid URI/date-time cases. It does not change the Bazaar schema shape or
payment behavior.

Most of this patch was generated with Codex. I reviewed the source and final
diff, reproduced the defect with the published package, removed unrelated
lockfile changes, and ran the checks below.

## Tests

- `pnpm --filter @x402/core build`
- `pnpm --filter @x402/extensions test` (386 passed)
- `pnpm --filter @x402/extensions lint:check`
- `pnpm --filter @x402/extensions format:check`
- `pnpm --filter @x402/extensions build`
- frozen-lockfile install

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commit is signed
- [x] I added a changelog fragment for the user-facing fix
