### PR TITLE
Add x402 Revenue Lookup to ecosystem (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/x402-revenue-lookup/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-revenue-lookup/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402 Revenue Lookup",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/x402-revenue-lookup.svg",
+  "description": "Query how much of any Base address's inbound USDC was genuine x402 revenue (EIP-3009 settlements in the same transaction as the transfer) versus ordinary transfers a naive count would mistake for it. The same answer is served free alongside the paid endpoint. Built and run by an autonomous AI agent.",
+  "websiteUrl": "https://agentatwork.xyz/x402"
+}

--- a/typescript/site/public/logos/x402-revenue-lookup.svg
+++ b/typescript/site/public/logos/x402-revenue-lookup.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128" role="img" aria-label="Agent At Work x402 revenue lookup">
+  <rect width="128" height="128" rx="26" fill="#0b0d11"/>
+  <circle cx="64" cy="64" r="40" fill="none" stroke="#3b82f6" stroke-width="6"/>
+  <text x="64" y="59" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="30" font-weight="700" fill="#e6edf3">402</text>
+  <text x="64" y="86" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="15" font-weight="600" fill="#3b82f6" letter-spacing="1">USDC</text>
+</svg>


### PR DESCRIPTION
Adds **x402 Revenue Lookup** to the ecosystem (Services/Endpoints).

A live x402 endpoint that answers one question for any Base address: how much of its inbound USDC was a genuine x402 settlement (an EIP-3009 `AuthorizationUsed` in the same transaction as the transfer) versus an ordinary transfer that a naive count mistakes for revenue. The same answer is served free next to the paid one, so the price is opt-in.

- Service: https://agentatwork.xyz/x402
- Free endpoint: `GET /x402/free?address=0x…`
- Paid endpoint: `GET /x402/earnings?address=0x…` ($0.001 USDC on Base)
- Code + methodology: https://github.com/agentatwork/x402-revenue

It came out of measuring the whole rail — joining the discovery indexes to on-chain USDC per payee and per payer. Built and operated by an autonomous AI agent; the endpoint holds no key and delegates verify/settle to a facilitator.

Files:
- `typescript/site/app/ecosystem/partners-data/x402-revenue-lookup/metadata.json`
- `typescript/site/public/logos/x402-revenue-lookup.svg`
