### PR TITLE
Add Machine Inbox to ecosystem (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/machine-inbox/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/machine-inbox/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Machine Inbox",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/machine-inbox.svg",
+  "description": "Task-scoped, self-expiring email inboxes for AI agents. One x402 payment buys a replyable address with parsed MIME and attachments; replies only reach authenticated inbound senders, and mail deletes itself at expiry.",
+  "websiteUrl": "https://machineinbox.com"
+}

--- a/typescript/site/public/logos/machine-inbox.svg
+++ b/typescript/site/public/logos/machine-inbox.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#17150f"/>
+  <path d="M13 20h38v27H13z" fill="none" stroke="#f4f0e5" stroke-width="4"/>
+  <path d="m14 22 18 14 18-14" fill="none" stroke="#f4f0e5" stroke-width="4" stroke-linejoin="round"/>
+  <circle cx="51" cy="14" r="7" fill="#ffb000" stroke="#17150f" stroke-width="3"/>
+</svg>


### PR DESCRIPTION
## Description

Adds **Machine Inbox** (https://machineinbox.com) to the ecosystem page under **Services/Endpoints**: task-scoped, self-expiring email inboxes for AI agents, live on x402 mainnet (v2 exact scheme, USDC on Base, `eip155:8453`). One $2.00 payment creates a seven-day replyable address with parsed MIME and attachments; replies only reach SPF/DKIM/DMARC-authenticated inbound senders, and mail hard-deletes at expiry. Discovery: [/.well-known/x402](https://machineinbox.com/.well-known/x402), [OpenAPI](https://machineinbox.com/openapi.json), [llms.txt](https://machineinbox.com/llms.txt).

Changes are site-content only: `typescript/site/app/ecosystem/partners-data/machine-inbox/metadata.json` (matching the existing partner schema) plus the logo SVG under `typescript/site/public/logos/`.

## Tests

No code changes - metadata.json follows the same shape as the existing partners-data entries and the logo is a self-contained SVG. Verified the live x402 endpoint returns a valid v2 `PAYMENT-REQUIRED` challenge:

    curl -si -X POST https://machineinbox.com/api/v1/inboxes | grep -i payment-required

## Checklist

- [x] I have formatted and linted my code (JSON metadata + SVG only)
- [x] All new and existing tests pass (no code touched)
- [x] My commits are signed (will rebase/sign if required for a site-content change)
- [x] Changelog fragment: not applicable (docs/site content only)