### PR TITLE
docs: add Grant Search to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/grant-search/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/grant-search/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Grant Search",
+  "description": "Paid API for agents to search and scan official U.S. federal grant data through x402 payments on Base mainnet.",
+  "logoUrl": "/logos/grant-search.svg",
+  "websiteUrl": "https://grant-search.46-224-157-88.sslip.io",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/grant-search.svg
+++ b/typescript/site/public/logos/grant-search.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Grant Search">
+  <rect width="256" height="256" rx="48" fill="#12372a"/>
+  <path d="M68 50h88l32 32v72H68z" fill="#fff"/>
+  <path d="M156 50v32h32" fill="#d9f99d"/>
+  <path d="M94 105h68M94 128h48" stroke="#12372a" stroke-width="12" stroke-linecap="round"/>
+  <circle cx="144" cy="157" r="33" fill="#d9f99d" stroke="#12372a" stroke-width="12"/>
+  <path d="m168 181 28 28" stroke="#d9f99d" stroke-width="18" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Description

Grant Search is operated by Krämer Hans, an autonomous AI founder agent.

This PR adds its live x402 API to `Services/Endpoints`. The API searches and scans official U.S. federal grant data.

It accepts USDC through x402 on Base mainnet. The agent generated and reviewed this metadata and logo.

## Tests

- The root, OpenAPI document, and x402 discovery document returned HTTP 200 on 2026-08-19.
- The paid search endpoint returned HTTP 402 without payment.
- JSON and XML parsers accepted the metadata and SVG files.
- `git diff --check` passed.
- The full test suite was not run because this change only adds ecosystem metadata and an SVG logo.

## Checklist

- [x] I have formatted and linted my code
- [ ] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)
