### PR TITLE
fix(x402-fetch): skip unparseable accepts entries instead of throwing

### DIFF
--- a/typescript/packages/legacy/x402-fetch/src/index.test.ts
+++ b/typescript/packages/legacy/x402-fetch/src/index.test.ts
@@ -108,6 +108,49 @@ describe("fetchWithPayment()", () => {
     } as RequestInitWithRetry);
   });
 
+  it("should skip accepts entries it cannot parse and pay via a supported one", async () => {
+    // A 402 may advertise multiple rails; entries with e.g. CAIP-2 network ids that this
+    // client does not know must not prevent paying via a supported rail.
+    const unknownRailEntry = {
+      ...validPaymentRequirements[0],
+      network: "eip155:137",
+    };
+    const paymentResponse = createResponse(200, { data: "paid" });
+    mockFetch
+      .mockResolvedValueOnce(
+        createResponse(402, {
+          accepts: [unknownRailEntry, ...validPaymentRequirements],
+          x402Version: 1,
+        }),
+      )
+      .mockResolvedValueOnce(paymentResponse);
+    const { createPaymentHeader, selectPaymentRequirements } = await import("x402/client");
+    (createPaymentHeader as ReturnType<typeof vi.fn>).mockResolvedValue("payment-header");
+
+    const result = await wrappedFetch("https://api.example.com/resource", {});
+
+    expect(result).toBe(paymentResponse);
+    // Only the parseable entry reaches the selector.
+    expect(selectPaymentRequirements).toHaveBeenCalledWith(
+      validPaymentRequirements,
+      undefined,
+      "exact",
+    );
+  });
+
+  it("should reject with a clear error when no accepts entry is parseable", async () => {
+    mockFetch.mockResolvedValue(
+      createResponse(402, {
+        accepts: [{ ...validPaymentRequirements[0], network: "eip155:137" }],
+        x402Version: 1,
+      }),
+    );
+
+    await expect(wrappedFetch("https://api.example.com/resource", {})).rejects.toThrow(
+      "No supported payment requirements in 402 response",
+    );
+  });
+
   it("should not retry if already retried", async () => {
     const errorResponse = createResponse(402, {
       accepts: validPaymentRequirements,

--- a/typescript/packages/legacy/x402-fetch/src/index.ts
+++ b/typescript/packages/legacy/x402-fetch/src/index.ts
@@ -70,7 +70,16 @@ export function wrapFetchWithPayment(
       x402Version: number;
       accepts: unknown[];
     };
-    const parsedPaymentRequirements = accepts.map(x => PaymentRequirementsSchema.parse(x));
+    // Per the x402 protocol a 402 may advertise multiple payment rails, including ones
+    // this client does not support (other schemes, facilitator-specific networks, CAIP-2
+    // ids). Skip entries we cannot interpret instead of failing the whole purchase.
+    const parsedPaymentRequirements = accepts.flatMap(x => {
+      const parsed = PaymentRequirementsSchema.safeParse(x);
+      return parsed.success ? [parsed.data] : [];
+    });
+    if (parsedPaymentRequirements.length === 0) {
+      throw new Error("No supported payment requirements in 402 response");
+    }
 
     const network = isMultiNetworkSigner(walletClient)
       ? undefined


### PR DESCRIPTION
## Problem

`wrapFetchWithPayment` parses **every** element of a 402's `accepts` with `PaymentRequirementsSchema.parse` before selecting one:

```ts
const parsedPaymentRequirements = accepts.map(x => PaymentRequirementsSchema.parse(x));
```

A 402 that advertises multiple payment rails — as the protocol allows — fails entirely with a `ZodError` if any single entry uses a network id this client doesn't know, even when a perfectly payable `base` entry is present.

**Real-world case**: OpenPay's dual-rail resources (e.g. `https://aegis-ai.xyz/api/d2a/briefing-jpyc`, listed on the x402 Bazaar) advertise a JPYC rail (Polygon, CAIP-2 `eip155:137`, settled by OpenPay's facilitator) next to a standard USDC (Base) rail. x402-fetch 1.2.0 throws on the CAIP-2 entry before it can select the Base rail, so standard buyers discovering the resource via the Bazaar cannot pay in USDC at all:

```
ZodError: [{ "received": "eip155:137", "code": "invalid_enum_value", "path": ["network"], ... }]
```

## Fix

`safeParse` each entry and skip the ones this client cannot interpret; throw a clear error only when nothing is parseable:

```ts
const parsedPaymentRequirements = accepts.flatMap(x => {
  const parsed = PaymentRequirementsSchema.safeParse(x);
  return parsed.success ? [parsed.data] : [];
});
if (parsedPaymentRequirements.length === 0) {
  throw new Error("No supported payment requirements in 402 response");
}
```

Unknown rails should not prevent paying via a supported one — this also future-proofs the client against new networks/schemes appearing in mixed `accepts` lists.

## Tests

- mixed `accepts` (unknown CAIP-2 entry + valid `base-sepolia` entry) → the supported entry reaches the selector and the payment retry succeeds
- all entries unparseable → rejects with `"No supported payment requirements in 402 response"` (previously an opaque `ZodError`)

`vitest run` in `typescript/packages/legacy/x402-fetch`: 8/8 passing.