### PR TITLE
feat: add Robinhood Chain (eip155:4663) default asset

### DIFF
--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -92,6 +92,15 @@ var (
 	// EIP-3009 is the default. Set AssetTransferMethod to AssetTransferMethodPermit2 for tokens
 	// that don't support EIP-3009. See DEFAULT_ASSET.md for details.
 	NetworkConfigs = map[string]NetworkConfig{
+	"eip155:4663": {
+		ChainID: big.NewInt(4663),
+		DefaultAsset: AssetInfo{
+			Address:  "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168",
+			Name:     "Global Dollar",
+			Version:  "1",
+			Decimals: 6,
+		},
+	},
 		// Base Mainnet
 		"eip155:8453": {
 			ChainID: ChainIDBase,

--- a/python/x402/mechanisms/evm/constants.py
+++ b/python/x402/mechanisms/evm/constants.py
@@ -392,6 +392,15 @@ class NetworkConfig(_NetworkConfigRequired, total=False):
 
 # Network configurations
 NETWORK_CONFIGS: dict[str, NetworkConfig] = {
+    "eip155:4663": NetworkConfig(
+        chain_id=4663,
+        default_asset=AssetInfo(
+            address="0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168",
+            name="Global Dollar",
+            version="1",
+            decimals=6,
+        ),
+    ),
     # Base Mainnet
     "eip155:8453": {
         "chain_id": 8453,

--- a/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
+++ b/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
@@ -41,6 +41,12 @@ export type ExactDefaultAssetInfo = DefaultAssetInfo & {
  * exact/server/ for how to add new chains.
  */
 export const DEFAULT_STABLECOINS: Record<string, ExactDefaultAssetInfo> = {
+  "eip155:4663": {
+    address: "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168",
+    name: "Global Dollar",
+    version: "1",
+    decimals: 6,
+  },
   "eip155:8453": {
     address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
     name: "USD Coin",


### PR DESCRIPTION
Adds USDG on Robinhood Chain as a default stablecoin, following DEFAULT_ASSETS.md. All three SDKs updated with identical values.

## Asset selection

Robinhood Chain settles in USDG (Global Dollar). It is the chain's stablecoin rather than one of several competing options, so there is no ambiguity about which to default to.

## EIP-712 domain, verified on chain

`name()` returns `Global Dollar`, not `USDG`, which is the kind of mismatch that produces silently invalid signatures. The contract does not expose `version()`, so the version was derived rather than assumed: reconstructing the domain separator with version `"1"` reproduces the on-chain `DOMAIN_SEPARATOR()` exactly.

```
DOMAIN_SEPARATOR()  0x7a3d7400b27830f4f91c2c16a082486d67c1befecaec2f53b33f1f35d5b62036
name="Global Dollar" version="1" chainId=4663  -> identical
version="2"                                    -> no match
```

## Transfer method

EIP-3009, so no override is needed. `TRANSFER_WITH_AUTHORIZATION_TYPEHASH()` returns the canonical `0x7c7c6cdb67a18743f49ec6fa9b35f50d52ed05cbed4cc592e13b44501c1a2267`, and `authorizationState(address,bytes32)` is present.

| field | value |
| --- | --- |
| address | `0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168` |
| name | `Global Dollar` |
| version | `1` |
| decimals | 6 |

Go builds and the Python module parses with the additions. Disclosure: we run an x402 resource server and facilitator on this chain, which is how the domain values were verified against live payments.