### PR TITLE
Add AgentRisk M2M to ecosystem (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/agentrisk/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/agentrisk/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "AgentRisk M2M",
+  "description": "Pre-trade risk scoring API for Base tokens: honeypot detection, deployer wallet freshness, on-chain LP-lock verification, brand impersonation checks, and live sell simulation via Uniswap V3 and Aerodrome. Paid per call via x402, 0.15 USDC.",
+  "logoUrl": "/logos/agentrisk.svg",
+  "websiteUrl": "https://agentrisk.dev",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/agentrisk.svg
+++ b/typescript/site/public/logos/agentrisk.svg
@@ -1,0 +1,4 @@
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+  <path d="M64 8 L112 24 L112 60 C112 92 92 112 64 120 C36 112 16 92 16 60 L16 24 Z" fill="#0A0E1A" stroke="#5EA6F0" stroke-width="4"/>
+  <text x="64" y="80" font-family="-apple-system, sans-serif" font-size="56" font-weight="700" fill="#5EA6F0" text-anchor="middle">A</text>
+</svg>


### PR DESCRIPTION
AgentRisk M2M — Services/Endpoints

Website: https://agentrisk.dev
GitHub: https://github.com/Neurobyteio/agentrisk

What it is

Pre-trade risk scoring API for Base tokens. Checks honeypot status, deployer wallet freshness, on-chain LP-lock verification, brand impersonation, and runs a live sell simulation (via Uniswap V3 and Aerodrome) that catches dynamic honeypots — tokens that behave normally for the first N buys, then block sells, which static bytecode analysis misses.

x402 integration

- Scheme: exact
- Network: Base mainnet (eip155:8453)
- Asset: USDC
- Facilitator: Coinbase CDP
- Price: $0.15 per scan
- Also supports signed attestation receipts (?attest=true) so agents can verify results were not tampered with, plus a /verify endpoint for checking receipt validity without re-scanning.