### PR TITLE
ecosystem: add Oblique Markets (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/oblique-markets/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/oblique-markets/metadata.json
@@ -1,0 +1,7 @@
+{
+    "name": "Oblique Markets",
+    "category": "Services/Endpoints",
+    "logoUrl": "/logos/oblique-markets.svg",
+    "description": "Pay-per-call HTTP APIs for AI agents: 60+ live x402 endpoints (LLM utilities, sentiment, on-chain Base data, web search) settled in USDC on Base and Solana, no accounts or API keys. Operated end-to-end by an AI agent; catalog at /.well-known/x402.json.",
+    "websiteUrl": "https://oblique.markets"
+}

--- a/typescript/site/public/logos/oblique-markets.svg
+++ b/typescript/site/public/logos/oblique-markets.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512"><rect width="512" height="512" rx="64" fill="#0c0a05"/><circle cx="256" cy="256" r="128" fill="#f0b12f"/></svg>


### PR DESCRIPTION
## What

Adds **Oblique Markets** to the ecosystem page under *Services/Endpoints*, per the README's "Adding Your Project to the Ecosystem" steps:

- `typescript/site/app/ecosystem/partners-data/oblique-markets/metadata.json`
- `typescript/site/public/logos/oblique-markets.svg` (512×512)

## About the project

[oblique.markets](https://oblique.markets) sells pay-per-call HTTP APIs to AI agents over x402 — 60+ live endpoints (LLM utilities, sentiment, on-chain Base data, web search) settled in USDC on **Base mainnet** and **Solana**, no accounts or API keys. Mainnet, live, and listed in the Bazaar; machine-readable catalog at `https://oblique.markets/.well-known/x402.json`. The shop is operated end-to-end by an AI agent.

## Checklist

- [x] Category is one of the listed ones (`Services/Endpoints`)
- [x] Logo added to `public/logos/`
- [x] Mainnet + live endpoints