### PR TITLE
feat: initial evm passthrough implementation

### DIFF
--- a/.github/workflows/publish_npm_scoped_x402_all.yml
+++ b/.github/workflows/publish_npm_scoped_x402_all.yml
@@ -68,6 +68,7 @@ jobs:
           publish_package "packages/core"
           publish_package "packages/extensions"
           publish_package "packages/mechanisms/evm"
+          publish_package "packages/mechanisms/base"
           publish_package "packages/mechanisms/svm"
           publish_package "packages/mechanisms/avm"
           publish_package "packages/mechanisms/aptos"

--- a/.github/workflows/publish_npm_scoped_x402_base.yml
+++ b/.github/workflows/publish_npm_scoped_x402_base.yml
@@ -1,0 +1,49 @@
+name: Publish @x402/base package to NPM
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-npm-x402-base:
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 11.1.1
+      
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+      
+      - name: Update npm for OIDC trusted publishing
+        run: npm install -g npm@11.14.1 --ignore-scripts
+
+      - name: Configure npm for trusted publishing
+        run: npm config delete always-auth 2>/dev/null || true
+      
+      - name: Install and build
+        working-directory: ./typescript
+        run: |
+          pnpm install --frozen-lockfile --ignore-scripts
+          pnpm -r --filter=@x402/core --filter=@x402/extensions --filter=@x402/evm --filter=@x402/base run build
+      
+      - name: Publish @x402/base package
+        working-directory: ./typescript/packages/mechanisms/base
+        run: |
+          # Get package information directly
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          
+          echo "Package: $PACKAGE_NAME@$PACKAGE_VERSION"
+          
+          echo "Publishing to NPM (main branch)"
+          pnpm publish --provenance --access public

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ app.use(
 ```shell
 # All available reference sdks
 npm install @x402/core \
-  @x402/evm @x402/svm @x402/avm @x402/aptos @x402/stellar @x402/tvm @x402/hedera @x402/keeta \
+  @x402/evm @x402/base @x402/svm @x402/avm @x402/aptos @x402/stellar @x402/tvm @x402/hedera @x402/keeta \
   @x402/axios @x402/fastify @x402/fetch @x402/express @x402/hono @x402/next @x402/paywall @x402/extensions @x402/mcp
 ```
 

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -1344,6 +1344,61 @@ importers:
         specifier: ^3.0.5
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.16.0)(jiti@1.21.7)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)
 
+  ../typescript/packages/mechanisms/base:
+    dependencies:
+      '@x402/core':
+        specifier: workspace:~
+        version: link:../../core
+      '@x402/evm':
+        specifier: workspace:~
+        version: link:../evm
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.24.0
+        version: 9.38.0
+      '@types/node':
+        specifier: ^22.13.4
+        version: 22.16.0
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.29.1
+        version: 8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.29.1
+        version: 8.48.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
+      eslint:
+        specifier: ^9.24.0
+        version: 9.38.0(jiti@1.21.7)
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@1.21.7))
+      eslint-plugin-jsdoc:
+        specifier: ^50.6.9
+        version: 50.8.0(eslint@9.38.0(jiti@1.21.7))
+      eslint-plugin-prettier:
+        specifier: ^5.2.6
+        version: 5.5.4(eslint@9.38.0(jiti@1.21.7))(prettier@3.5.2)
+      prettier:
+        specifier: 3.5.2
+        version: 3.5.2
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.0(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.8.3
+      viem:
+        specifier: ^2.48.11
+        version: 2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12)
+      vite:
+        specifier: ^6.2.6
+        version: 6.4.1(@types/node@22.16.0)(jiti@1.21.7)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.8.3)(vite@6.4.1(@types/node@22.16.0)(jiti@1.21.7)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1))
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.16.0)(jiti@1.21.7)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)
+
   ../typescript/packages/mechanisms/concordium:
     dependencies:
       '@concordium/web-sdk':

--- a/examples/typescript/pnpm-lock.yaml
+++ b/examples/typescript/pnpm-lock.yaml
@@ -827,6 +827,61 @@ importers:
         specifier: ^3.0.5
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.2)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)
 
+  ../../typescript/packages/mechanisms/base:
+    dependencies:
+      '@x402/core':
+        specifier: workspace:~
+        version: link:../../core
+      '@x402/evm':
+        specifier: workspace:~
+        version: link:../evm
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.24.0
+        version: 9.33.0
+      '@types/node':
+        specifier: ^22.13.4
+        version: 22.17.2
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.29.1
+        version: 8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.29.1
+        version: 8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.3)
+      eslint:
+        specifier: ^9.24.0
+        version: 9.33.0(jiti@2.6.1)
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.33.0(jiti@2.6.1))
+      eslint-plugin-jsdoc:
+        specifier: ^50.6.9
+        version: 50.8.0(eslint@9.33.0(jiti@2.6.1))
+      eslint-plugin-prettier:
+        specifier: ^5.2.6
+        version: 5.5.4(eslint@9.33.0(jiti@2.6.1))(prettier@3.5.2)
+      prettier:
+        specifier: 3.5.2
+        version: 3.5.2
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      viem:
+        specifier: ^2.48.11
+        version: 2.48.11(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.13)
+      vite:
+        specifier: ^6.2.6
+        version: 6.3.5(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.9.3)(vite@6.3.5(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1))
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.2)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.1)
+
   ../../typescript/packages/mechanisms/concordium:
     dependencies:
       '@concordium/web-sdk':

--- a/typescript/.changeset/base-package-initial-release.md
+++ b/typescript/.changeset/base-package-initial-release.md
@@ -1,0 +1,5 @@
+---
+"@x402/base": minor
+---
+
+Introduce `@x402/base`, a Base-scoped (`eip155:8453` mainnet / `eip155:84532` Sepolia) mechanism providing `exact`, `upto`, `auth-capture`, and `batch-settlement` `BaseScheme` client/server/facilitator wrappers around `@x402/evm`. Each wrapper takes the same constructor arguments as its `@x402/evm` counterpart and delegates entirely, with all public types re-exported under a `Base`-prefixed alias so nothing `Evm`-named leaks through the public API. Value-affecting methods (`createPaymentPayload`, `verify`, `settle`, `parsePrice`, `enhancePaymentRequirements`, `buildChannelConfig`, `createChannelManager`) reject any network outside Base's scope, metadata reads (`getAssetDecimals`, `getExtra`, `getSigners`) fail closed, and `validateFacilitatorSupport` fails server startup for a mis-registered network instead of surfacing at first payment.

--- a/typescript/.changeset/config.json
+++ b/typescript/.changeset/config.json
@@ -9,6 +9,7 @@
       "@x402/extensions",
       "@x402/hedera",
       "@x402/evm",
+      "@x402/base",
       "@x402/avm",
       "@x402/aptos",
       "@x402/stellar",

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -25,6 +25,7 @@ This folder contains Typescript packages to help developers implement the x402 p
 | Package | Description | Latest version |
 | --- | --- | --- |
 | **EVM** - [`@x402/evm`](./packages/mechanisms/evm) | EVM implementation of x402 using the Exact payment scheme. | [![npm version](https://img.shields.io/npm/v/%40x402%2Fevm.svg)](https://www.npmjs.com/package/@x402/evm) |
+| **Base** - [`@x402/base`](./packages/mechanisms/base) | Base (mainnet + Sepolia) pass-through wrapper around `@x402/evm`, scoped to `eip155:8453`/`eip155:84532`. | [![npm version](https://img.shields.io/npm/v/%40x402%2Fbase.svg)](https://www.npmjs.com/package/@x402/base) |
 | **Algorand** - [`@x402/avm`](./packages/mechanisms/avm) | AVM implementation of x402 using ASA transfers. | [![npm version](https://img.shields.io/npm/v/%40x402%2Favm.svg)](https://www.npmjs.com/package/@x402/avm) |
 | **Aptos** - [`@x402/aptos`](./packages/mechanisms/aptos) | Aptos implementation of the x402 payment protocol. | [![npm version](https://img.shields.io/npm/v/%40x402%2Faptos.svg)](https://www.npmjs.com/package/@x402/aptos) |
 | **Stellar** - [`@x402/stellar`](./packages/mechanisms/stellar) | Stellar implementation of x402 using Soroban token transfers. | [![npm version](https://img.shields.io/npm/v/%40x402%2Fstellar.svg)](https://www.npmjs.com/package/@x402/stellar) |

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -17,7 +17,7 @@
     "lint:check": "turbo run lint:check",
     "format:check": "turbo run format:check",
     "test": "turbo run test",
-    "test:integration": "pnpm --filter @x402/core --filter @x402/evm --filter @x402/svm --filter @x402/avm --filter @x402/aptos --filter @x402/hedera --filter @x402/keeta --filter @x402/near --filter @x402/stellar --filter @x402/xrpl test:integration",
+    "test:integration": "pnpm --filter @x402/core --filter @x402/evm --filter @x402/base --filter @x402/svm --filter @x402/avm --filter @x402/aptos --filter @x402/hedera --filter @x402/keeta --filter @x402/near --filter @x402/stellar --filter @x402/xrpl test:integration",
     "test:all": "pnpm test && pnpm test:integration"
   },
   "keywords": [],

--- a/typescript/packages/mechanisms/base/.prettierignore
+++ b/typescript/packages/mechanisms/base/.prettierignore
@@ -1,0 +1,7 @@
+docs/
+dist/
+node_modules/
+coverage/
+.github/
+**/**/*.json
+*.md

--- a/typescript/packages/mechanisms/base/.prettierrc
+++ b/typescript/packages/mechanisms/base/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "avoid",
+  "printWidth": 100,
+  "proseWrap": "never"
+}

--- a/typescript/packages/mechanisms/base/README.md
+++ b/typescript/packages/mechanisms/base/README.md
@@ -1,0 +1,120 @@
+# `@x402/base` [![npm version](https://img.shields.io/npm/v/%40x402%2Fbase.svg)](https://www.npmjs.com/package/@x402/base)
+
+Base (`eip155:8453` mainnet / `eip155:84532` Sepolia) implementation of the x402 payment protocol.
+
+## Installation
+
+```bash
+npm install @x402/base
+```
+
+## Overview
+
+`@x402/base` provides Base-specific mechanisms for the `exact`, `upto`, `auth-capture`, and
+`batch-settlement` payment schemes. Today it is a thin pass-through wrapper around
+[`@x402/evm`](../evm) — Base is fully EVM-compatible and has no protocol-level differences from
+generic EVM chains yet, so every method simply delegates to the underlying `@x402/evm`
+implementation.
+
+This package exists as an explicit, overridable seam: registering `@x402/base`'s schemes against
+`eip155:8453` / `eip155:84532` (instead of, or alongside, `@x402/evm`'s `eip155:*` wildcard) lets
+Base-specific behavior be introduced later — a different gas-sponsoring strategy, a different
+default asset transfer method, etc. — without changing the public API or requiring consumers to
+switch schemes.
+
+## Network Scope
+
+`@x402/base` is scoped to exactly two networks: `eip155:8453` (Base) and `eip155:84532` (Base
+Sepolia). Because the underlying `@x402/evm` schemes are generic across the entire `eip155:*`
+family, `@x402/base` enforces this scope itself at runtime rather than relying solely on the
+`@x402/core` registration key — a `BaseScheme` reached via a wildcard registration, or called
+directly, would otherwise silently process payments for any EVM chain.
+
+- Value-affecting methods (`createPaymentPayload`, `verify`, `settle`, `parsePrice`,
+  `enhancePaymentRequirements`, `buildChannelConfig`, `createChannelManager`) throw for any other
+  network.
+- Metadata reads (`getAssetDecimals`, `getExtra`, `getSigners`, `findDefaultAsset`) fail closed,
+  returning `undefined` / `[]` instead of throwing.
+- `validateFacilitatorSupport` reports a problem string for a mis-registered network, which
+  `@x402/core` surfaces as a startup error from `x402ResourceServer.initialize()` instead of at
+  first payment.
+
+See [`src/networks.ts`](./src/networks.ts) (`isBaseNetwork`, `assertBaseNetwork`,
+`findBaseDefaultAsset`) for the shared implementation, exported from the package root.
+
+- **Client** - For applications that need to make payments (have wallets/signers)
+- **Server** - For resource servers that accept payments and build payment requirements
+- **Facilitator** - For payment processors that verify and settle on-chain transactions
+
+## Package Exports
+
+| Scheme | Role | Import | Class |
+|--------|------|--------|-------|
+| Exact (fixed-price) | Client | `@x402/base/exact/client` | `BaseScheme` |
+| Exact (fixed-price) | Server | `@x402/base/exact/server` | `BaseScheme` |
+| Exact (fixed-price) | Facilitator | `@x402/base/exact/facilitator` | `BaseScheme` |
+| Upto (usage-based) | Client | `@x402/base/upto/client` | `BaseScheme` |
+| Upto (usage-based) | Server | `@x402/base/upto/server` | `BaseScheme` |
+| Upto (usage-based) | Facilitator | `@x402/base/upto/facilitator` | `BaseScheme` |
+| AuthCapture (refundable) | Client | `@x402/base/auth-capture/client` | `BaseScheme` |
+| Batch-Settlement (payment channels) | Client | `@x402/base/batch-settlement/client` | `BaseScheme` |
+| Batch-Settlement (payment channels) | Server | `@x402/base/batch-settlement/server` | `BaseScheme` |
+| Batch-Settlement (payment channels) | Facilitator | `@x402/base/batch-settlement/facilitator` | `BaseScheme` |
+
+AuthCapture is client-only today — `@x402/evm` has no server/facilitator implementation yet.
+
+See [`src/exact/README.md`](./src/exact/README.md), [`src/upto/README.md`](./src/upto/README.md),
+[`src/auth-capture/README.md`](./src/auth-capture/README.md), and
+[`src/batch-settlement/README.md`](./src/batch-settlement/README.md) for usage details.
+
+## Usage
+
+```typescript
+import { x402Client } from "@x402/core/client";
+import { BaseScheme as BaseExactScheme } from "@x402/base/exact/client";
+import { BaseScheme as BaseUptoScheme } from "@x402/base/upto/client";
+import { privateKeyToAccount } from "viem/accounts";
+
+const signer = privateKeyToAccount(process.env.EVM_PRIVATE_KEY as `0x${string}`);
+
+const client = new x402Client()
+  .register("eip155:8453", new BaseExactScheme(signer)) // fixed-price services
+  .register("eip155:8453", new BaseUptoScheme(signer)); // usage-based services
+```
+
+Constructor arguments, signer types, and options are identical to `@x402/evm`'s `ExactEvmScheme` /
+`UptoEvmScheme` — `BaseScheme` re-exports and forwards to the same underlying types.
+
+## Signers
+
+Every scheme's client/facilitator constructor takes a `BaseClientSigner` / `BaseFacilitatorSigner`
+— Base-branded aliases of `@x402/evm`'s `ClientEvmSigner` / `FacilitatorEvmSigner` (a Base wallet
+is just an EVM wallet). The package root also re-exports the `@x402/evm` adapter helpers under
+Base-branded names so nothing `Evm`-named needs to be imported directly from `@x402/evm`:
+
+```typescript
+import { toBaseClientSigner, toBaseFacilitatorSigner } from "@x402/base";
+```
+
+## Development
+
+```bash
+# Build
+npm run build
+
+# Test
+npm run test
+
+# Integration tests
+npm run test:integration
+
+# Lint & Format
+npm run lint
+npm run format
+```
+
+## Related Packages
+
+- `@x402/core` - Core protocol types and client
+- `@x402/evm` - Generic EVM (`eip155:*`) implementation that this package wraps
+- `@x402/fetch` - HTTP wrapper with automatic payment handling

--- a/typescript/packages/mechanisms/base/eslint.config.js
+++ b/typescript/packages/mechanisms/base/eslint.config.js
@@ -1,0 +1,91 @@
+import js from "@eslint/js";
+import ts from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+import prettier from "eslint-plugin-prettier";
+import jsdoc from "eslint-plugin-jsdoc";
+import importPlugin from "eslint-plugin-import";
+
+export default [
+  {
+    ignores: ["dist/**", "node_modules/**"],
+  },
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    ignores: ["**/*.test.ts", "test/**/*"],
+    languageOptions: {
+      parser: tsParser,
+      sourceType: "module",
+      ecmaVersion: 2020,
+      globals: {
+        process: "readonly",
+        __dirname: "readonly",
+        module: "readonly",
+        require: "readonly",
+        Buffer: "readonly",
+        exports: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly",
+      },
+    },
+    plugins: {
+      "@typescript-eslint": ts,
+      prettier: prettier,
+      jsdoc: jsdoc,
+      import: importPlugin,
+    },
+    rules: {
+      ...ts.configs.recommended.rules,
+      "import/first": "error",
+      "prettier/prettier": "error",
+      "@typescript-eslint/member-ordering": "error",
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_$" }],
+      "jsdoc/tag-lines": ["error", "any", { startLines: 1 }],
+      "jsdoc/check-alignment": "error",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/check-param-names": "error",
+      "jsdoc/check-tag-names": "error",
+      "jsdoc/check-types": "error",
+      "jsdoc/implements-on-classes": "error",
+      "jsdoc/require-description": "error",
+      "jsdoc/require-jsdoc": [
+        "error",
+        {
+          require: {
+            FunctionDeclaration: true,
+            MethodDefinition: true,
+            ClassDeclaration: true,
+            ArrowFunctionExpression: false,
+            FunctionExpression: false,
+          },
+        },
+      ],
+      "jsdoc/require-param": "error",
+      "jsdoc/require-param-description": "error",
+      "jsdoc/require-param-type": "off",
+      "jsdoc/require-returns": "error",
+      "jsdoc/require-returns-description": "error",
+      "jsdoc/require-returns-type": "off",
+      "jsdoc/require-hyphen-before-param-description": ["error", "always"],
+    },
+  },
+  {
+    files: ["**/*.test.ts", "test/**/*"],
+    languageOptions: {
+      parser: tsParser,
+      sourceType: "module",
+      ecmaVersion: 2020,
+    },
+    plugins: {
+      "@typescript-eslint": ts,
+      prettier: prettier,
+    },
+    rules: {
+      "prettier/prettier": "error",
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/member-ordering": "off",
+    },
+  },
+];

--- a/typescript/packages/mechanisms/base/package.json
+++ b/typescript/packages/mechanisms/base/package.json
@@ -1,0 +1,166 @@
+{
+  "name": "@x402/base",
+  "version": "2.24.0",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:watch": "vitest",
+    "watch": "tsc --watch",
+    "format": "prettier -c .prettierrc --write \"**/*.{ts,js,cjs,json,md}\"",
+    "format:check": "prettier -c .prettierrc --check \"**/*.{ts,js,cjs,json,md}\"",
+    "lint": "eslint . --ext .ts --fix",
+    "lint:check": "eslint . --ext .ts"
+  },
+  "keywords": [
+    "x402",
+    "payment",
+    "protocol",
+    "evm",
+    "base",
+    "ethereum"
+  ],
+  "license": "Apache-2.0",
+  "author": "x402 Foundation",
+  "repository": "https://github.com/x402-foundation/x402",
+  "description": "x402 Payment Protocol Base Implementation",
+  "devDependencies": {
+    "@eslint/js": "^9.24.0",
+    "@types/node": "^22.13.4",
+    "@typescript-eslint/eslint-plugin": "^8.29.1",
+    "@typescript-eslint/parser": "^8.29.1",
+    "eslint": "^9.24.0",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-jsdoc": "^50.6.9",
+    "eslint-plugin-prettier": "^5.2.6",
+    "prettier": "3.5.2",
+    "tsup": "^8.4.0",
+    "typescript": "^5.7.3",
+    "viem": "^2.48.11",
+    "vite": "^6.2.6",
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.0.5"
+  },
+  "dependencies": {
+    "@x402/core": "workspace:~",
+    "@x402/evm": "workspace:~"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.mts",
+        "default": "./dist/esm/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    },
+    "./exact/client": {
+      "import": {
+        "types": "./dist/esm/exact/client/index.d.mts",
+        "default": "./dist/esm/exact/client/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/exact/client/index.d.ts",
+        "default": "./dist/cjs/exact/client/index.js"
+      }
+    },
+    "./exact/server": {
+      "import": {
+        "types": "./dist/esm/exact/server/index.d.mts",
+        "default": "./dist/esm/exact/server/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/exact/server/index.d.ts",
+        "default": "./dist/cjs/exact/server/index.js"
+      }
+    },
+    "./exact/facilitator": {
+      "import": {
+        "types": "./dist/esm/exact/facilitator/index.d.mts",
+        "default": "./dist/esm/exact/facilitator/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/exact/facilitator/index.d.ts",
+        "default": "./dist/cjs/exact/facilitator/index.js"
+      }
+    },
+    "./upto/client": {
+      "import": {
+        "types": "./dist/esm/upto/client/index.d.mts",
+        "default": "./dist/esm/upto/client/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/upto/client/index.d.ts",
+        "default": "./dist/cjs/upto/client/index.js"
+      }
+    },
+    "./upto/server": {
+      "import": {
+        "types": "./dist/esm/upto/server/index.d.mts",
+        "default": "./dist/esm/upto/server/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/upto/server/index.d.ts",
+        "default": "./dist/cjs/upto/server/index.js"
+      }
+    },
+    "./upto/facilitator": {
+      "import": {
+        "types": "./dist/esm/upto/facilitator/index.d.mts",
+        "default": "./dist/esm/upto/facilitator/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/upto/facilitator/index.d.ts",
+        "default": "./dist/cjs/upto/facilitator/index.js"
+      }
+    },
+    "./auth-capture/client": {
+      "import": {
+        "types": "./dist/esm/auth-capture/client/index.d.mts",
+        "default": "./dist/esm/auth-capture/client/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/auth-capture/client/index.d.ts",
+        "default": "./dist/cjs/auth-capture/client/index.js"
+      }
+    },
+    "./batch-settlement/client": {
+      "import": {
+        "types": "./dist/esm/batch-settlement/client/index.d.mts",
+        "default": "./dist/esm/batch-settlement/client/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/batch-settlement/client/index.d.ts",
+        "default": "./dist/cjs/batch-settlement/client/index.js"
+      }
+    },
+    "./batch-settlement/server": {
+      "import": {
+        "types": "./dist/esm/batch-settlement/server/index.d.mts",
+        "default": "./dist/esm/batch-settlement/server/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/batch-settlement/server/index.d.ts",
+        "default": "./dist/cjs/batch-settlement/server/index.js"
+      }
+    },
+    "./batch-settlement/facilitator": {
+      "import": {
+        "types": "./dist/esm/batch-settlement/facilitator/index.d.mts",
+        "default": "./dist/esm/batch-settlement/facilitator/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/batch-settlement/facilitator/index.d.ts",
+        "default": "./dist/cjs/batch-settlement/facilitator/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/typescript/packages/mechanisms/base/src/auth-capture/README.md
+++ b/typescript/packages/mechanisms/base/src/auth-capture/README.md
@@ -1,0 +1,67 @@
+# AuthCapture Base Scheme (`@x402/base/auth-capture`, client)
+
+The **auth-capture** scheme adds refundable payments to x402, built on Base's audited
+[Commerce Payments Protocol](https://github.com/base/commerce-payments). The client signs a
+single payload (ERC-3009 or Permit2) over a payer-agnostic PaymentInfo hash. A facilitator later
+submits that payload to `AuthCaptureEscrow`, where funds are held under a `captureAuthorizer` role
+rather than transferred straight to the merchant, enabling capture, void, and refund flows before
+settlement is final.
+
+Today, `@x402/base`'s `auth-capture` scheme is a thin pass-through wrapper around
+[`@x402/evm`'s `auth-capture` scheme](../../../evm/src/auth-capture/README.md) — every method
+delegates to an internal `AuthCaptureEvmScheme` instance from `@x402/evm`.
+
+**`@x402/evm` currently ships the auth-capture client only** — there is no server or facilitator
+implementation yet, so `@x402/base` mirrors that scope. Server/facilitator wrappers will follow
+once `@x402/evm` adds them.
+
+See the [scheme specification](https://github.com/x402-foundation/x402/blob/main/specs/schemes/auth-capture/scheme_auth-capture_evm.md)
+for full protocol details.
+
+## Import
+
+| Role | Import |
+|------|--------|
+| Client | `@x402/base/auth-capture/client` |
+
+## Usage
+
+Register `BaseScheme` with an `x402Client`. The client validates the requirement's `extra`
+fields, reconstructs the PaymentInfo struct, computes the payer-agnostic hash, and emits an
+ERC-3009 (default) or Permit2 payload — identical behavior to `@x402/evm`.
+
+```typescript
+import { x402Client } from "@x402/core/client";
+import { BaseScheme } from "@x402/base/auth-capture/client";
+import { privateKeyToAccount } from "viem/accounts";
+
+const account = privateKeyToAccount(process.env.EVM_PRIVATE_KEY as `0x${string}`);
+
+const client = new x402Client();
+client.register("eip155:8453", new BaseScheme(account));
+client.register("eip155:84532", new BaseScheme(account));
+```
+
+`BaseScheme`'s `BaseClientSigner` only needs `address` + `signTypedData`; a bare viem
+`LocalAccount` satisfies the shape, with no `PublicClient` required.
+
+## Payment requirements the client reads
+
+See [`@x402/evm`'s auth-capture docs](../../../evm/src/auth-capture/README.md#payment-requirements-the-client-reads)
+for the full `requirements.extra` field table (`captureAuthorizer`, `feeRecipient`,
+`captureDeadline`, `refundDeadline`, `minFeeBps`, `maxFeeBps`, `name`, `version`, and the optional
+`assetTransferMethod` / `authCaptureEscrow` / `receiverAuthorizer` / `policy` fields) — behavior is
+identical to `@x402/evm`.
+
+## Supported networks
+
+| Network | CAIP-2 ID |
+|---------|-----------|
+| Base Mainnet | `eip155:8453` |
+| Base Sepolia | `eip155:84532` |
+
+## See Also
+
+- [`@x402/evm` AuthCapture Scheme](../../../evm/src/auth-capture/README.md) — the implementation this package wraps
+- [Scheme specification](https://github.com/x402-foundation/x402/blob/main/specs/schemes/auth-capture/scheme_auth-capture_evm.md)
+- [`AuthCaptureEscrow` contract](https://github.com/base/commerce-payments)

--- a/typescript/packages/mechanisms/base/src/auth-capture/client/index.ts
+++ b/typescript/packages/mechanisms/base/src/auth-capture/client/index.ts
@@ -1,0 +1,2 @@
+export { BaseScheme } from "./scheme";
+export type { BaseClientSigner } from "./scheme";

--- a/typescript/packages/mechanisms/base/src/auth-capture/client/scheme.ts
+++ b/typescript/packages/mechanisms/base/src/auth-capture/client/scheme.ts
@@ -1,0 +1,69 @@
+import type {
+  PaymentPayloadContext,
+  PaymentPayloadResult,
+  PaymentRequirements,
+  SchemeNetworkClient,
+} from "@x402/core/types";
+import { ClientEvmSigner } from "@x402/evm";
+import { AuthCaptureEvmScheme } from "@x402/evm/auth-capture/client";
+import { assertBaseNetwork, findBaseDefaultAsset } from "../../networks";
+
+/** Signer required by {@link BaseScheme} (client). Identical to `@x402/evm`'s `ClientEvmSigner`. */
+export type BaseClientSigner = ClientEvmSigner;
+
+/**
+ * Base client implementation for the AuthCapture payment scheme.
+ *
+ * Thin pass-through wrapper around the generic EVM {@link AuthCaptureEvmScheme}
+ * (`@x402/evm`). Base (`eip155:8453` / `eip155:84532`) has no client-side
+ * differences from generic EVM today - this class exists as an explicit,
+ * overridable seam so Base-specific behavior can be introduced later without
+ * changing the public `@x402/base` API surface.
+ *
+ * `createPaymentPayload` rejects any network outside `eip155:8453` /
+ * `eip155:84532` - see {@link assertBaseNetwork}. `findDefaultAsset` is
+ * scoped the same way via {@link findBaseDefaultAsset}.
+ *
+ * Note: `@x402/evm` currently ships the auth-capture **client only** - there
+ * is no server or facilitator implementation to wrap yet, so `@x402/base`
+ * mirrors that scope.
+ */
+export class BaseScheme implements SchemeNetworkClient {
+  readonly scheme = "auth-capture";
+  findDefaultAsset = findBaseDefaultAsset;
+  private readonly authCaptureEvmScheme: AuthCaptureEvmScheme;
+
+  /**
+   * Creates a new BaseScheme client instance.
+   *
+   * @param signer - The Base (EVM) signer for client operations. Only requires
+   *   `address` + `signTypedData`.
+   */
+  constructor(signer: BaseClientSigner) {
+    this.authCaptureEvmScheme = new AuthCaptureEvmScheme(signer);
+  }
+
+  /**
+   * Creates a payment payload for the AuthCapture scheme. Delegates to the
+   * underlying {@link AuthCaptureEvmScheme} after asserting the
+   * requirements' network is in Base's scope.
+   *
+   * @param x402Version - The x402 protocol version (only `2` is supported)
+   * @param paymentRequirements - The payment requirements
+   * @param context - Optional context with server-declared extensions (unused)
+   * @returns Promise resolving to a signed payment payload result
+   * @throws When `paymentRequirements.network` is not `eip155:8453` / `eip155:84532`
+   */
+  async createPaymentPayload(
+    x402Version: number,
+    paymentRequirements: PaymentRequirements,
+    context?: PaymentPayloadContext,
+  ): Promise<PaymentPayloadResult> {
+    assertBaseNetwork(paymentRequirements.network, "BaseScheme.createPaymentPayload");
+    return this.authCaptureEvmScheme.createPaymentPayload(
+      x402Version,
+      paymentRequirements,
+      context,
+    );
+  }
+}

--- a/typescript/packages/mechanisms/base/src/auth-capture/index.ts
+++ b/typescript/packages/mechanisms/base/src/auth-capture/index.ts
@@ -1,0 +1,1 @@
+export { BaseScheme } from "./client/scheme";

--- a/typescript/packages/mechanisms/base/src/batch-settlement/README.md
+++ b/typescript/packages/mechanisms/base/src/batch-settlement/README.md
@@ -1,0 +1,80 @@
+# Batch-Settlement Base Scheme (`@x402/base/batch-settlement`)
+
+The **batch-settlement** scheme implements payment channels: the client deposits funds once into a
+channel (an onchain `x402BatchSettlement` contract), then signs cheap, gasless EIP-712 vouchers for
+each subsequent request. The facilitator claims vouchers in batches, amortizing gas across many
+requests — ideal for high-frequency, low-value payments (metering, streaming, per-request APIs).
+
+Today, `@x402/base`'s `batch-settlement` scheme is a thin pass-through wrapper around
+[`@x402/evm`'s `batch-settlement` scheme](../../../evm/src/batch-settlement/README.md) — every
+method delegates to an internal `BatchSettlementEvmScheme` instance from `@x402/evm`. Constructor
+arguments, channel/voucher/deposit mechanics, and storage backends are all identical to
+`@x402/evm` — see that package's docs for the full behavior. This package exists as an explicit,
+overridable seam for introducing Base-specific behavior later without changing the public API.
+
+## Import Paths
+
+| Role | Import |
+|------|--------|
+| Client | `@x402/base/batch-settlement/client` |
+| Server | `@x402/base/batch-settlement/server` |
+| Facilitator | `@x402/base/batch-settlement/facilitator` |
+
+## Client Usage
+
+```typescript
+import { x402Client } from "@x402/core/client";
+import { BaseScheme } from "@x402/base/batch-settlement/client";
+import { privateKeyToAccount } from "viem/accounts";
+
+const signer = privateKeyToAccount(process.env.EVM_PRIVATE_KEY as `0x${string}`);
+
+const client = new x402Client();
+client.register("eip155:8453", new BaseScheme(signer, { depositPolicy: { depositMultiplier: 5 } }));
+```
+
+The client automatically deposits (bundled with the first voucher) when a channel has no balance
+or needs a top-up, and signs voucher-only payloads for subsequent requests against the same
+channel. Cooperative refunds are available via `client.refund(url)`.
+
+## Server Usage
+
+```typescript
+import { x402ResourceServer } from "@x402/core/server";
+import { BaseScheme } from "@x402/base/batch-settlement/server";
+
+const server = new x402ResourceServer(facilitatorClient);
+server.register(
+  "eip155:84532",
+  new BaseScheme("0xYourReceiverAddress", { receiverAuthorizerSigner }),
+);
+```
+
+The server must either configure its own `receiverAuthorizerSigner` or use a facilitator that
+advertises one via `getExtra()` — see
+[`@x402/evm`'s batch-settlement docs](../../../evm/src/batch-settlement/README.md) for the
+receiver-authorizer delegation model and channel storage options (in-memory, file, Redis).
+
+## Facilitator Usage
+
+```typescript
+import { BaseScheme } from "@x402/base/batch-settlement/facilitator";
+
+const scheme = new BaseScheme(facilitatorSigner, authorizerSigner);
+```
+
+The facilitator verifies deposits/vouchers and settles deposits, claims, batch settlements, and
+refunds onchain against the deployed `x402BatchSettlement` contract.
+
+## Supported networks
+
+| Network | CAIP-2 ID |
+|---------|-----------|
+| Base Mainnet | `eip155:8453` |
+| Base Sepolia | `eip155:84532` |
+
+## See Also
+
+- [`@x402/evm` Batch-Settlement Scheme](../../../evm/src/batch-settlement/README.md) — the implementation this package wraps
+- [Exact Base Scheme](../exact/README.md) — fixed-price payments
+- [Upto Base Scheme](../upto/README.md) — usage-based payments

--- a/typescript/packages/mechanisms/base/src/batch-settlement/client/index.ts
+++ b/typescript/packages/mechanisms/base/src/batch-settlement/client/index.ts
@@ -1,0 +1,33 @@
+import type {
+  BatchSettlementClientContext,
+  BatchSettlementDepositStrategy,
+  BatchSettlementDepositStrategyContext,
+  BatchSettlementDepositStrategyResult,
+  ClientChannelStorage,
+} from "@x402/evm/batch-settlement/client";
+
+export { BaseScheme } from "./scheme";
+export type {
+  BaseChannelConfig,
+  BaseBatchSettlementDepositPolicy,
+  BaseBatchSettlementSchemeOptions,
+  BaseClientSigner,
+  BaseRefundOptions,
+} from "./scheme";
+
+export { InMemoryClientChannelStorage as BaseInMemoryClientChannelStorage } from "@x402/evm/batch-settlement/client";
+
+/** Per-request context surfaced to a {@link BaseBatchSettlementDepositStrategy}. Identical to `@x402/evm`'s `BatchSettlementClientContext`. */
+export type BaseBatchSettlementClientContext = BatchSettlementClientContext;
+
+/** Custom deposit-sizing callback. Identical to `@x402/evm`'s `BatchSettlementDepositStrategy`. */
+export type BaseBatchSettlementDepositStrategy = BatchSettlementDepositStrategy;
+
+/** Context passed to a {@link BaseBatchSettlementDepositStrategy}. Identical to `@x402/evm`'s `BatchSettlementDepositStrategyContext`. */
+export type BaseBatchSettlementDepositStrategyContext = BatchSettlementDepositStrategyContext;
+
+/** Return shape for a {@link BaseBatchSettlementDepositStrategy}. Identical to `@x402/evm`'s `BatchSettlementDepositStrategyResult`. */
+export type BaseBatchSettlementDepositStrategyResult = BatchSettlementDepositStrategyResult;
+
+/** Pluggable client-side channel storage backend. Identical to `@x402/evm`'s `ClientChannelStorage`. */
+export type BaseClientChannelStorage = ClientChannelStorage;

--- a/typescript/packages/mechanisms/base/src/batch-settlement/client/scheme.ts
+++ b/typescript/packages/mechanisms/base/src/batch-settlement/client/scheme.ts
@@ -1,0 +1,130 @@
+import type {
+  PaymentPayloadContext,
+  PaymentPayloadResult,
+  PaymentRequired,
+  PaymentRequirements,
+  SchemeClientHooks,
+  SchemeNetworkClient,
+  SettleResponse,
+} from "@x402/core/types";
+import { BatchSettlementEvmScheme, ChannelConfig, ClientEvmSigner } from "@x402/evm";
+import type {
+  BatchSettlementDepositPolicy,
+  BatchSettlementEvmSchemeOptions,
+  RefundOptions,
+} from "@x402/evm/batch-settlement/client";
+import { assertBaseNetwork, findBaseDefaultAsset } from "../../networks";
+
+/** Signer required by {@link BaseScheme} (client). Identical to `@x402/evm`'s `ClientEvmSigner`. */
+export type BaseClientSigner = ClientEvmSigner;
+
+/** Immutable channel identity. Identical to `@x402/evm`'s `ChannelConfig`. */
+export type BaseChannelConfig = ChannelConfig;
+
+/** Deposit-sizing policy accepted by {@link BaseScheme} (client). Identical to `@x402/evm`'s `BatchSettlementDepositPolicy`. */
+export type BaseBatchSettlementDepositPolicy = BatchSettlementDepositPolicy;
+
+/** Full constructor options for {@link BaseScheme} (client). Identical to `@x402/evm`'s `BatchSettlementEvmSchemeOptions`. */
+export type BaseBatchSettlementSchemeOptions = BatchSettlementEvmSchemeOptions;
+
+/** Options accepted by {@link BaseScheme.refund}. Identical to `@x402/evm`'s `RefundOptions`. */
+export type BaseRefundOptions = RefundOptions;
+
+/**
+ * Base client implementation for the batch-settlement (payment channel) scheme.
+ *
+ * Thin pass-through wrapper around the generic EVM {@link BatchSettlementEvmScheme}
+ * (`@x402/evm`). Base (`eip155:8453` / `eip155:84532`) has no client-side
+ * differences from generic EVM today - this class exists as an explicit,
+ * overridable seam so Base-specific behavior can be introduced later without
+ * changing the public `@x402/base` API surface.
+ *
+ * `createPaymentPayload` and `buildChannelConfig` reject any network outside
+ * `eip155:8453` / `eip155:84532` - see {@link assertBaseNetwork}.
+ * `findDefaultAsset` is scoped the same way via {@link findBaseDefaultAsset}.
+ * `refund` and `processCorrectivePaymentRequired` are left unguarded: the
+ * network they act on lives inside an already-established channel (or a
+ * `PaymentRequired.accepts[]` whose follow-up `createPaymentPayload` call is
+ * itself guarded), not a fresh caller-supplied value.
+ */
+export class BaseScheme implements SchemeNetworkClient {
+  readonly scheme = "batch-settlement";
+  findDefaultAsset = findBaseDefaultAsset;
+  readonly schemeHooks: SchemeClientHooks;
+  private readonly batchSettlementEvmScheme: BatchSettlementEvmScheme;
+
+  /**
+   * Creates a new BaseScheme client instance.
+   *
+   * @param signer - Base (EVM) wallet used for signing vouchers and deposit authorizations.
+   * @param optionsOrPolicy - Either a full options object or a bare deposit-policy.
+   */
+  constructor(
+    signer: BaseClientSigner,
+    optionsOrPolicy?: BaseBatchSettlementSchemeOptions | BaseBatchSettlementDepositPolicy,
+  ) {
+    this.batchSettlementEvmScheme = new BatchSettlementEvmScheme(signer, optionsOrPolicy);
+    this.schemeHooks = this.batchSettlementEvmScheme.schemeHooks;
+  }
+
+  /**
+   * Creates the payment payload for a batched request. Delegates to the
+   * underlying {@link BatchSettlementEvmScheme} after asserting the
+   * requirements' network is in Base's scope.
+   *
+   * @param x402Version - Protocol version for the payload envelope.
+   * @param paymentRequirements - Server payment requirements (scheme, network, asset, amount).
+   * @param context - Optional payment payload context with extension hints.
+   * @returns A {@link PaymentPayloadResult} ready to be sent as the `X-PAYMENT` header.
+   * @throws When `paymentRequirements.network` is not `eip155:8453` / `eip155:84532`
+   */
+  async createPaymentPayload(
+    x402Version: number,
+    paymentRequirements: PaymentRequirements,
+    context?: PaymentPayloadContext,
+  ): Promise<PaymentPayloadResult> {
+    assertBaseNetwork(paymentRequirements.network, "BaseScheme.createPaymentPayload");
+    return this.batchSettlementEvmScheme.createPaymentPayload(
+      x402Version,
+      paymentRequirements,
+      context,
+    );
+  }
+
+  /**
+   * Sends a cooperative refund request. Passes through entirely to the
+   * underlying {@link BatchSettlementEvmScheme}.
+   *
+   * @param url - The route URL backing the channel to refund.
+   * @param options - Optional `amount` (partial refund) and `fetch` override.
+   * @returns The settle response describing the refund outcome.
+   */
+  async refund(url: string, options?: BaseRefundOptions): Promise<SettleResponse> {
+    return this.batchSettlementEvmScheme.refund(url, options);
+  }
+
+  /**
+   * Resyncs local channel state from a corrective 402 response. Passes
+   * through entirely to the underlying {@link BatchSettlementEvmScheme}.
+   *
+   * @param paymentRequired - The decoded 402 response body.
+   * @returns `true` if local state was successfully resynced and a retry is warranted.
+   */
+  async processCorrectivePaymentRequired(paymentRequired: PaymentRequired): Promise<boolean> {
+    return this.batchSettlementEvmScheme.processCorrectivePaymentRequired(paymentRequired);
+  }
+
+  /**
+   * Builds the immutable {@link BaseChannelConfig} for a given set of payment
+   * requirements. Delegates to the underlying {@link BatchSettlementEvmScheme}
+   * after asserting the requirements' network is in Base's scope.
+   *
+   * @param paymentRequirements - Server payment requirements for the channel.
+   * @returns The channel config that uniquely identifies the payment channel.
+   * @throws When `paymentRequirements.network` is not `eip155:8453` / `eip155:84532`
+   */
+  buildChannelConfig(paymentRequirements: PaymentRequirements): BaseChannelConfig {
+    assertBaseNetwork(paymentRequirements.network, "BaseScheme.buildChannelConfig");
+    return this.batchSettlementEvmScheme.buildChannelConfig(paymentRequirements);
+  }
+}

--- a/typescript/packages/mechanisms/base/src/batch-settlement/facilitator/index.ts
+++ b/typescript/packages/mechanisms/base/src/batch-settlement/facilitator/index.ts
@@ -1,0 +1,6 @@
+export { BaseScheme } from "./scheme";
+export type {
+  BaseAuthorizerSigner,
+  BaseBatchSettlementSchemeConfig,
+  BaseFacilitatorSigner,
+} from "./scheme";

--- a/typescript/packages/mechanisms/base/src/batch-settlement/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/base/src/batch-settlement/facilitator/scheme.ts
@@ -1,0 +1,124 @@
+import type {
+  FacilitatorContext,
+  PaymentPayload,
+  PaymentRequirements,
+  SchemeNetworkFacilitator,
+  SettleResponse,
+  VerifyResponse,
+} from "@x402/core/types";
+import { AuthorizerSigner, FacilitatorEvmSigner } from "@x402/evm";
+import { BatchSettlementEvmScheme } from "@x402/evm/batch-settlement/facilitator";
+import type { BatchSettlementEvmSchemeConfig } from "@x402/evm/batch-settlement/facilitator";
+import { assertBaseNetwork, isBaseNetwork } from "../../networks";
+
+/** Signer required by {@link BaseScheme} (facilitator). Identical to `@x402/evm`'s `FacilitatorEvmSigner`. */
+export type BaseFacilitatorSigner = FacilitatorEvmSigner;
+
+/** EIP-712 signer for receiver-authorizer claims/refunds. Identical to `@x402/evm`'s `AuthorizerSigner`. */
+export type BaseAuthorizerSigner = AuthorizerSigner;
+
+/** Optional constructor config for {@link BaseScheme} (facilitator). Identical to `@x402/evm`'s `BatchSettlementEvmSchemeConfig`. */
+export type BaseBatchSettlementSchemeConfig = BatchSettlementEvmSchemeConfig;
+
+/**
+ * Base facilitator implementation for the batch-settlement (payment channel)
+ * scheme.
+ *
+ * Thin pass-through wrapper around the generic EVM {@link BatchSettlementEvmScheme}
+ * (`@x402/evm`). Base (`eip155:8453` / `eip155:84532`) has no facilitator-side
+ * differences from generic EVM today - this class exists as an explicit,
+ * overridable seam so Base-specific verify/settle behavior can be introduced
+ * later without changing the public `@x402/base` API surface.
+ *
+ * `verify` and `settle` reject any network outside `eip155:8453` /
+ * `eip155:84532` - see {@link assertBaseNetwork}. `getExtra` and
+ * `getSigners` fail closed (return `undefined` / `[]`) off-Base instead.
+ */
+export class BaseScheme implements SchemeNetworkFacilitator {
+  readonly scheme = "batch-settlement";
+  readonly caipFamily = "eip155:*";
+  private readonly batchSettlementEvmScheme: BatchSettlementEvmScheme;
+
+  /**
+   * Creates a facilitator scheme for verifying and settling batch-settlement payments.
+   *
+   * @param signer - Base (EVM) signer(s) used for tx submission and onchain reads.
+   * @param authorizerSigner - Optional dedicated key that provides EIP-712 signatures for
+   *   `claimWithSignature` / `refundWithSignature`.
+   * @param config - Optional configuration (e.g. ERC-6492 factory allowlist).
+   */
+  constructor(
+    signer: BaseFacilitatorSigner,
+    authorizerSigner?: BaseAuthorizerSigner,
+    config?: BaseBatchSettlementSchemeConfig,
+  ) {
+    this.batchSettlementEvmScheme = new BatchSettlementEvmScheme(signer, authorizerSigner, config);
+  }
+
+  /**
+   * Returns facilitator-specific extra fields to be merged into payment
+   * requirements, or `undefined` off-Base. Otherwise passes through to the
+   * underlying {@link BatchSettlementEvmScheme}.
+   *
+   * @param network - Network identifier.
+   * @returns Extra fields containing `receiverAuthorizer`, or `undefined`.
+   */
+  getExtra(network: string): { receiverAuthorizer: `0x${string}` } | undefined {
+    if (!isBaseNetwork(network)) return undefined;
+    return this.batchSettlementEvmScheme.getExtra(network);
+  }
+
+  /**
+   * Returns all facilitator signer addresses available for the given
+   * network, or `[]` off-Base. Otherwise passes through to the underlying
+   * {@link BatchSettlementEvmScheme}.
+   *
+   * @param network - Network identifier.
+   * @returns Array of hex addresses.
+   */
+  getSigners(network: string): `0x${string}`[] {
+    if (!isBaseNetwork(network)) return [];
+    return this.batchSettlementEvmScheme.getSigners(network);
+  }
+
+  /**
+   * Verifies a payment payload (deposit or voucher) without executing
+   * settlement. Passes through to the underlying {@link BatchSettlementEvmScheme}.
+   *
+   * @param payload - The x402 payment payload envelope.
+   * @param requirements - Server payment requirements (scheme, network, asset, amount).
+   * @param context - Optional facilitator extension context.
+   * @param extensions - Payment required extensions (unused; reserved for interface parity).
+   * @returns A {@link VerifyResponse} indicating validity with payer and channel state in `extra`.
+   * @throws When `requirements.network` is not `eip155:8453` / `eip155:84532`
+   */
+  async verify(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+    context?: FacilitatorContext,
+    extensions?: Record<string, unknown>,
+  ): Promise<VerifyResponse> {
+    assertBaseNetwork(requirements.network, "BaseScheme.verify");
+    return this.batchSettlementEvmScheme.verify(payload, requirements, context, extensions);
+  }
+
+  /**
+   * Executes settlement for a payment payload. Delegates to the underlying
+   * {@link BatchSettlementEvmScheme} after asserting `requirements.network`
+   * is in Base's scope.
+   *
+   * @param payload - The x402 payment payload envelope.
+   * @param requirements - Server payment requirements.
+   * @param context - Optional facilitator extension context.
+   * @returns A {@link SettleResponse} with the transaction hash on success.
+   * @throws When `requirements.network` is not `eip155:8453` / `eip155:84532`
+   */
+  async settle(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+    context?: FacilitatorContext,
+  ): Promise<SettleResponse> {
+    assertBaseNetwork(requirements.network, "BaseScheme.settle");
+    return this.batchSettlementEvmScheme.settle(payload, requirements, context);
+  }
+}

--- a/typescript/packages/mechanisms/base/src/batch-settlement/index.ts
+++ b/typescript/packages/mechanisms/base/src/batch-settlement/index.ts
@@ -1,0 +1,1 @@
+export { BaseScheme } from "./client/scheme";

--- a/typescript/packages/mechanisms/base/src/batch-settlement/server/index.ts
+++ b/typescript/packages/mechanisms/base/src/batch-settlement/server/index.ts
@@ -1,0 +1,54 @@
+import type {
+  AutoSettlementConfig,
+  AutoSettlementContext,
+  ChannelManagerConfig,
+  ChannelUpdateResult,
+  ClaimChannelSelector,
+  ClaimOptions,
+  ClaimResult,
+  PendingRequest,
+  RefundResult,
+  SettleResult,
+} from "@x402/evm/batch-settlement/server";
+
+export { BaseScheme } from "./scheme";
+export type {
+  BaseAuthorizerSigner,
+  BaseBatchSettlementChannelManager,
+  BaseBatchSettlementRequestContext,
+  BaseBatchSettlementSchemeServerConfig,
+  BaseChannel,
+  BaseChannelStorage,
+} from "./scheme";
+
+export { InMemoryChannelStorage as BaseInMemoryChannelStorage } from "@x402/evm/batch-settlement/server";
+
+/** Result of a completed onchain channel state update. Identical to `@x402/evm`'s `ChannelUpdateResult`. */
+export type BaseChannelUpdateResult = ChannelUpdateResult;
+
+/** A channel's pending withdrawal reservation. Identical to `@x402/evm`'s `PendingRequest`. */
+export type BasePendingRequest = PendingRequest;
+
+/** Constructor config for {@link BaseBatchSettlementChannelManager}. Identical to `@x402/evm`'s `ChannelManagerConfig`. */
+export type BaseChannelManagerConfig = ChannelManagerConfig;
+
+/** Auto-settlement policy for {@link BaseBatchSettlementChannelManager}. Identical to `@x402/evm`'s `AutoSettlementConfig`. */
+export type BaseAutoSettlementConfig = AutoSettlementConfig;
+
+/** Context passed to an auto-settlement policy callback. Identical to `@x402/evm`'s `AutoSettlementContext`. */
+export type BaseAutoSettlementContext = AutoSettlementContext;
+
+/** Selector for which channels to claim in a batch. Identical to `@x402/evm`'s `ClaimChannelSelector`. */
+export type BaseClaimChannelSelector = ClaimChannelSelector;
+
+/** Options accepted by a batch claim call. Identical to `@x402/evm`'s `ClaimOptions`. */
+export type BaseClaimOptions = ClaimOptions;
+
+/** Result of a batch claim call. Identical to `@x402/evm`'s `ClaimResult`. */
+export type BaseClaimResult = ClaimResult;
+
+/** Result of a channel refund. Identical to `@x402/evm`'s `RefundResult`. */
+export type BaseRefundResult = RefundResult;
+
+/** Result of a channel settle call. Identical to `@x402/evm`'s `SettleResult`. */
+export type BaseSettleResult = SettleResult;

--- a/typescript/packages/mechanisms/base/src/batch-settlement/server/scheme.ts
+++ b/typescript/packages/mechanisms/base/src/batch-settlement/server/scheme.ts
@@ -1,0 +1,356 @@
+import type {
+  AssetAmount,
+  DeepReadonly,
+  MoneyParser,
+  Network,
+  PaymentFlowConfig,
+  PaymentPayload,
+  PaymentRequirements,
+  Price,
+  SchemeNetworkServer,
+  SchemeServerHooks,
+  SupportedKind,
+} from "@x402/core/types";
+import type { FacilitatorClient, SettleContext, SettleResultContext } from "@x402/core/server";
+import { BatchSettlementEvmScheme } from "@x402/evm/batch-settlement/server";
+import type {
+  AuthorizerSigner,
+  BatchSettlementChannelManager,
+  BatchSettlementEvmSchemeServerConfig,
+  BatchSettlementRequestContext,
+  Channel,
+  ChannelStorage,
+} from "@x402/evm/batch-settlement/server";
+import { assertBaseNetwork, isBaseNetwork } from "../../networks";
+
+/** EIP-712 signer for receiver-authorizer claims/refunds. Identical to `@x402/evm`'s `AuthorizerSigner`. */
+export type BaseAuthorizerSigner = AuthorizerSigner;
+
+/** Optional constructor config for {@link BaseScheme} (server). Identical to `@x402/evm`'s `BatchSettlementEvmSchemeServerConfig`. */
+export type BaseBatchSettlementSchemeServerConfig = BatchSettlementEvmSchemeServerConfig;
+
+/** Per-request scratch state tracked by {@link BaseScheme} (server). Identical to `@x402/evm`'s `BatchSettlementRequestContext`. */
+export type BaseBatchSettlementRequestContext = BatchSettlementRequestContext;
+
+/** Onchain/local channel state. Identical to `@x402/evm`'s `Channel`. */
+export type BaseChannel = Channel;
+
+/** Pluggable server-side channel storage backend. Identical to `@x402/evm`'s `ChannelStorage`. */
+export type BaseChannelStorage = ChannelStorage;
+
+/** Claim/settle/refund orchestrator. Identical to `@x402/evm`'s `BatchSettlementChannelManager`. */
+export type BaseBatchSettlementChannelManager = BatchSettlementChannelManager;
+
+/**
+ * Base resource-server implementation for the batch-settlement (payment
+ * channel) scheme.
+ *
+ * Thin pass-through wrapper around the generic EVM {@link BatchSettlementEvmScheme}
+ * (`@x402/evm`). Base (`eip155:8453` / `eip155:84532`) has no
+ * resource-server-side differences from generic EVM today - this class
+ * exists as an explicit, overridable seam so Base-specific behavior can be
+ * introduced later without changing the public `@x402/base` API surface.
+ *
+ * `parsePrice`, `enhancePaymentRequirements`, and `createChannelManager`
+ * reject any network outside `eip155:8453` / `eip155:84532` - see
+ * {@link assertBaseNetwork}. Registering this scheme under a network (or
+ * wildcard pattern) outside Base's scope fails fast at
+ * `x402ResourceServer.initialize()` via {@link BaseScheme.validateFacilitatorSupport}.
+ */
+export class BaseScheme implements SchemeNetworkServer {
+  readonly scheme = "batch-settlement";
+  readonly defaultAssetTransferMethod: string;
+  readonly paymentFlows: Readonly<Record<string, PaymentFlowConfig>>;
+  readonly schemeHooks: SchemeServerHooks;
+  private readonly batchSettlementEvmScheme: BatchSettlementEvmScheme;
+
+  /**
+   * Creates a new BaseScheme server instance.
+   *
+   * @param receiverAddress - The server's receiver address (payTo).
+   * @param config - Optional configuration for storage, receiver-authorizer signer, and withdraw delay.
+   */
+  constructor(receiverAddress: `0x${string}`, config?: BaseBatchSettlementSchemeServerConfig) {
+    this.batchSettlementEvmScheme = new BatchSettlementEvmScheme(receiverAddress, config);
+    this.defaultAssetTransferMethod = this.batchSettlementEvmScheme.defaultAssetTransferMethod;
+    this.paymentFlows = this.batchSettlementEvmScheme.paymentFlows;
+    this.schemeHooks = this.batchSettlementEvmScheme.schemeHooks;
+  }
+
+  /**
+   * Adds server-owned settlement fields before facilitator settlement.
+   * Passes through to the underlying {@link BatchSettlementEvmScheme}.
+   *
+   * @param ctx - Settlement context for the current payment.
+   * @returns Additive payload fields, or nothing when no enrichment is needed.
+   */
+  enrichSettlementPayload = (ctx: SettleContext): Promise<Record<string, unknown> | void> =>
+    this.batchSettlementEvmScheme.enrichSettlementPayload(ctx);
+
+  /**
+   * Adds corrective channel state to payment-required responses when
+   * available. Passes through to the underlying {@link BatchSettlementEvmScheme}.
+   *
+   * @param ctx - Payment-required response context for the current request.
+   * @returns Updated payment requirements, or nothing when no enrichment is needed.
+   */
+  enrichPaymentRequiredResponse = (
+    ctx: Parameters<BatchSettlementEvmScheme["enrichPaymentRequiredResponse"]>[0],
+  ): Promise<PaymentRequirements[] | void> =>
+    this.batchSettlementEvmScheme.enrichPaymentRequiredResponse(ctx);
+
+  /**
+   * Adds server-owned extra fields after facilitator settlement. Passes
+   * through to the underlying {@link BatchSettlementEvmScheme}.
+   *
+   * @param ctx - Settlement result context for the current payment.
+   * @returns Additive response extra fields, or nothing when no enrichment is needed.
+   */
+  enrichSettlementResponse = (ctx: SettleResultContext): Promise<Record<string, unknown> | void> =>
+    this.batchSettlementEvmScheme.enrichSettlementResponse(ctx);
+
+  /**
+   * Merges batch-settlement state into the current request context. Passes
+   * through to the underlying {@link BatchSettlementEvmScheme}.
+   *
+   * @param payload - Request-scoped payment payload object.
+   * @param context - Partial context fields to merge.
+   */
+  mergeRequestContext(
+    payload: DeepReadonly<PaymentPayload>,
+    context: BaseBatchSettlementRequestContext,
+  ): void {
+    this.batchSettlementEvmScheme.mergeRequestContext(payload, context);
+  }
+
+  /**
+   * Reads batch-settlement state for the current request without clearing
+   * it. Passes through to the underlying {@link BatchSettlementEvmScheme}.
+   *
+   * @param payload - Request-scoped payment payload object.
+   * @returns Request context, if one was recorded.
+   */
+  readRequestContext(
+    payload: DeepReadonly<PaymentPayload>,
+  ): BaseBatchSettlementRequestContext | undefined {
+    return this.batchSettlementEvmScheme.readRequestContext(payload);
+  }
+
+  /**
+   * Reads and clears batch-settlement state for the current request. Passes
+   * through to the underlying {@link BatchSettlementEvmScheme}.
+   *
+   * @param payload - Request-scoped payment payload object.
+   * @returns Request context, if one was recorded.
+   */
+  takeRequestContext(
+    payload: DeepReadonly<PaymentPayload>,
+  ): BaseBatchSettlementRequestContext | undefined {
+    return this.batchSettlementEvmScheme.takeRequestContext(payload);
+  }
+
+  /**
+   * Stores a channel snapshot for the current settlement request. Passes
+   * through to the underlying {@link BatchSettlementEvmScheme}.
+   *
+   * @param payload - Request-scoped payment payload object.
+   * @param channel - Channel state to use during response enrichment.
+   */
+  rememberChannelSnapshot(payload: DeepReadonly<PaymentPayload>, channel: BaseChannel): void {
+    this.batchSettlementEvmScheme.rememberChannelSnapshot(payload, channel);
+  }
+
+  /**
+   * Reads and clears a channel snapshot for the current settlement request.
+   * Passes through to the underlying {@link BatchSettlementEvmScheme}.
+   *
+   * @param payload - Request-scoped payment payload object.
+   * @returns Stored channel state, if one was recorded.
+   */
+  takeChannelSnapshot(payload: DeepReadonly<PaymentPayload>): BaseChannel | undefined {
+    return this.batchSettlementEvmScheme.takeChannelSnapshot(payload);
+  }
+
+  /**
+   * Clears this request's pending reservation without touching newer
+   * reservations. Passes through to the underlying {@link BatchSettlementEvmScheme}.
+   *
+   * @param payload - Request-scoped payment payload object.
+   * @returns Resolves once the pending reservation is cleared.
+   */
+  async clearPendingRequest(payload: DeepReadonly<PaymentPayload>): Promise<void> {
+    await this.batchSettlementEvmScheme.clearPendingRequest(payload);
+  }
+
+  /**
+   * Registers a custom money parser for converting price strings to token
+   * amounts. Passes through to the underlying {@link BatchSettlementEvmScheme}.
+   *
+   * @param parser - A parser function to try before the default USD→token conversion.
+   * @returns `this` for chaining.
+   */
+  registerMoneyParser(parser: MoneyParser): BaseScheme {
+    this.batchSettlementEvmScheme.registerMoneyParser(parser);
+    return this;
+  }
+
+  /**
+   * Resolves a human-readable price (e.g. `"$0.01"`) into an onchain token
+   * amount. Delegates to the underlying {@link BatchSettlementEvmScheme}
+   * after asserting `network` is in Base's scope.
+   *
+   * @param price - A price string, number, or explicit `AssetAmount`.
+   * @param network - CAIP-2 network identifier for looking up the default asset.
+   * @returns Token amount with asset address and metadata.
+   * @throws When `network` is not `eip155:8453` / `eip155:84532`
+   */
+  async parsePrice(price: Price, network: Network): Promise<AssetAmount> {
+    assertBaseNetwork(network, "BaseScheme.parsePrice");
+    return this.batchSettlementEvmScheme.parsePrice(price, network);
+  }
+
+  /**
+   * Decimals for a known default asset, or undefined off-Base or when
+   * unrecognized. Otherwise passes through to the underlying
+   * {@link BatchSettlementEvmScheme}.
+   *
+   * @param asset - Asset address or symbol
+   * @param network - Target network
+   * @returns Decimals when the asset is a known Base default; otherwise undefined
+   */
+  getAssetDecimals(asset: string, network: Network): number | undefined {
+    if (!isBaseNetwork(network)) return undefined;
+    return this.batchSettlementEvmScheme.getAssetDecimals(asset, network);
+  }
+
+  /**
+   * Injects batched-specific fields into the payment requirements returned
+   * to the client. Passes through to the underlying {@link BatchSettlementEvmScheme}.
+   *
+   * @param paymentRequirements - Base payment requirements from the middleware.
+   * @param supportedKind - Matched scheme/network kind (extra may contain overrides).
+   * @param supportedKind.x402Version - The x402 version.
+   * @param supportedKind.scheme - The logical payment scheme.
+   * @param supportedKind.network - The network identifier in CAIP-2 format.
+   * @param supportedKind.extra - Optional extra metadata regarding scheme/network implementation details.
+   * @param extensionKeys - Extension keys (unused).
+   * @returns Enhanced payment requirements with batched fields in `extra`.
+   * @throws When `supportedKind.network` is not `eip155:8453` / `eip155:84532`
+   */
+  async enhancePaymentRequirements(
+    paymentRequirements: PaymentRequirements,
+    supportedKind: {
+      x402Version: number;
+      scheme: string;
+      network: Network;
+      extra?: Record<string, unknown>;
+    },
+    extensionKeys: string[],
+  ): Promise<PaymentRequirements> {
+    assertBaseNetwork(supportedKind.network, "BaseScheme.enhancePaymentRequirements");
+    return this.batchSettlementEvmScheme.enhancePaymentRequirements(
+      paymentRequirements,
+      supportedKind,
+      extensionKeys,
+    );
+  }
+
+  /**
+   * Fails server startup when this scheme is registered against a network
+   * outside Base's scope, or when it delegates the receiver-authorizer role
+   * but the facilitator does not advertise a usable `receiverAuthorizer`.
+   * The Base-scope check runs first, then composes with the underlying
+   * {@link BatchSettlementEvmScheme}'s own validation.
+   *
+   * @param network - The network identifier being validated.
+   * @param supportedKind - The facilitator's advertised kind for this scheme/network.
+   * @param extensionKeys - Extensions advertised by the facilitator (unused).
+   * @returns A problem message when delegation is impossible, or void when valid.
+   */
+  validateFacilitatorSupport(
+    network: Network,
+    supportedKind: SupportedKind,
+    extensionKeys: string[],
+  ): string | void {
+    if (!isBaseNetwork(network)) {
+      return `@x402/base only supports eip155:8453 and eip155:84532, but was registered for ${network}`;
+    }
+    return this.batchSettlementEvmScheme.validateFacilitatorSupport(
+      network,
+      supportedKind,
+      extensionKeys,
+    );
+  }
+
+  /**
+   * Returns the underlying channel storage instance. Passes through to the
+   * underlying {@link BatchSettlementEvmScheme}.
+   *
+   * @returns The configured channel storage backend.
+   */
+  getStorage(): BaseChannelStorage {
+    return this.batchSettlementEvmScheme.getStorage();
+  }
+
+  /**
+   * Returns the server's receiver address. Passes through to the underlying
+   * {@link BatchSettlementEvmScheme}.
+   *
+   * @returns Receiver wallet address for the payment channel.
+   */
+  getReceiverAddress(): `0x${string}` {
+    return this.batchSettlementEvmScheme.getReceiverAddress();
+  }
+
+  /**
+   * Returns the configured withdraw delay (seconds). Passes through to the
+   * underlying {@link BatchSettlementEvmScheme}.
+   *
+   * @returns Withdraw delay in seconds before uncooperative withdrawal is allowed.
+   */
+  getWithdrawDelay(): number {
+    return this.batchSettlementEvmScheme.getWithdrawDelay();
+  }
+
+  /**
+   * Returns how long mirrored onchain channel state is trusted for local
+   * voucher verification. Passes through to the underlying
+   * {@link BatchSettlementEvmScheme}.
+   *
+   * @returns Freshness window in milliseconds.
+   */
+  getOnchainStateTtlMs(): number {
+    return this.batchSettlementEvmScheme.getOnchainStateTtlMs();
+  }
+
+  /**
+   * Returns the receiver-authorizer signer, if configured. Passes through to
+   * the underlying {@link BatchSettlementEvmScheme}.
+   *
+   * @returns Receiver-authorizer signer, or `undefined` when not set.
+   */
+  getReceiverAuthorizerSigner(): BaseAuthorizerSigner | undefined {
+    return this.batchSettlementEvmScheme.getReceiverAuthorizerSigner();
+  }
+
+  /**
+   * Creates a {@link BaseBatchSettlementChannelManager} pre-configured with
+   * this scheme's receiver, a token for the given network, and the provided
+   * facilitator. Delegates to the underlying {@link BatchSettlementEvmScheme}
+   * after asserting `network` is in Base's scope.
+   *
+   * @param facilitator - Facilitator client for submitting onchain claims/settlements.
+   * @param network - CAIP-2 network identifier (e.g. `"eip155:84532"`).
+   * @param token - Explicit token address to use. Falls back to the network's default asset.
+   * @returns A ready-to-use channel manager.
+   * @throws When `network` is not `eip155:8453` / `eip155:84532`
+   */
+  createChannelManager(
+    facilitator: FacilitatorClient,
+    network: Network,
+    token?: `0x${string}`,
+  ): BaseBatchSettlementChannelManager {
+    assertBaseNetwork(network, "BaseScheme.createChannelManager");
+    return this.batchSettlementEvmScheme.createChannelManager(facilitator, network, token);
+  }
+}

--- a/typescript/packages/mechanisms/base/src/exact/README.md
+++ b/typescript/packages/mechanisms/base/src/exact/README.md
@@ -1,0 +1,91 @@
+# Exact Base Scheme (`@x402/base/exact`)
+
+The **exact** scheme is the default x402 payment scheme for Base. The client pays the exact
+advertised price — no more, no less.
+
+Today, `@x402/base`'s `exact` scheme is a thin pass-through wrapper around
+[`@x402/evm`'s `exact` scheme](../../../evm/src/exact/README.md) — every method delegates to an
+internal `ExactEvmScheme` instance from `@x402/evm`. Constructor arguments, signer requirements,
+supported transfer methods (EIP-3009 and Permit2), and gas-sponsoring extensions are all identical
+to `@x402/evm` — see that package's docs for the full behavior. This package exists as an
+explicit, overridable seam for introducing Base-specific behavior later without changing the
+public API.
+
+## Import Paths
+
+| Role | Import |
+|------|--------|
+| Client | `@x402/base/exact/client` |
+| Server | `@x402/base/exact/server` |
+| Facilitator | `@x402/base/exact/facilitator` |
+
+## Client Usage
+
+Register `BaseScheme` with an `x402Client` to automatically handle payments for Base services
+that use the `exact` scheme.
+
+```typescript
+import { x402Client } from "@x402/core/client";
+import { BaseScheme } from "@x402/base/exact/client";
+import { privateKeyToAccount } from "viem/accounts";
+
+const signer = privateKeyToAccount(process.env.EVM_PRIVATE_KEY as `0x${string}`);
+
+const client = new x402Client()
+  .register("eip155:8453", new BaseScheme(signer))
+  .register("eip155:84532", new BaseScheme(signer));
+```
+
+The client selects between EIP-3009 and Permit2 based on `paymentRequirements.extra.assetTransferMethod`
+(defaults to `eip3009`) — identical to `@x402/evm`.
+
+## Server Usage
+
+Register `BaseScheme` with an `x402ResourceServer` to protect routes with fixed-price payments
+on Base.
+
+```typescript
+import { x402ResourceServer } from "@x402/core/server";
+import { BaseScheme } from "@x402/base/exact/server";
+
+const server = new x402ResourceServer(facilitatorClient);
+server.register("eip155:8453", new BaseScheme());
+server.register("eip155:84532", new BaseScheme());
+```
+
+In your route config, set `scheme: "exact"` and `price` to the fixed amount:
+
+```typescript
+{
+  "GET /weather": {
+    accepts: {
+      scheme: "exact",
+      price: "$0.001",
+      network: "eip155:84532",
+      payTo: "0xYourAddress",
+    },
+  },
+}
+```
+
+## Facilitator Usage
+
+```typescript
+import { BaseScheme } from "@x402/base/exact/facilitator";
+
+const scheme = new BaseScheme(facilitatorSigner);
+```
+
+## Supported Networks
+
+| Network | CAIP-2 ID |
+|---------|-----------|
+| Base Mainnet | `eip155:8453` |
+| Base Sepolia | `eip155:84532` |
+
+## See Also
+
+- [`@x402/evm` Exact Scheme](../../../evm/src/exact/README.md) — the implementation this package wraps
+- [x402 Docs: Quickstart for Sellers](https://docs.x402.org/getting-started/quickstart-for-sellers)
+- [x402 Docs: Quickstart for Buyers](https://docs.x402.org/getting-started/quickstart-for-buyers)
+- [Exact EVM Scheme Specification](https://github.com/x402-foundation/x402/blob/main/specs/schemes/exact/scheme_exact_evm.md)

--- a/typescript/packages/mechanisms/base/src/exact/client/index.ts
+++ b/typescript/packages/mechanisms/base/src/exact/client/index.ts
@@ -1,0 +1,2 @@
+export { BaseScheme } from "./scheme";
+export type { BaseClientSigner, BaseSchemeOptions } from "./scheme";

--- a/typescript/packages/mechanisms/base/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/base/src/exact/client/scheme.ts
@@ -1,0 +1,69 @@
+import {
+  SchemeNetworkClient,
+  PaymentRequirements,
+  PaymentPayloadResult,
+  PaymentPayloadContext,
+} from "@x402/core/types";
+import { ClientEvmSigner } from "@x402/evm";
+import { ExactEvmScheme, type EvmSchemeOptions } from "@x402/evm/exact/client";
+import { assertBaseNetwork, findBaseDefaultAsset } from "../../networks";
+
+/** Signer required by {@link BaseScheme} (client). Identical to `@x402/evm`'s `ClientEvmSigner`. */
+export type BaseClientSigner = ClientEvmSigner;
+
+/** Optional constructor options for {@link BaseScheme} (client). Identical to `@x402/evm`'s `EvmSchemeOptions`. */
+export type BaseSchemeOptions = EvmSchemeOptions;
+
+/**
+ * Base client implementation for the Exact payment scheme.
+ *
+ * Thin pass-through wrapper around the generic EVM {@link ExactEvmScheme}
+ * (`@x402/evm`). Base (`eip155:8453` / `eip155:84532`) has no client-side
+ * differences from generic EVM today - this class exists as an explicit,
+ * overridable seam so Base-specific behavior (e.g. a different default
+ * asset transfer method, extension, or signer requirement) can be
+ * introduced later without changing the public `@x402/base` API surface or
+ * requiring consumers to re-register a different scheme.
+ *
+ * `createPaymentPayload` rejects any network outside `eip155:8453` /
+ * `eip155:84532` - see {@link assertBaseNetwork}. `findDefaultAsset` is
+ * scoped the same way via {@link findBaseDefaultAsset}.
+ */
+export class BaseScheme implements SchemeNetworkClient {
+  readonly scheme = "exact";
+  findDefaultAsset = findBaseDefaultAsset;
+  private readonly exactEvmScheme: ExactEvmScheme;
+
+  /**
+   * Creates a new BaseScheme client instance.
+   *
+   * @param signer - The Base (EVM) signer for client operations.
+   *   Base flow only requires `address` + `signTypedData`.
+   *   Extension enrichment (EIP-2612 / ERC-20 approval sponsoring) additionally
+   *   requires optional capabilities like `readContract` and tx signing helpers.
+   * @param options - Optional RPC configuration used to backfill extension capabilities.
+   */
+  constructor(signer: BaseClientSigner, options?: BaseSchemeOptions) {
+    this.exactEvmScheme = new ExactEvmScheme(signer, options);
+  }
+
+  /**
+   * Creates a payment payload for the Exact scheme. Delegates to the
+   * underlying {@link ExactEvmScheme} after asserting the requirements'
+   * network is in Base's scope.
+   *
+   * @param x402Version - The x402 protocol version
+   * @param paymentRequirements - The payment requirements
+   * @param context - Optional context with server-declared extensions
+   * @returns Promise resolving to a payment payload result (with optional extensions)
+   * @throws When `paymentRequirements.network` is not `eip155:8453` / `eip155:84532`
+   */
+  async createPaymentPayload(
+    x402Version: number,
+    paymentRequirements: PaymentRequirements,
+    context?: PaymentPayloadContext,
+  ): Promise<PaymentPayloadResult> {
+    assertBaseNetwork(paymentRequirements.network, "BaseScheme.createPaymentPayload");
+    return this.exactEvmScheme.createPaymentPayload(x402Version, paymentRequirements, context);
+  }
+}

--- a/typescript/packages/mechanisms/base/src/exact/facilitator/index.ts
+++ b/typescript/packages/mechanisms/base/src/exact/facilitator/index.ts
@@ -1,0 +1,2 @@
+export { BaseScheme } from "./scheme";
+export type { BaseFacilitatorSigner, BaseSchemeConfig } from "./scheme";

--- a/typescript/packages/mechanisms/base/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/base/src/exact/facilitator/scheme.ts
@@ -1,0 +1,114 @@
+import {
+  PaymentPayload,
+  PaymentRequirements,
+  SchemeNetworkFacilitator,
+  FacilitatorContext,
+  SettleResponse,
+  VerifyResponse,
+} from "@x402/core/types";
+import type { FacilitatorEvmSigner } from "@x402/evm";
+import { ExactEvmScheme, type ExactEvmSchemeConfig } from "@x402/evm/exact/facilitator";
+import { assertBaseNetwork, isBaseNetwork } from "../../networks";
+
+/** Signer required by {@link BaseScheme} (facilitator). Identical to `@x402/evm`'s `FacilitatorEvmSigner`. */
+export type BaseFacilitatorSigner = FacilitatorEvmSigner;
+
+/** Optional constructor config for {@link BaseScheme} (facilitator). Identical to `@x402/evm`'s `ExactEvmSchemeConfig`. */
+export type BaseSchemeConfig = ExactEvmSchemeConfig;
+
+/**
+ * Base facilitator implementation for the Exact payment scheme.
+ *
+ * Thin pass-through wrapper around the generic EVM {@link ExactEvmScheme}
+ * (`@x402/evm`). Base (`eip155:8453` / `eip155:84532`) has no
+ * facilitator-side differences from generic EVM today - this class exists
+ * as an explicit, overridable seam so Base-specific verify/settle behavior
+ * (e.g. a Base-specific gas-sponsoring strategy) can be introduced later
+ * without changing the public `@x402/base` API surface.
+ *
+ * `verify` and `settle` reject any network outside `eip155:8453` /
+ * `eip155:84532` - see {@link assertBaseNetwork}. `getExtra` and
+ * `getSigners` fail closed (return `undefined` / `[]`) off-Base instead.
+ */
+export class BaseScheme implements SchemeNetworkFacilitator {
+  readonly scheme = "exact";
+  readonly caipFamily = "eip155:*";
+  private readonly exactEvmScheme: ExactEvmScheme;
+
+  /**
+   * Creates a new BaseScheme facilitator instance.
+   *
+   * @param signer - The Base (EVM) signer for facilitator operations
+   * @param config - Optional configuration
+   */
+  constructor(signer: BaseFacilitatorSigner, config?: BaseSchemeConfig) {
+    this.exactEvmScheme = new ExactEvmScheme(signer, config);
+  }
+
+  /**
+   * Returns mechanism-specific extra data for the given network, or
+   * `undefined` off-Base. Otherwise passes through to the underlying
+   * {@link ExactEvmScheme}.
+   *
+   * @param network - The network identifier
+   * @returns undefined - EVM (and Base) have no mechanism-specific extra data
+   */
+  getExtra(network: string): Record<string, unknown> | undefined {
+    if (!isBaseNetwork(network)) return undefined;
+    return this.exactEvmScheme.getExtra(network);
+  }
+
+  /**
+   * Returns facilitator wallet addresses for the supported response, or
+   * `[]` off-Base. Otherwise passes through to the underlying
+   * {@link ExactEvmScheme}.
+   *
+   * @param network - The network identifier
+   * @returns Array of facilitator wallet addresses
+   */
+  getSigners(network: string): string[] {
+    if (!isBaseNetwork(network)) return [];
+    return this.exactEvmScheme.getSigners(network);
+  }
+
+  /**
+   * Verifies a payment payload. Delegates to the underlying
+   * {@link ExactEvmScheme} after asserting `requirements.network` is in
+   * Base's scope.
+   *
+   * @param payload - The payment payload to verify
+   * @param requirements - The payment requirements
+   * @param context - Optional facilitator context for extension capabilities
+   * @param extra - Payment required extensions (unused; reserved for interface parity)
+   * @returns Promise resolving to verification response
+   * @throws When `requirements.network` is not `eip155:8453` / `eip155:84532`
+   */
+  async verify(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+    context?: FacilitatorContext,
+    extra?: Record<string, unknown>,
+  ): Promise<VerifyResponse> {
+    assertBaseNetwork(requirements.network, "BaseScheme.verify");
+    return this.exactEvmScheme.verify(payload, requirements, context, extra);
+  }
+
+  /**
+   * Settles a payment. Delegates to the underlying {@link ExactEvmScheme}
+   * after asserting `requirements.network` is in Base's scope.
+   *
+   * @param payload - The payment payload to settle
+   * @param requirements - The payment requirements
+   * @param context - Optional facilitator context for extension capabilities
+   * @returns Promise resolving to settlement response
+   * @throws When `requirements.network` is not `eip155:8453` / `eip155:84532`
+   */
+  async settle(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+    context?: FacilitatorContext,
+  ): Promise<SettleResponse> {
+    assertBaseNetwork(requirements.network, "BaseScheme.settle");
+    return this.exactEvmScheme.settle(payload, requirements, context);
+  }
+}

--- a/typescript/packages/mechanisms/base/src/exact/index.ts
+++ b/typescript/packages/mechanisms/base/src/exact/index.ts
@@ -1,0 +1,1 @@
+export { BaseScheme } from "./client/scheme";

--- a/typescript/packages/mechanisms/base/src/exact/server/index.ts
+++ b/typescript/packages/mechanisms/base/src/exact/server/index.ts
@@ -1,0 +1,1 @@
+export { BaseScheme } from "./scheme";

--- a/typescript/packages/mechanisms/base/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/base/src/exact/server/scheme.ts
@@ -1,0 +1,140 @@
+import {
+  AssetAmount,
+  Network,
+  PaymentFlowConfig,
+  PaymentRequirements,
+  Price,
+  SchemeNetworkServer,
+  MoneyParser,
+  SupportedKind,
+} from "@x402/core/types";
+import { ExactEvmScheme } from "@x402/evm/exact/server";
+import { assertBaseNetwork, isBaseNetwork } from "../../networks";
+
+/**
+ * Base resource-server implementation for the Exact payment scheme.
+ *
+ * Thin pass-through wrapper around the generic EVM {@link ExactEvmScheme}
+ * (`@x402/evm`). Base (`eip155:8453` / `eip155:84532`) has no
+ * resource-server-side differences from generic EVM today - this class
+ * exists as an explicit, overridable seam so Base-specific pricing/asset
+ * behavior can be introduced later without changing the public
+ * `@x402/base` API surface.
+ *
+ * `parsePrice` and `enhancePaymentRequirements` reject any network outside
+ * `eip155:8453` / `eip155:84532` - see {@link assertBaseNetwork}. Registering
+ * this scheme under a network (or wildcard pattern) outside Base's scope
+ * fails fast at `x402ResourceServer.initialize()` via
+ * {@link BaseScheme.validateFacilitatorSupport}.
+ */
+export class BaseScheme implements SchemeNetworkServer {
+  readonly scheme = "exact";
+  readonly defaultAssetTransferMethod: string;
+  readonly paymentFlows: Readonly<Record<string, PaymentFlowConfig>>;
+  private readonly exactEvmScheme: ExactEvmScheme;
+
+  /**
+   * Creates a new BaseScheme server instance.
+   */
+  constructor() {
+    this.exactEvmScheme = new ExactEvmScheme();
+    this.defaultAssetTransferMethod = this.exactEvmScheme.defaultAssetTransferMethod;
+    this.paymentFlows = this.exactEvmScheme.paymentFlows;
+  }
+
+  /**
+   * Register a custom money parser in the parser chain. Passes through to
+   * the underlying {@link ExactEvmScheme}.
+   *
+   * @param parser - Custom function to convert amount to AssetAmount (or null to skip)
+   * @returns This scheme instance, for chaining
+   */
+  registerMoneyParser(parser: MoneyParser): BaseScheme {
+    this.exactEvmScheme.registerMoneyParser(parser);
+    return this;
+  }
+
+  /**
+   * Decimals for a known default asset, or undefined off-Base or when
+   * unrecognized. Otherwise passes through to the underlying
+   * {@link ExactEvmScheme}.
+   *
+   * @param asset - Asset address or symbol
+   * @param network - Target network
+   * @returns Decimals when the asset is a known Base default; otherwise undefined
+   */
+  getAssetDecimals(asset: string, network: Network): number | undefined {
+    if (!isBaseNetwork(network)) return undefined;
+    return this.exactEvmScheme.getAssetDecimals(asset, network);
+  }
+
+  /**
+   * Parses a price into an asset amount. Delegates to the underlying
+   * {@link ExactEvmScheme} after asserting `network` is in Base's scope.
+   *
+   * @param price - The price to parse
+   * @param network - The network to use
+   * @returns Promise that resolves to the parsed asset amount
+   * @throws When `network` is not `eip155:8453` / `eip155:84532`
+   */
+  async parsePrice(price: Price, network: Network): Promise<AssetAmount> {
+    assertBaseNetwork(network, "BaseScheme.parsePrice");
+    return this.exactEvmScheme.parsePrice(price, network);
+  }
+
+  /**
+   * Builds payment requirements for this scheme/network combination.
+   * Delegates to the underlying {@link ExactEvmScheme} after asserting
+   * `supportedKind.network` is in Base's scope.
+   *
+   * @param paymentRequirements - The base payment requirements
+   * @param supportedKind - The supported kind from facilitator (unused)
+   * @param supportedKind.x402Version - The x402 version
+   * @param supportedKind.scheme - The logical payment scheme
+   * @param supportedKind.network - The network identifier in CAIP-2 format
+   * @param supportedKind.extra - Optional extra metadata regarding scheme/network implementation details
+   * @param extensionKeys - Extension keys supported by the facilitator (unused)
+   * @returns Payment requirements ready to be sent to clients
+   * @throws When `supportedKind.network` is not `eip155:8453` / `eip155:84532`
+   */
+  async enhancePaymentRequirements(
+    paymentRequirements: PaymentRequirements,
+    supportedKind: {
+      x402Version: number;
+      scheme: string;
+      network: Network;
+      extra?: Record<string, unknown>;
+    },
+    extensionKeys: string[],
+  ): Promise<PaymentRequirements> {
+    assertBaseNetwork(supportedKind.network, "BaseScheme.enhancePaymentRequirements");
+    return this.exactEvmScheme.enhancePaymentRequirements(
+      paymentRequirements,
+      supportedKind,
+      extensionKeys,
+    );
+  }
+
+  /**
+   * Fails server startup when this scheme is registered against a network
+   * outside Base's scope, so a mis-registration (e.g. under a wildcard
+   * pattern that also matches non-Base chains) surfaces at
+   * `x402ResourceServer.initialize()` instead of at first payment.
+   *
+   * @param network - The network identifier being validated.
+   * @param supportedKind - The facilitator's advertised kind for this scheme/network (unused).
+   * @param extensionKeys - Extensions advertised by the facilitator (unused).
+   * @returns A problem message when `network` is outside Base's scope, or void when valid.
+   */
+  validateFacilitatorSupport(
+    network: Network,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    supportedKind: SupportedKind,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    extensionKeys: string[],
+  ): string | void {
+    if (!isBaseNetwork(network)) {
+      return `@x402/base only supports eip155:8453 and eip155:84532, but was registered for ${network}`;
+    }
+  }
+}

--- a/typescript/packages/mechanisms/base/src/index.ts
+++ b/typescript/packages/mechanisms/base/src/index.ts
@@ -1,0 +1,43 @@
+/**
+ * @module @x402/base - x402 Payment Protocol Base Implementation
+ *
+ * Base-specific (`eip155:8453` / `eip155:84532`) mechanisms for the x402
+ * payment protocol. These are thin pass-through wrappers around
+ * `@x402/evm` today - they exist as explicit, overridable seams so
+ * Base-specific behavior can be introduced later without changing the
+ * public `@x402/base` API surface.
+ */
+
+// Signers (shared across all schemes) - renamed from `@x402/evm` so nothing
+// "Evm"-named leaks through the public `@x402/base` API surface.
+export {
+  toClientEvmSigner as toBaseClientSigner,
+  toFacilitatorEvmSigner as toBaseFacilitatorSigner,
+} from "@x402/evm";
+export type {
+  ClientEvmSigner as BaseClientSigner,
+  FacilitatorEvmSigner as BaseFacilitatorSigner,
+} from "@x402/evm";
+
+// Base network scope (shared by all schemes)
+export {
+  BASE_MAINNET,
+  BASE_SEPOLIA,
+  BASE_NETWORKS,
+  isBaseNetwork,
+  assertBaseNetwork,
+  findBaseDefaultAsset,
+} from "./networks";
+export type { BaseNetwork } from "./networks";
+
+// Exact scheme client (default export - the primary payment scheme)
+export { BaseScheme } from "./exact";
+
+// Upto scheme client
+export { BaseScheme as BaseUptoScheme } from "./upto";
+
+// AuthCapture scheme client (client only - see src/auth-capture/README.md)
+export { BaseScheme as BaseAuthCaptureScheme } from "./auth-capture";
+
+// Batch-settlement scheme client
+export { BaseScheme as BaseBatchSettlementScheme } from "./batch-settlement";

--- a/typescript/packages/mechanisms/base/src/networks.ts
+++ b/typescript/packages/mechanisms/base/src/networks.ts
@@ -1,0 +1,71 @@
+import type { FindDefaultAsset } from "@x402/core/types";
+import { findDefaultAsset, type ExactDefaultAssetInfo } from "@x402/evm";
+
+/** Base mainnet CAIP-2 network id. */
+export const BASE_MAINNET = "eip155:8453" as const;
+
+/** Base Sepolia (testnet) CAIP-2 network id. */
+export const BASE_SEPOLIA = "eip155:84532" as const;
+
+/** The only two networks `@x402/base` is scoped to. */
+export const BASE_NETWORKS = [BASE_MAINNET, BASE_SEPOLIA] as const;
+
+/** A CAIP-2 network id `@x402/base` is scoped to. */
+export type BaseNetwork = (typeof BASE_NETWORKS)[number];
+
+/**
+ * Checks whether a network identifier is one `@x402/base` is scoped to
+ * (`eip155:8453` mainnet or `eip155:84532` Sepolia).
+ *
+ * @param network - CAIP-2 network identifier to check.
+ * @returns `true` when `network` is Base mainnet or Base Sepolia.
+ */
+export function isBaseNetwork(network: string): network is BaseNetwork {
+  return (BASE_NETWORKS as readonly string[]).includes(network);
+}
+
+/**
+ * Asserts that a network identifier is one `@x402/base` is scoped to.
+ *
+ * `@x402/base`'s wrappers are thin pass-throughs to `@x402/evm`, which is
+ * generic across the entire `eip155:*` family. Without this guard, a
+ * `BaseScheme` registered under a wildcard pattern (or called directly,
+ * bypassing `@x402/core` registration) would silently process payments for
+ * any EVM chain. This makes that a loud, immediate failure instead.
+ *
+ * @param network - CAIP-2 network identifier to check.
+ * @param operation - Name of the calling operation, included in the error for context.
+ * @throws When `network` is not Base mainnet or Base Sepolia.
+ */
+export function assertBaseNetwork(
+  network: string,
+  operation: string,
+): asserts network is BaseNetwork {
+  if (!isBaseNetwork(network)) {
+    throw new Error(
+      `@x402/base: ${operation} does not support network "${network}" - ` +
+        `@x402/base only supports ${BASE_MAINNET} (Base) and ${BASE_SEPOLIA} (Base Sepolia). ` +
+        `Use @x402/evm directly for other EVM networks.`,
+    );
+  }
+}
+
+/**
+ * Base-scoped reverse lookup for a default asset by address and network.
+ *
+ * Identical to `@x402/evm`'s `findDefaultAsset`, except it returns
+ * `undefined` for any network `@x402/base` is not scoped to, instead of
+ * resolving against `@x402/evm`'s full `eip155:*` asset table. Used as the
+ * client wrappers' `findDefaultAsset` hook, which `@x402/core` also reads
+ * for default spend-control asset recognition.
+ *
+ * @param asset - Asset address from payment requirements.
+ * @param network - CAIP-2 network identifier.
+ * @returns Matching entry, or `undefined` when off-Base or unrecognized.
+ */
+export const findBaseDefaultAsset: FindDefaultAsset<ExactDefaultAssetInfo> = (asset, network) => {
+  if (!isBaseNetwork(network)) {
+    return undefined;
+  }
+  return findDefaultAsset(asset, network);
+};

--- a/typescript/packages/mechanisms/base/src/upto/README.md
+++ b/typescript/packages/mechanisms/base/src/upto/README.md
@@ -1,0 +1,98 @@
+# Upto Base Scheme (`@x402/base/upto`)
+
+The **upto** scheme enables usage-based billing on Base. The client authorizes a **maximum**
+payment amount, but the server settles **only what was actually used** — ideal for variable-cost
+endpoints like LLM token generation, compute time, or bandwidth metering.
+
+Today, `@x402/base`'s `upto` scheme is a thin pass-through wrapper around
+[`@x402/evm`'s `upto` scheme](../../../evm/src/upto/README.md) — every method delegates to an
+internal `UptoEvmScheme` instance from `@x402/evm`. Constructor arguments, signer requirements,
+the Permit2-only transfer method, and gas-sponsoring extensions are all identical to `@x402/evm` —
+see that package's docs for the full behavior. This package exists as an explicit, overridable
+seam for introducing Base-specific behavior later without changing the public API.
+
+## Import Paths
+
+| Role | Import |
+|------|--------|
+| Client | `@x402/base/upto/client` |
+| Server | `@x402/base/upto/server` |
+| Facilitator | `@x402/base/upto/facilitator` |
+
+## Client Usage
+
+Register `BaseScheme` with an `x402Client` to handle payments for Base services that use the
+`upto` scheme.
+
+```typescript
+import { x402Client } from "@x402/core/client";
+import { BaseScheme as BaseExactScheme } from "@x402/base/exact/client";
+import { BaseScheme as BaseUptoScheme } from "@x402/base/upto/client";
+import { privateKeyToAccount } from "viem/accounts";
+
+const signer = privateKeyToAccount(process.env.EVM_PRIVATE_KEY as `0x${string}`);
+
+const client = new x402Client();
+client.register("eip155:8453", new BaseExactScheme(signer)); // fixed-price services
+client.register("eip155:8453", new BaseUptoScheme(signer)); // usage-based services
+```
+
+### Key Difference from Exact
+
+The upto client requires `paymentRequirements.extra.facilitatorAddress` (provided automatically by
+the facilitator via `getExtra()`). This address is embedded in the Permit2 witness so only the
+designated facilitator can settle the payment — identical to `@x402/evm`.
+
+## Server Usage
+
+Register `BaseScheme` with an `x402ResourceServer` and use `setSettlementOverrides` in your
+handler to specify the actual charge.
+
+```typescript
+import { x402ResourceServer } from "@x402/core/server";
+import { BaseScheme } from "@x402/base/upto/server";
+
+const server = new x402ResourceServer(facilitatorClient).register("eip155:84532", new BaseScheme());
+
+// In your route config, `price` is the maximum authorized amount:
+const routes = {
+  "GET /api/generate": {
+    accepts: {
+      scheme: "upto",
+      price: "$0.10", // client authorizes up to 10 cents
+      network: "eip155:84532",
+      payTo: "0xYourAddress",
+    },
+    description: "AI text generation — billed by token usage",
+  },
+};
+```
+
+Settlement override formats (`setSettlementOverrides`) are identical to `@x402/evm` — see the
+[`@x402/evm` upto docs](../../../evm/src/upto/README.md#settlement-override-formats).
+
+## Facilitator Usage
+
+```typescript
+import { BaseScheme } from "@x402/base/upto/facilitator";
+
+const scheme = new BaseScheme(facilitatorSigner);
+```
+
+The upto facilitator's `getExtra()` returns a `facilitatorAddress` that the client embeds in the
+signed Permit2 witness. Only this address can call `settle()` on the upto proxy contract.
+
+## Supported Networks
+
+| Network | CAIP-2 ID |
+|---------|-----------|
+| Base Mainnet | `eip155:8453` |
+| Base Sepolia | `eip155:84532` |
+
+## See Also
+
+- [`@x402/evm` Upto Scheme](../../../evm/src/upto/README.md) — the implementation this package wraps
+- [Exact Base Scheme](../exact/README.md) — fixed-price payments
+- [x402 Docs: Payment Schemes](https://docs.x402.org/getting-started/quickstart-for-sellers#payment-schemes-exact-vs-upto)
+- [x402 Docs: Quickstart for Sellers](https://docs.x402.org/getting-started/quickstart-for-sellers)
+- [x402 Docs: Quickstart for Buyers](https://docs.x402.org/getting-started/quickstart-for-buyers)

--- a/typescript/packages/mechanisms/base/src/upto/client/index.ts
+++ b/typescript/packages/mechanisms/base/src/upto/client/index.ts
@@ -1,0 +1,2 @@
+export { BaseScheme } from "./scheme";
+export type { BaseClientSigner, BaseUptoSchemeOptions } from "./scheme";

--- a/typescript/packages/mechanisms/base/src/upto/client/scheme.ts
+++ b/typescript/packages/mechanisms/base/src/upto/client/scheme.ts
@@ -1,0 +1,69 @@
+import {
+  SchemeNetworkClient,
+  PaymentRequirements,
+  PaymentPayloadResult,
+  PaymentPayloadContext,
+} from "@x402/core/types";
+import { ClientEvmSigner } from "@x402/evm";
+import { UptoEvmScheme, type UptoEvmSchemeOptions } from "@x402/evm/upto/client";
+import { assertBaseNetwork, findBaseDefaultAsset } from "../../networks";
+
+/** Signer required by {@link BaseScheme} (client). Identical to `@x402/evm`'s `ClientEvmSigner`. */
+export type BaseClientSigner = ClientEvmSigner;
+
+/** Optional constructor options for {@link BaseScheme} (client). Identical to `@x402/evm`'s `UptoEvmSchemeOptions`. */
+export type BaseUptoSchemeOptions = UptoEvmSchemeOptions;
+
+/**
+ * Base client implementation for the Upto payment scheme.
+ *
+ * Thin pass-through wrapper around the generic EVM {@link UptoEvmScheme}
+ * (`@x402/evm`). Base (`eip155:8453` / `eip155:84532`) has no client-side
+ * differences from generic EVM today - this class exists as an explicit,
+ * overridable seam so Base-specific behavior (e.g. a different default
+ * asset transfer method, extension, or signer requirement) can be
+ * introduced later without changing the public `@x402/base` API surface or
+ * requiring consumers to re-register a different scheme.
+ *
+ * `createPaymentPayload` rejects any network outside `eip155:8453` /
+ * `eip155:84532` - see {@link assertBaseNetwork}. `findDefaultAsset` is
+ * scoped the same way via {@link findBaseDefaultAsset}.
+ */
+export class BaseScheme implements SchemeNetworkClient {
+  readonly scheme = "upto";
+  findDefaultAsset = findBaseDefaultAsset;
+  private readonly uptoEvmScheme: UptoEvmScheme;
+
+  /**
+   * Creates a new BaseScheme client instance.
+   *
+   * @param signer - The Base (EVM) signer for client operations.
+   *   Upto flow only requires `address` + `signTypedData`.
+   *   Extension enrichment (EIP-2612 / ERC-20 approval sponsoring) additionally
+   *   requires optional capabilities like `readContract` and tx signing helpers.
+   * @param options - Optional RPC configuration used to backfill extension capabilities.
+   */
+  constructor(signer: BaseClientSigner, options?: BaseUptoSchemeOptions) {
+    this.uptoEvmScheme = new UptoEvmScheme(signer, options);
+  }
+
+  /**
+   * Creates a payment payload for the Upto scheme. Delegates to the
+   * underlying {@link UptoEvmScheme} after asserting the requirements'
+   * network is in Base's scope.
+   *
+   * @param x402Version - The x402 protocol version
+   * @param paymentRequirements - The payment requirements
+   * @param context - Optional context with server-declared extensions
+   * @returns Promise resolving to a payment payload result (with optional extensions)
+   * @throws When `paymentRequirements.network` is not `eip155:8453` / `eip155:84532`
+   */
+  async createPaymentPayload(
+    x402Version: number,
+    paymentRequirements: PaymentRequirements,
+    context?: PaymentPayloadContext,
+  ): Promise<PaymentPayloadResult> {
+    assertBaseNetwork(paymentRequirements.network, "BaseScheme.createPaymentPayload");
+    return this.uptoEvmScheme.createPaymentPayload(x402Version, paymentRequirements, context);
+  }
+}

--- a/typescript/packages/mechanisms/base/src/upto/facilitator/index.ts
+++ b/typescript/packages/mechanisms/base/src/upto/facilitator/index.ts
@@ -1,0 +1,2 @@
+export { BaseScheme } from "./scheme";
+export type { BaseFacilitatorSigner, BaseUptoSchemeConfig } from "./scheme";

--- a/typescript/packages/mechanisms/base/src/upto/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/base/src/upto/facilitator/scheme.ts
@@ -1,0 +1,114 @@
+import {
+  PaymentPayload,
+  PaymentRequirements,
+  SchemeNetworkFacilitator,
+  FacilitatorContext,
+  SettleResponse,
+  VerifyResponse,
+} from "@x402/core/types";
+import type { FacilitatorEvmSigner } from "@x402/evm";
+import { UptoEvmScheme, type UptoEvmSchemeConfig } from "@x402/evm/upto/facilitator";
+import { assertBaseNetwork, isBaseNetwork } from "../../networks";
+
+/** Signer required by {@link BaseScheme} (facilitator). Identical to `@x402/evm`'s `FacilitatorEvmSigner`. */
+export type BaseFacilitatorSigner = FacilitatorEvmSigner;
+
+/** Optional constructor config for {@link BaseScheme} (facilitator). Identical to `@x402/evm`'s `UptoEvmSchemeConfig`. */
+export type BaseUptoSchemeConfig = UptoEvmSchemeConfig;
+
+/**
+ * Base facilitator implementation for the Upto payment scheme.
+ *
+ * Thin pass-through wrapper around the generic EVM {@link UptoEvmScheme}
+ * (`@x402/evm`). Base (`eip155:8453` / `eip155:84532`) has no
+ * facilitator-side differences from generic EVM today - this class exists
+ * as an explicit, overridable seam so Base-specific verify/settle behavior
+ * (e.g. a Base-specific gas-sponsoring strategy) can be introduced later
+ * without changing the public `@x402/base` API surface.
+ *
+ * `verify` and `settle` reject any network outside `eip155:8453` /
+ * `eip155:84532` - see {@link assertBaseNetwork}. `getExtra` and
+ * `getSigners` fail closed (return `undefined` / `[]`) off-Base instead.
+ */
+export class BaseScheme implements SchemeNetworkFacilitator {
+  readonly scheme = "upto";
+  readonly caipFamily = "eip155:*";
+  private readonly uptoEvmScheme: UptoEvmScheme;
+
+  /**
+   * Creates a new BaseScheme facilitator instance.
+   *
+   * @param signer - The Base (EVM) signer for facilitator operations
+   * @param config - Optional configuration
+   */
+  constructor(signer: BaseFacilitatorSigner, config?: BaseUptoSchemeConfig) {
+    this.uptoEvmScheme = new UptoEvmScheme(signer, config);
+  }
+
+  /**
+   * Returns mechanism-specific extra data for the given network, or
+   * `undefined` off-Base. Otherwise passes through to the underlying
+   * {@link UptoEvmScheme}.
+   *
+   * @param network - The network identifier
+   * @returns Object with facilitatorAddress, or undefined if off-Base or no signer addresses are available
+   */
+  getExtra(network: string): Record<string, unknown> | undefined {
+    if (!isBaseNetwork(network)) return undefined;
+    return this.uptoEvmScheme.getExtra(network);
+  }
+
+  /**
+   * Returns facilitator wallet addresses for the supported response, or
+   * `[]` off-Base. Otherwise passes through to the underlying
+   * {@link UptoEvmScheme}.
+   *
+   * @param network - The network identifier
+   * @returns Array of facilitator wallet addresses
+   */
+  getSigners(network: string): string[] {
+    if (!isBaseNetwork(network)) return [];
+    return this.uptoEvmScheme.getSigners(network);
+  }
+
+  /**
+   * Verifies a payment payload. Delegates to the underlying
+   * {@link UptoEvmScheme} after asserting `requirements.network` is in
+   * Base's scope.
+   *
+   * @param payload - The payment payload to verify
+   * @param requirements - The payment requirements
+   * @param context - Optional facilitator context for extension capabilities
+   * @param extra - Payment required extensions (unused; reserved for interface parity)
+   * @returns Promise resolving to verification response
+   * @throws When `requirements.network` is not `eip155:8453` / `eip155:84532`
+   */
+  async verify(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+    context?: FacilitatorContext,
+    extra?: Record<string, unknown>,
+  ): Promise<VerifyResponse> {
+    assertBaseNetwork(requirements.network, "BaseScheme.verify");
+    return this.uptoEvmScheme.verify(payload, requirements, context, extra);
+  }
+
+  /**
+   * Settles a payment. Delegates to the underlying {@link UptoEvmScheme}
+   * after asserting `requirements.network` is in Base's scope.
+   *
+   * @param payload - The payment payload to settle
+   * @param requirements - The payment requirements
+   * @param context - Optional facilitator context for extension capabilities
+   * @returns Promise resolving to settlement response
+   * @throws When `requirements.network` is not `eip155:8453` / `eip155:84532`
+   */
+  async settle(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+    context?: FacilitatorContext,
+  ): Promise<SettleResponse> {
+    assertBaseNetwork(requirements.network, "BaseScheme.settle");
+    return this.uptoEvmScheme.settle(payload, requirements, context);
+  }
+}

--- a/typescript/packages/mechanisms/base/src/upto/index.ts
+++ b/typescript/packages/mechanisms/base/src/upto/index.ts
@@ -1,0 +1,1 @@
+export { BaseScheme } from "./client/scheme";

--- a/typescript/packages/mechanisms/base/src/upto/server/index.ts
+++ b/typescript/packages/mechanisms/base/src/upto/server/index.ts
@@ -1,0 +1,1 @@
+export { BaseScheme } from "./scheme";

--- a/typescript/packages/mechanisms/base/src/upto/server/scheme.ts
+++ b/typescript/packages/mechanisms/base/src/upto/server/scheme.ts
@@ -1,0 +1,140 @@
+import {
+  AssetAmount,
+  Network,
+  PaymentFlowConfig,
+  PaymentRequirements,
+  Price,
+  SchemeNetworkServer,
+  MoneyParser,
+  SupportedKind,
+} from "@x402/core/types";
+import { UptoEvmScheme } from "@x402/evm/upto/server";
+import { assertBaseNetwork, isBaseNetwork } from "../../networks";
+
+/**
+ * Base resource-server implementation for the Upto payment scheme.
+ *
+ * Thin pass-through wrapper around the generic EVM {@link UptoEvmScheme}
+ * (`@x402/evm`). Base (`eip155:8453` / `eip155:84532`) has no
+ * resource-server-side differences from generic EVM today - this class
+ * exists as an explicit, overridable seam so Base-specific pricing/asset
+ * behavior can be introduced later without changing the public
+ * `@x402/base` API surface.
+ *
+ * `parsePrice` and `enhancePaymentRequirements` reject any network outside
+ * `eip155:8453` / `eip155:84532` - see {@link assertBaseNetwork}. Registering
+ * this scheme under a network (or wildcard pattern) outside Base's scope
+ * fails fast at `x402ResourceServer.initialize()` via
+ * {@link BaseScheme.validateFacilitatorSupport}.
+ */
+export class BaseScheme implements SchemeNetworkServer {
+  readonly scheme = "upto";
+  readonly defaultAssetTransferMethod: string;
+  readonly paymentFlows: Readonly<Record<string, PaymentFlowConfig>>;
+  private readonly uptoEvmScheme: UptoEvmScheme;
+
+  /**
+   * Creates a new BaseScheme server instance.
+   */
+  constructor() {
+    this.uptoEvmScheme = new UptoEvmScheme();
+    this.defaultAssetTransferMethod = this.uptoEvmScheme.defaultAssetTransferMethod;
+    this.paymentFlows = this.uptoEvmScheme.paymentFlows;
+  }
+
+  /**
+   * Register a custom money parser in the parser chain. Passes through to
+   * the underlying {@link UptoEvmScheme}.
+   *
+   * @param parser - Custom function to convert amount to AssetAmount (or null to skip)
+   * @returns This scheme instance, for chaining
+   */
+  registerMoneyParser(parser: MoneyParser): BaseScheme {
+    this.uptoEvmScheme.registerMoneyParser(parser);
+    return this;
+  }
+
+  /**
+   * Decimals for a known default asset, or undefined off-Base or when
+   * unrecognized. Otherwise passes through to the underlying
+   * {@link UptoEvmScheme}.
+   *
+   * @param asset - Asset address or symbol
+   * @param network - Target network
+   * @returns Decimals when the asset is a known Base default; otherwise undefined
+   */
+  getAssetDecimals(asset: string, network: Network): number | undefined {
+    if (!isBaseNetwork(network)) return undefined;
+    return this.uptoEvmScheme.getAssetDecimals(asset, network);
+  }
+
+  /**
+   * Parses a price into an asset amount. Delegates to the underlying
+   * {@link UptoEvmScheme} after asserting `network` is in Base's scope.
+   *
+   * @param price - The price to parse
+   * @param network - The network to use
+   * @returns Promise that resolves to the parsed asset amount
+   * @throws When `network` is not `eip155:8453` / `eip155:84532`
+   */
+  async parsePrice(price: Price, network: Network): Promise<AssetAmount> {
+    assertBaseNetwork(network, "BaseScheme.parsePrice");
+    return this.uptoEvmScheme.parsePrice(price, network);
+  }
+
+  /**
+   * Builds payment requirements for this scheme/network combination.
+   * Delegates to the underlying {@link UptoEvmScheme} after asserting
+   * `supportedKind.network` is in Base's scope.
+   *
+   * @param paymentRequirements - The base payment requirements
+   * @param supportedKind - The supported kind from facilitator
+   * @param supportedKind.x402Version - The x402 version
+   * @param supportedKind.scheme - The logical payment scheme
+   * @param supportedKind.network - The network identifier in CAIP-2 format
+   * @param supportedKind.extra - Optional extra metadata regarding scheme/network implementation details
+   * @param extensionKeys - Extension keys supported by the facilitator (unused)
+   * @returns Payment requirements ready to be sent to clients
+   * @throws When `supportedKind.network` is not `eip155:8453` / `eip155:84532`
+   */
+  async enhancePaymentRequirements(
+    paymentRequirements: PaymentRequirements,
+    supportedKind: {
+      x402Version: number;
+      scheme: string;
+      network: Network;
+      extra?: Record<string, unknown>;
+    },
+    extensionKeys: string[],
+  ): Promise<PaymentRequirements> {
+    assertBaseNetwork(supportedKind.network, "BaseScheme.enhancePaymentRequirements");
+    return this.uptoEvmScheme.enhancePaymentRequirements(
+      paymentRequirements,
+      supportedKind,
+      extensionKeys,
+    );
+  }
+
+  /**
+   * Fails server startup when this scheme is registered against a network
+   * outside Base's scope, so a mis-registration (e.g. under a wildcard
+   * pattern that also matches non-Base chains) surfaces at
+   * `x402ResourceServer.initialize()` instead of at first payment.
+   *
+   * @param network - The network identifier being validated.
+   * @param supportedKind - The facilitator's advertised kind for this scheme/network (unused).
+   * @param extensionKeys - Extensions advertised by the facilitator (unused).
+   * @returns A problem message when `network` is outside Base's scope, or void when valid.
+   */
+  validateFacilitatorSupport(
+    network: Network,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    supportedKind: SupportedKind,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    extensionKeys: string[],
+  ): string | void {
+    if (!isBaseNetwork(network)) {
+      return `@x402/base only supports eip155:8453 and eip155:84532, but was registered for ${network}`;
+    }
+  }
+}

--- a/typescript/packages/mechanisms/base/test/integrations/auth-capture-eoa-evm.test.ts
+++ b/typescript/packages/mechanisms/base/test/integrations/auth-capture-eoa-evm.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from "vitest";
+import type { PaymentRequirements } from "@x402/core/types";
+import {
+  AUTH_CAPTURE_ESCROW_ADDRESS,
+  EIP3009_TOKEN_COLLECTOR_ADDRESS,
+  PERMIT2_TOKEN_COLLECTOR_ADDRESS,
+  PERMIT2_ADDRESS,
+} from "@x402/evm";
+import { BaseScheme as BaseAuthCaptureClient } from "../../src/auth-capture/client/scheme";
+import { privateKeyToAccount } from "viem/accounts";
+import { recoverTypedDataAddress, keccak256, encodeAbiParameters, zeroAddress } from "viem";
+
+// Load private key from environment
+const CLIENT_PRIVATE_KEY = process.env.CLIENT_PRIVATE_KEY as `0x${string}` | undefined;
+
+const HAS_KEYS = Boolean(CLIENT_PRIVATE_KEY);
+const describeOnChain = HAS_KEYS ? describe : describe.skip;
+
+if (!HAS_KEYS) {
+  console.warn(
+    "[auth-capture-eoa-evm.test.ts] Skipping on-chain tests: CLIENT_PRIVATE_KEY env var is required.",
+  );
+}
+
+/**
+ * These tests use a real signer (from env) and the real, unmocked
+ * `@x402/evm` `AuthCaptureEvmScheme` (via `@x402/base`'s pass-through wrapper) to
+ * sign real EIP-712 payloads, then independently recover the signer address
+ * from the signature using `viem`'s pure `recoverTypedDataAddress` - no RPC or
+ * on-chain state required.
+ *
+ * `@x402/evm` ships the auth-capture client only today (no server/facilitator
+ * to verify/settle against - see `src/auth-capture/README.md`), so unlike the
+ * exact/upto integration tests this suite cannot exercise a full
+ * client -> server -> facilitator round trip. It instead validates the one
+ * real thing there is to validate end-to-end: that the signed wire payload
+ * is cryptographically valid for the real EIP-712 domain/types the escrow
+ * contract expects.
+ */
+describeOnChain("Base AuthCapture Integration Tests", () => {
+  // Well-known standardized EIP-712 type structs (public spec, not exported by
+  // @x402/evm) - see EIP-3009 (ReceiveWithAuthorization) and Uniswap Permit2
+  // (PermitTransferFrom).
+  const RECEIVE_AUTHORIZATION_TYPES = {
+    ReceiveWithAuthorization: [
+      { name: "from", type: "address" },
+      { name: "to", type: "address" },
+      { name: "value", type: "uint256" },
+      { name: "validAfter", type: "uint256" },
+      { name: "validBefore", type: "uint256" },
+      { name: "nonce", type: "bytes32" },
+    ],
+  } as const;
+
+  const PERMIT2_TRANSFER_FROM_TYPES = {
+    PermitTransferFrom: [
+      { name: "permitted", type: "TokenPermissions" },
+      { name: "spender", type: "address" },
+      { name: "nonce", type: "uint256" },
+      { name: "deadline", type: "uint256" },
+    ],
+    TokenPermissions: [
+      { name: "token", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+  } as const;
+
+  // Mirrors AuthCaptureEscrow.PAYMENT_INFO_TYPEHASH so this test can
+  // independently recompute the payer-agnostic nonce the client signs over.
+  const PAYMENT_INFO_TYPEHASH = keccak256(
+    new TextEncoder().encode(
+      "PaymentInfo(address operator,address payer,address receiver,address token,uint120 maxAmount,uint48 preApprovalExpiry,uint48 authorizationExpiry,uint48 refundExpiry,uint16 minFeeBps,uint16 maxFeeBps,address feeReceiver,uint256 salt)",
+    ),
+  );
+
+  /**
+   * Independently recomputes the payer-agnostic PaymentInfo hash the same way
+   * `AuthCaptureEscrow.getHash` does (with `payer` zeroed), so this test can
+   * verify the client's signature without depending on `@x402/evm`'s internal
+   * (non-exported) nonce helpers.
+   *
+   * @param chainId - EVM chain id binding the hash to a specific chain
+   * @param paymentInfo - The canonical, reconstructed PaymentInfo struct
+   * @returns The 32-byte payer-agnostic hash
+   */
+  function computePayerAgnosticHash(
+    chainId: number,
+    paymentInfo: {
+      operator: `0x${string}`;
+      receiver: `0x${string}`;
+      token: `0x${string}`;
+      maxAmount: string;
+      preApprovalExpiry: number;
+      authorizationExpiry: number;
+      refundExpiry: number;
+      minFeeBps: number;
+      maxFeeBps: number;
+      feeReceiver: `0x${string}`;
+      salt: `0x${string}`;
+    },
+  ): `0x${string}` {
+    const paymentInfoHash = keccak256(
+      encodeAbiParameters(
+        [
+          { name: "typehash", type: "bytes32" },
+          { name: "operator", type: "address" },
+          { name: "payer", type: "address" },
+          { name: "receiver", type: "address" },
+          { name: "token", type: "address" },
+          { name: "maxAmount", type: "uint120" },
+          { name: "preApprovalExpiry", type: "uint48" },
+          { name: "authorizationExpiry", type: "uint48" },
+          { name: "refundExpiry", type: "uint48" },
+          { name: "minFeeBps", type: "uint16" },
+          { name: "maxFeeBps", type: "uint16" },
+          { name: "feeReceiver", type: "address" },
+          { name: "salt", type: "uint256" },
+        ],
+        [
+          PAYMENT_INFO_TYPEHASH,
+          paymentInfo.operator,
+          zeroAddress,
+          paymentInfo.receiver,
+          paymentInfo.token,
+          BigInt(paymentInfo.maxAmount),
+          paymentInfo.preApprovalExpiry,
+          paymentInfo.authorizationExpiry,
+          paymentInfo.refundExpiry,
+          paymentInfo.minFeeBps,
+          paymentInfo.maxFeeBps,
+          paymentInfo.feeReceiver,
+          BigInt(paymentInfo.salt),
+        ],
+      ),
+    );
+    return keccak256(
+      encodeAbiParameters(
+        [
+          { name: "chainId", type: "uint256" },
+          { name: "escrow", type: "address" },
+          { name: "paymentInfoHash", type: "bytes32" },
+        ],
+        [BigInt(chainId), AUTH_CAPTURE_ESCROW_ADDRESS, paymentInfoHash],
+      ),
+    );
+  }
+
+  const clientAccount = privateKeyToAccount(CLIENT_PRIVATE_KEY!);
+  const client = new BaseAuthCaptureClient(clientAccount);
+
+  const captureAuthorizer = "0x1234567890123456789012345678901234567890" as const;
+  const feeRecipient = "0x1234567890123456789012345678901234567890" as const;
+  const payTo = "0x9876543210987654321098765432109876543210" as const;
+
+  function buildRequirements(overrides: Record<string, unknown> = {}): PaymentRequirements {
+    return {
+      scheme: "auth-capture",
+      network: "eip155:84532", // Base Sepolia
+      asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e", // Base Sepolia USDC
+      amount: "1000000", // 1.00 USDC max authorized
+      payTo,
+      maxTimeoutSeconds: 3600,
+      extra: {
+        name: "USDC",
+        version: "2",
+        captureAuthorizer,
+        feeRecipient,
+        captureDeadline: Math.floor(Date.now() / 1000) + 3600,
+        refundDeadline: Math.floor(Date.now() / 1000) + 7200,
+        minFeeBps: 0,
+        maxFeeBps: 100,
+        ...overrides,
+      },
+    };
+  }
+
+  it("signs a valid EIP-3009 ReceiveWithAuthorization payload (default transfer method)", async () => {
+    const requirements = buildRequirements();
+    const result = await client.createPaymentPayload(2, requirements);
+
+    const payload = result.payload as {
+      authorization: {
+        from: `0x${string}`;
+        to: `0x${string}`;
+        value: string;
+        validAfter: string;
+        validBefore: string;
+        nonce: `0x${string}`;
+      };
+      signature: `0x${string}`;
+      salt: `0x${string}`;
+    };
+
+    expect(payload.authorization.from).toBe(clientAccount.address);
+    expect(payload.authorization.to).toBe(EIP3009_TOKEN_COLLECTOR_ADDRESS);
+
+    // Independently recompute the payer-agnostic nonce and confirm it matches
+    // what the client signed - proves the wrapper didn't alter the PaymentInfo
+    // derivation on its way through `@x402/base`.
+    const expectedNonce = computePayerAgnosticHash(84532, {
+      operator: captureAuthorizer,
+      receiver: payTo,
+      token: requirements.asset as `0x${string}`,
+      maxAmount: requirements.amount,
+      preApprovalExpiry: payload.authorization.validBefore
+        ? Number(payload.authorization.validBefore)
+        : 0,
+      authorizationExpiry: requirements.extra.captureDeadline as number,
+      refundExpiry: requirements.extra.refundDeadline as number,
+      minFeeBps: requirements.extra.minFeeBps as number,
+      maxFeeBps: requirements.extra.maxFeeBps as number,
+      feeReceiver: feeRecipient,
+      salt: payload.salt,
+    });
+    expect(payload.authorization.nonce).toBe(expectedNonce);
+
+    // Recover the signer address from the signature over the real EIP-712
+    // domain the escrow's EIP3009 token collector expects - proves the
+    // signature is cryptographically valid, without needing a facilitator.
+    const recovered = await recoverTypedDataAddress({
+      domain: {
+        name: "USDC",
+        version: "2",
+        chainId: 84532,
+        verifyingContract: requirements.asset as `0x${string}`,
+      },
+      types: RECEIVE_AUTHORIZATION_TYPES,
+      primaryType: "ReceiveWithAuthorization",
+      message: {
+        from: payload.authorization.from,
+        to: payload.authorization.to,
+        value: BigInt(payload.authorization.value),
+        validAfter: BigInt(payload.authorization.validAfter),
+        validBefore: BigInt(payload.authorization.validBefore),
+        nonce: payload.authorization.nonce,
+      },
+      signature: payload.signature,
+    });
+    expect(recovered).toBe(clientAccount.address);
+  });
+
+  it("signs a valid Permit2 PermitTransferFrom payload (assetTransferMethod: permit2)", async () => {
+    const requirements = buildRequirements({ assetTransferMethod: "permit2" });
+    const result = await client.createPaymentPayload(2, requirements);
+
+    const payload = result.payload as {
+      permit2Authorization: {
+        from: `0x${string}`;
+        permitted: { token: `0x${string}`; amount: string };
+        spender: `0x${string}`;
+        nonce: string;
+        deadline: string;
+      };
+      signature: `0x${string}`;
+    };
+
+    expect(payload.permit2Authorization.from).toBe(clientAccount.address);
+    expect(payload.permit2Authorization.spender).toBe(PERMIT2_TOKEN_COLLECTOR_ADDRESS);
+
+    const recovered = await recoverTypedDataAddress({
+      domain: {
+        name: "Permit2",
+        chainId: 84532,
+        verifyingContract: PERMIT2_ADDRESS,
+      },
+      types: PERMIT2_TRANSFER_FROM_TYPES,
+      primaryType: "PermitTransferFrom",
+      message: {
+        permitted: {
+          token: payload.permit2Authorization.permitted.token,
+          amount: BigInt(payload.permit2Authorization.permitted.amount),
+        },
+        spender: payload.permit2Authorization.spender,
+        nonce: BigInt(payload.permit2Authorization.nonce),
+        deadline: BigInt(payload.permit2Authorization.deadline),
+      },
+      signature: payload.signature,
+    });
+    expect(recovered).toBe(clientAccount.address);
+  });
+
+  it("emits a bound salt + saltNonce when receiverAuthorizer is set (salt binding on)", async () => {
+    const receiverAuthorizer = "0x1111111111111111111111111111111111111111" as const;
+    const requirements = buildRequirements({ receiverAuthorizer });
+    const result = await client.createPaymentPayload(2, requirements);
+
+    const payload = result.payload as { salt: `0x${string}`; saltNonce?: `0x${string}` };
+    expect(payload.saltNonce).toBeDefined();
+    expect(payload.salt).toBeDefined();
+  });
+
+  it("emits an unbound (random) salt with no saltNonce when salt binding is off", async () => {
+    const requirements = buildRequirements();
+    const result = await client.createPaymentPayload(2, requirements);
+
+    const payload = result.payload as { salt: `0x${string}`; saltNonce?: `0x${string}` };
+    expect(payload.salt).toBeDefined();
+    expect(payload.saltNonce).toBeUndefined();
+  });
+});

--- a/typescript/packages/mechanisms/base/test/integrations/batch-settlement-evm.test.ts
+++ b/typescript/packages/mechanisms/base/test/integrations/batch-settlement-evm.test.ts
@@ -1,0 +1,439 @@
+import { randomBytes } from "node:crypto";
+import { beforeEach, describe, expect, it } from "vitest";
+import { x402Client, x402HTTPClient } from "@x402/core/client";
+import { x402Facilitator } from "@x402/core/facilitator";
+import {
+  HTTPAdapter,
+  HTTPResponseInstructions,
+  x402HTTPResourceServer,
+  x402ResourceServer,
+  FacilitatorClient,
+} from "@x402/core/server";
+import {
+  Network,
+  PaymentPayload,
+  PaymentRequirements,
+  VerifyResponse,
+  SettleResponse,
+  SupportedResponse,
+} from "@x402/core/types";
+import { AuthorizerSigner, toClientEvmSigner, toFacilitatorEvmSigner } from "@x402/evm";
+import {
+  InMemoryClientChannelStorage,
+  readChannelBalanceAndTotalClaimed,
+  updateChannelFromSettle,
+} from "@x402/evm/batch-settlement/client";
+import { BaseScheme as BaseBatchSettlementClient } from "../../src/batch-settlement/client/scheme";
+import { BaseScheme as BaseBatchSettlementServer } from "../../src/batch-settlement/server/scheme";
+import { BaseScheme as BaseBatchSettlementFacilitator } from "../../src/batch-settlement/facilitator/scheme";
+import { privateKeyToAccount } from "viem/accounts";
+import { createWalletClient, createPublicClient, http } from "viem";
+import { baseSepolia } from "viem/chains";
+
+const CLIENT_PRIVATE_KEY = process.env.CLIENT_PRIVATE_KEY as `0x${string}` | undefined;
+const FACILITATOR_PRIVATE_KEY = process.env.FACILITATOR_PRIVATE_KEY as `0x${string}` | undefined;
+const RECEIVER_AUTHORIZER_PRIVATE_KEY = process.env.RECEIVER_AUTHORIZER_PRIVATE_KEY as
+  | `0x${string}`
+  | undefined;
+
+const HAS_KEYS = Boolean(CLIENT_PRIVATE_KEY && FACILITATOR_PRIVATE_KEY);
+const describeOnChain = HAS_KEYS ? describe : describe.skip;
+
+if (!HAS_KEYS) {
+  console.warn(
+    "[batch-settlement-evm.test.ts] Skipping on-chain tests: CLIENT_PRIVATE_KEY and FACILITATOR_PRIVATE_KEY env vars are required.",
+  );
+}
+
+const NETWORK: Network = "eip155:84532";
+const ASSET_USDC_BASE_SEPOLIA = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
+
+/**
+ * Waits until an RPC read sees non-zero channel balance (some providers lag after receipt).
+ *
+ * @param clientSigner - A `ClientEvmSigner` with `readContract` wired to a live RPC.
+ * @param channelId - Channel id to poll.
+ */
+async function waitForChannelBalanceOnChain(
+  clientSigner: Parameters<typeof readChannelBalanceAndTotalClaimed>[0],
+  channelId: `0x${string}`,
+): Promise<void> {
+  const timeoutMs = 20000;
+  const intervalMs = 250;
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const [balance] = await readChannelBalanceAndTotalClaimed(clientSigner, channelId);
+    if (balance > 0n) return;
+    await new Promise<void>(resolve => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(`Timed out waiting for channel ${channelId} balance > 0`);
+}
+
+/**
+ * Wraps an x402Facilitator instance for use as a FacilitatorClient.
+ */
+class EvmFacilitatorClient implements FacilitatorClient {
+  /**
+   * @param facilitator - The x402 facilitator to wrap.
+   */
+  constructor(private readonly facilitator: x402Facilitator) {}
+
+  /**
+   * @param paymentPayload - Payment payload to verify.
+   * @param paymentRequirements - Payment requirements to verify against.
+   * @returns Verification response from the wrapped facilitator.
+   */
+  verify(
+    paymentPayload: PaymentPayload,
+    paymentRequirements: PaymentRequirements,
+  ): Promise<VerifyResponse> {
+    return this.facilitator.verify(paymentPayload, paymentRequirements);
+  }
+
+  /**
+   * @param paymentPayload - Payment payload to settle.
+   * @param paymentRequirements - Payment requirements for settlement.
+   * @returns Settlement response from the wrapped facilitator.
+   */
+  settle(
+    paymentPayload: PaymentPayload,
+    paymentRequirements: PaymentRequirements,
+  ): Promise<SettleResponse> {
+    return this.facilitator.settle(paymentPayload, paymentRequirements);
+  }
+
+  /**
+   * @returns Supported payment kinds reported by the wrapped facilitator.
+   */
+  getSupported(): Promise<SupportedResponse> {
+    return Promise.resolve(this.facilitator.getSupported() as unknown as SupportedResponse);
+  }
+}
+
+/**
+ * Builds payment requirements suitable for the batched scheme on Base Sepolia.
+ *
+ * @param payTo - Receiver address.
+ * @param amount - Amount in smallest token units (USDC has 6 decimals).
+ * @param receiverAuthorizer - Receiver-authorizer address (must be non-zero on-chain).
+ * @returns Configured {@link PaymentRequirements}.
+ */
+function buildBatchSettlementRequirements(
+  payTo: `0x${string}`,
+  amount: string,
+  receiverAuthorizer: `0x${string}`,
+): PaymentRequirements {
+  return {
+    scheme: "batch-settlement",
+    network: NETWORK,
+    asset: ASSET_USDC_BASE_SEPOLIA,
+    amount,
+    payTo,
+    maxTimeoutSeconds: 3600,
+    extra: {
+      name: "USDC",
+      version: "2",
+      assetTransferMethod: "eip3009",
+      receiverAuthorizer,
+    },
+  };
+}
+
+/**
+ * Constructs the wired client + server + facilitator pipeline for Base Sepolia
+ * batch-settlement integration tests.
+ *
+ * @returns The configured client/server pair plus the receiver address.
+ */
+function buildPipeline(): {
+  client: x402Client;
+  server: x402ResourceServer;
+  receiverAddress: `0x${string}`;
+  clientAddress: `0x${string}`;
+  authorizerSigner: AuthorizerSigner;
+  clientSigner: ReturnType<typeof toClientEvmSigner>;
+  batchSettlementClient: BaseBatchSettlementClient;
+  batchSettlementStorage: InMemoryClientChannelStorage;
+} {
+  const clientAccount = privateKeyToAccount(CLIENT_PRIVATE_KEY!);
+  const facilitatorAccount = privateKeyToAccount(FACILITATOR_PRIVATE_KEY!);
+  const authorizerAccount = privateKeyToAccount(
+    RECEIVER_AUTHORIZER_PRIVATE_KEY ?? FACILITATOR_PRIVATE_KEY!,
+  );
+
+  const publicClient = createPublicClient({ chain: baseSepolia, transport: http() });
+  const facilitatorWalletClient = createWalletClient({
+    account: facilitatorAccount,
+    chain: baseSepolia,
+    transport: http(),
+  });
+
+  const facilitatorSigner = toFacilitatorEvmSigner({
+    address: facilitatorAccount.address,
+    readContract: args => publicClient.readContract({ ...args, args: args.args || [] } as never),
+    verifyTypedData: args => publicClient.verifyTypedData(args as never),
+    writeContract: args =>
+      facilitatorWalletClient.writeContract({ ...args, args: args.args || [] } as never),
+    sendTransaction: args => facilitatorWalletClient.sendTransaction(args),
+    waitForTransactionReceipt: args => publicClient.waitForTransactionReceipt(args),
+    getCode: args => publicClient.getCode(args),
+  });
+
+  const authorizerSigner: AuthorizerSigner = {
+    address: authorizerAccount.address,
+    signTypedData: msg =>
+      authorizerAccount.signTypedData({
+        domain: msg.domain,
+        types: msg.types,
+        primaryType: msg.primaryType,
+        message: msg.message,
+      } as Parameters<typeof authorizerAccount.signTypedData>[0]),
+  };
+
+  const facilitator = new x402Facilitator().register(
+    NETWORK,
+    new BaseBatchSettlementFacilitator(facilitatorSigner, authorizerSigner),
+  );
+  const facilitatorClient = new EvmFacilitatorClient(facilitator);
+
+  const clientSigner = toClientEvmSigner(clientAccount, publicClient);
+  const channelSalt = `0x${randomBytes(32).toString("hex")}` as `0x${string}`;
+  const batchSettlementStorage = new InMemoryClientChannelStorage();
+  const batchSettlementClient = new BaseBatchSettlementClient(clientSigner, {
+    depositPolicy: { depositMultiplier: 3 },
+    salt: channelSalt,
+    storage: batchSettlementStorage,
+  });
+  const client = new x402Client().register(NETWORK, batchSettlementClient);
+
+  const server = new x402ResourceServer(facilitatorClient);
+  server.register(
+    NETWORK,
+    new BaseBatchSettlementServer(facilitatorAccount.address, {
+      receiverAuthorizerSigner: authorizerSigner,
+    }),
+  );
+
+  return {
+    client,
+    server,
+    receiverAddress: facilitatorAccount.address,
+    clientAddress: clientAccount.address,
+    authorizerSigner,
+    clientSigner,
+    batchSettlementClient,
+    batchSettlementStorage,
+  };
+}
+
+describe("Batch-Settlement EVM Integration Tests", () => {
+  describeOnChain("x402Client / x402ResourceServer / x402Facilitator - direct API", () => {
+    let client: x402Client;
+    let server: x402ResourceServer;
+    let receiverAddress: `0x${string}`;
+    let clientAddress: `0x${string}`;
+    let receiverAuthorizer: `0x${string}`;
+    let batchSettlementStorage: InMemoryClientChannelStorage;
+    let clientSigner: ReturnType<typeof toClientEvmSigner>;
+
+    beforeEach(async () => {
+      const pipeline = buildPipeline();
+      client = pipeline.client;
+      server = pipeline.server;
+      receiverAddress = pipeline.receiverAddress;
+      clientAddress = pipeline.clientAddress;
+      receiverAuthorizer = pipeline.authorizerSigner.address;
+      batchSettlementStorage = pipeline.batchSettlementStorage;
+      clientSigner = pipeline.clientSigner;
+      await server.initialize();
+    });
+
+    it(
+      "verifies and settles a deposit-with-voucher payment, then a follow-up voucher payment",
+      { timeout: 60000 },
+      async () => {
+        const accepts = [
+          buildBatchSettlementRequirements(receiverAddress, "1000", receiverAuthorizer),
+        ];
+        const resource = {
+          url: "https://example.com/api",
+          description: "Batched test resource",
+          mimeType: "application/json",
+        };
+
+        const paymentRequired = await server.createPaymentRequiredResponse(accepts, resource);
+        const firstPayload = await client.createPaymentPayload(paymentRequired);
+
+        expect(firstPayload.x402Version).toBe(2);
+        expect(firstPayload.accepted.scheme).toBe("batch-settlement");
+        const firstRaw = firstPayload.payload as Record<string, unknown>;
+        expect(firstRaw.type).toBe("deposit");
+
+        const accepted = server.findMatchingRequirements(accepts, firstPayload);
+        expect(accepted).toBeDefined();
+
+        const verifyResponse = await server.verifyPayment(firstPayload, accepted!);
+        expect(verifyResponse.isValid).toBe(true);
+        expect(verifyResponse.payer?.toLowerCase()).toBe(clientAddress.toLowerCase());
+
+        const settleResponse = await server.settlePayment(firstPayload, accepted!);
+        expect(settleResponse.success, JSON.stringify(settleResponse)).toBe(true);
+        expect(settleResponse.network).toBe(NETWORK);
+        expect(settleResponse.transaction).toBeDefined();
+        expect(settleResponse.payer?.toLowerCase()).toBe(clientAddress.toLowerCase());
+
+        const depositChannelId = (firstPayload.payload as { voucher: { channelId: `0x${string}` } })
+          .voucher.channelId;
+        await waitForChannelBalanceOnChain(clientSigner, depositChannelId);
+
+        const depositAmount = (firstPayload.payload as { deposit: { amount: string } }).deposit
+          .amount;
+        await updateChannelFromSettle(batchSettlementStorage, {
+          server: { chargedAmount: settleResponse.extra?.chargedAmount as string | undefined },
+          local: {
+            channelId: depositChannelId,
+            requestAmount: accepted!.amount,
+            depositAmount,
+          },
+        });
+
+        const followupRequired = await server.createPaymentRequiredResponse(accepts, resource);
+        const secondPayload = await client.createPaymentPayload(followupRequired);
+        const secondRaw = secondPayload.payload as Record<string, unknown>;
+        expect(secondRaw.type).toBe("voucher");
+
+        const accepted2 = server.findMatchingRequirements(accepts, secondPayload);
+        expect(accepted2).toBeDefined();
+
+        const verify2 = await server.verifyPayment(secondPayload, accepted2!);
+        expect(verify2.isValid).toBe(true);
+
+        const settle2 = await server.settlePayment(secondPayload, accepted2!);
+        expect(settle2.success, JSON.stringify(settle2)).toBe(true);
+        expect(settle2.payer?.toLowerCase()).toBe(clientAddress.toLowerCase());
+      },
+    );
+  });
+
+  describeOnChain("x402HTTPClient / x402HTTPResourceServer / x402Facilitator - HTTP API", () => {
+    let httpClient: x402HTTPClient;
+    let httpServer: x402HTTPResourceServer;
+    let receiverAddress: `0x${string}`;
+    let clientAddress: `0x${string}`;
+
+    const routes = {
+      "/api/protected": {
+        accepts: {
+          scheme: "batch-settlement",
+          payTo: "0x0000000000000000000000000000000000000000" as `0x${string}`,
+          price: "$0.001",
+          network: NETWORK,
+        },
+        description: "Batched protected API",
+        mimeType: "application/json",
+      },
+    };
+
+    const adapter: HTTPAdapter = {
+      getHeader: () => undefined,
+      getMethod: () => "GET",
+      getPath: () => "/api/protected",
+      getUrl: () => "https://example.com/api/protected",
+      getAcceptHeader: () => "application/json",
+      getUserAgent: () => "TestClient/1.0",
+    };
+
+    beforeEach(async () => {
+      const pipeline = buildPipeline();
+      receiverAddress = pipeline.receiverAddress;
+      clientAddress = pipeline.clientAddress;
+
+      routes["/api/protected"].accepts.payTo = receiverAddress;
+
+      const publicClient = createPublicClient({ chain: baseSepolia, transport: http() });
+      const facilitatorWalletClient = createWalletClient({
+        account: privateKeyToAccount(FACILITATOR_PRIVATE_KEY!),
+        chain: baseSepolia,
+        transport: http(),
+      });
+
+      const resourceServer = new x402ResourceServer(
+        new EvmFacilitatorClient(
+          new x402Facilitator().register(
+            NETWORK,
+            new BaseBatchSettlementFacilitator(
+              toFacilitatorEvmSigner({
+                address: privateKeyToAccount(FACILITATOR_PRIVATE_KEY!).address,
+                readContract: args =>
+                  publicClient.readContract({ ...args, args: args.args || [] } as never),
+                verifyTypedData: args => publicClient.verifyTypedData(args as never),
+                writeContract: args =>
+                  facilitatorWalletClient.writeContract({
+                    ...args,
+                    args: args.args || [],
+                  } as never),
+                sendTransaction: args => facilitatorWalletClient.sendTransaction(args),
+                waitForTransactionReceipt: args => publicClient.waitForTransactionReceipt(args),
+                getCode: args => publicClient.getCode(args),
+              }),
+              pipeline.authorizerSigner,
+            ),
+          ),
+        ),
+      );
+      resourceServer.register(
+        NETWORK,
+        new BaseBatchSettlementServer(receiverAddress, {
+          receiverAuthorizerSigner: pipeline.authorizerSigner,
+        }),
+      );
+      await resourceServer.initialize();
+
+      httpServer = new x402HTTPResourceServer(resourceServer, routes);
+      httpClient = new x402HTTPClient(pipeline.client) as x402HTTPClient;
+    });
+
+    it(
+      "negotiates a batched payment via HTTP middleware end-to-end",
+      { timeout: 60000 },
+      async () => {
+        const context = { adapter, path: "/api/protected", method: "GET" };
+
+        const initial = (await httpServer.processHTTPRequest(context))!;
+        expect(initial.type).toBe("payment-error");
+        const response402 = (
+          initial as { type: "payment-error"; response: HTTPResponseInstructions }
+        ).response;
+        expect(response402.status).toBe(402);
+        expect(response402.headers["PAYMENT-REQUIRED"]).toBeDefined();
+
+        const paymentRequired = httpClient.getPaymentRequiredResponse(
+          name => response402.headers[name],
+          response402.body,
+        );
+        const paymentPayload = await httpClient.createPaymentPayload(paymentRequired);
+        expect(paymentPayload.accepted.scheme).toBe("batch-settlement");
+
+        const requestHeaders = await httpClient.encodePaymentSignatureHeader(paymentPayload);
+        adapter.getHeader = (name: string) =>
+          name === "PAYMENT-SIGNATURE" ? requestHeaders["PAYMENT-SIGNATURE"] : undefined;
+
+        const verified = await httpServer.processHTTPRequest(context);
+        expect(verified.type).toBe("payment-verified");
+
+        const { paymentPayload: verifiedPayload, paymentRequirements: verifiedReqs } = verified as {
+          type: "payment-verified";
+          paymentPayload: PaymentPayload;
+          paymentRequirements: PaymentRequirements;
+        };
+
+        const settlement = await httpServer.processSettlement(verifiedPayload, verifiedReqs);
+        expect(settlement.success).toBe(true);
+        if (settlement.success) {
+          expect(settlement.headers["PAYMENT-RESPONSE"]).toBeDefined();
+        }
+        expect(clientAddress).toMatch(/^0x[0-9a-fA-F]{40}$/);
+      },
+    );
+  });
+});

--- a/typescript/packages/mechanisms/base/test/integrations/exact-eoa-evm.test.ts
+++ b/typescript/packages/mechanisms/base/test/integrations/exact-eoa-evm.test.ts
@@ -1,0 +1,304 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { x402Client } from "@x402/core/client";
+import { x402Facilitator } from "@x402/core/facilitator";
+import { x402ResourceServer, FacilitatorClient } from "@x402/core/server";
+import {
+  Network,
+  PaymentPayload,
+  PaymentRequirements,
+  VerifyResponse,
+  SettleResponse,
+  SupportedResponse,
+} from "@x402/core/types";
+import { isEIP3009Payload, toFacilitatorEvmSigner } from "@x402/evm";
+import type { ExactEvmPayloadV2 } from "@x402/evm";
+import { BaseScheme as BaseExactClient } from "../../src/exact/client/scheme";
+import { BaseScheme as BaseExactServer } from "../../src/exact/server/scheme";
+import { BaseScheme as BaseExactFacilitator } from "../../src/exact/facilitator/scheme";
+import { privateKeyToAccount } from "viem/accounts";
+import { createWalletClient, createPublicClient, http } from "viem";
+import { baseSepolia } from "viem/chains";
+
+const CLIENT_PRIVATE_KEY = process.env.CLIENT_PRIVATE_KEY as `0x${string}` | undefined;
+const FACILITATOR_PRIVATE_KEY = process.env.FACILITATOR_PRIVATE_KEY as `0x${string}` | undefined;
+
+const HAS_KEYS = Boolean(CLIENT_PRIVATE_KEY && FACILITATOR_PRIVATE_KEY);
+const describeOnChain = HAS_KEYS ? describe : describe.skip;
+
+if (!HAS_KEYS) {
+  console.warn(
+    "[exact-eoa-evm.test.ts] Skipping on-chain tests: CLIENT_PRIVATE_KEY and FACILITATOR_PRIVATE_KEY env vars are required.",
+  );
+}
+
+/**
+ * Base Exact Facilitator Client wrapper
+ * Wraps the x402Facilitator for use with x402ResourceServer
+ */
+class BaseExactFacilitatorClient implements FacilitatorClient {
+  readonly scheme = "exact";
+  readonly network = "eip155:84532"; // Base Sepolia
+  readonly x402Version = 2;
+
+  /**
+   * Creates a new BaseExactFacilitatorClient instance
+   *
+   * @param facilitator - The x402 facilitator to wrap
+   */
+  constructor(private readonly facilitator: x402Facilitator) {}
+
+  /**
+   * Verifies a payment payload
+   *
+   * @param paymentPayload - The payment payload to verify
+   * @param paymentRequirements - The payment requirements
+   * @returns Promise resolving to verification response
+   */
+  verify(
+    paymentPayload: PaymentPayload,
+    paymentRequirements: PaymentRequirements,
+  ): Promise<VerifyResponse> {
+    return this.facilitator.verify(paymentPayload, paymentRequirements);
+  }
+
+  /**
+   * Settles a payment
+   *
+   * @param paymentPayload - The payment payload to settle
+   * @param paymentRequirements - The payment requirements
+   * @returns Promise resolving to settlement response
+   */
+  settle(
+    paymentPayload: PaymentPayload,
+    paymentRequirements: PaymentRequirements,
+  ): Promise<SettleResponse> {
+    return this.facilitator.settle(paymentPayload, paymentRequirements);
+  }
+
+  /**
+   * Gets supported payment kinds
+   *
+   * @returns Promise resolving to supported response
+   */
+  getSupported(): Promise<SupportedResponse> {
+    return Promise.resolve(this.facilitator.getSupported() as unknown as SupportedResponse);
+  }
+}
+
+describeOnChain("Base Exact Integration Tests", () => {
+  describe("x402Client / x402ResourceServer / x402Facilitator - Exact Flow", () => {
+    let client: x402Client;
+    let server: x402ResourceServer;
+    let clientAddress: `0x${string}`;
+
+    beforeEach(async () => {
+      const clientAccount = privateKeyToAccount(CLIENT_PRIVATE_KEY!);
+      clientAddress = clientAccount.address;
+
+      const exactClient = new BaseExactClient(clientAccount);
+      client = new x402Client().register("eip155:84532", exactClient);
+
+      const facilitatorAccount = privateKeyToAccount(FACILITATOR_PRIVATE_KEY!);
+
+      const publicClient = createPublicClient({
+        chain: baseSepolia,
+        transport: http(),
+      });
+
+      const walletClient = createWalletClient({
+        account: facilitatorAccount,
+        chain: baseSepolia,
+        transport: http(),
+      });
+
+      const facilitatorSigner = toFacilitatorEvmSigner({
+        address: facilitatorAccount.address,
+        readContract: args =>
+          publicClient.readContract({
+            ...args,
+            args: args.args || [],
+          } as never),
+        verifyTypedData: args => publicClient.verifyTypedData(args as never),
+        writeContract: args =>
+          walletClient.writeContract({
+            ...args,
+            args: args.args || [],
+          } as never),
+        sendTransaction: args => walletClient.sendTransaction(args),
+        waitForTransactionReceipt: args => publicClient.waitForTransactionReceipt(args),
+        getCode: args => publicClient.getCode(args),
+      });
+
+      const exactFacilitator = new BaseExactFacilitator(facilitatorSigner);
+      const facilitator = new x402Facilitator().register("eip155:84532", exactFacilitator);
+
+      const facilitatorClient = new BaseExactFacilitatorClient(facilitator);
+      server = new x402ResourceServer(facilitatorClient);
+      server.register("eip155:84532", new BaseExactServer());
+      await server.initialize();
+    });
+
+    it(
+      "server should successfully verify and settle a Base exact payment from a client",
+      { timeout: 30000 },
+      async () => {
+        const accepts: PaymentRequirements[] = [
+          {
+            scheme: "exact",
+            network: "eip155:84532",
+            asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e", // Base Sepolia USDC
+            amount: "1000", // 0.001 USDC
+            payTo: "0x9876543210987654321098765432109876543210",
+            maxTimeoutSeconds: 3600,
+            extra: {
+              name: "USDC",
+              version: "2",
+            },
+          },
+        ];
+        const resource = {
+          url: "https://company.co",
+          description: "Company Co. resource",
+          mimeType: "application/json",
+        };
+        const paymentRequired = await server.createPaymentRequiredResponse(accepts, resource);
+        const paymentPayload = await client.createPaymentPayload(paymentRequired);
+
+        expect(paymentPayload).toBeDefined();
+        expect(paymentPayload.x402Version).toBe(2);
+        expect(paymentPayload.accepted.scheme).toBe("exact");
+
+        // Base Sepolia USDC supports EIP-3009
+        const exactPayload = paymentPayload.payload as ExactEvmPayloadV2;
+        expect(isEIP3009Payload(exactPayload)).toBe(true);
+        if (!isEIP3009Payload(exactPayload)) throw new Error("expected EIP-3009 payload");
+        expect(exactPayload.authorization).toBeDefined();
+        expect(exactPayload.authorization.from).toBe(clientAddress);
+        expect(exactPayload.authorization.to).toBe("0x9876543210987654321098765432109876543210");
+        expect(exactPayload.signature).toBeDefined();
+
+        const accepted = server.findMatchingRequirements(accepts, paymentPayload);
+        expect(accepted).toBeDefined();
+
+        const verifyResponse = await server.verifyPayment(paymentPayload, accepted!);
+
+        if (!verifyResponse.isValid) {
+          console.log("❌ Verification failed!");
+          console.log("Invalid reason:", verifyResponse.invalidReason);
+          console.log("Payer:", verifyResponse.payer);
+          console.log("Client address:", clientAddress);
+        }
+
+        expect(verifyResponse.isValid).toBe(true);
+        expect(verifyResponse.payer).toBe(clientAddress);
+
+        const settleResponse = await server.settlePayment(paymentPayload, accepted!);
+        expect(settleResponse.success).toBe(true);
+        expect(settleResponse.network).toBe("eip155:84532");
+        expect(settleResponse.transaction).toBeDefined();
+        expect(settleResponse.payer).toBe(clientAddress);
+      },
+    );
+  });
+
+  describe("Price Parsing Integration", () => {
+    let server: x402ResourceServer;
+    let exactServer: BaseExactServer;
+
+    beforeEach(async () => {
+      const facilitatorAccount = privateKeyToAccount(FACILITATOR_PRIVATE_KEY!);
+      const publicClient = createPublicClient({
+        chain: baseSepolia,
+        transport: http(),
+      });
+      const walletClient = createWalletClient({
+        account: facilitatorAccount,
+        chain: baseSepolia,
+        transport: http(),
+      });
+
+      const facilitatorSigner = toFacilitatorEvmSigner({
+        address: facilitatorAccount.address,
+        readContract: args =>
+          publicClient.readContract({
+            ...args,
+            args: args.args || [],
+          } as never),
+        verifyTypedData: args => publicClient.verifyTypedData(args as never),
+        writeContract: args =>
+          walletClient.writeContract({
+            ...args,
+            args: args.args || [],
+          } as never),
+        sendTransaction: args => walletClient.sendTransaction(args),
+        waitForTransactionReceipt: args => publicClient.waitForTransactionReceipt(args),
+        getCode: args => publicClient.getCode(args),
+      });
+      const facilitator = new x402Facilitator().register(
+        "eip155:84532",
+        new BaseExactFacilitator(facilitatorSigner),
+      );
+
+      const facilitatorClient = new BaseExactFacilitatorClient(facilitator);
+      server = new x402ResourceServer(facilitatorClient);
+
+      exactServer = new BaseExactServer();
+      server.register("eip155:84532", exactServer);
+      await server.initialize();
+    });
+
+    it("should parse Money formats and build payment requirements", async () => {
+      const testCases = [
+        { input: "$1.00", expectedAmount: "1000000" },
+        { input: "1.50", expectedAmount: "1500000" },
+        { input: 2.5, expectedAmount: "2500000" },
+      ];
+
+      for (const testCase of testCases) {
+        const requirements = await server.buildPaymentRequirements({
+          scheme: "exact",
+          payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+          price: testCase.input,
+          network: "eip155:84532" as Network,
+        });
+
+        expect(requirements).toHaveLength(1);
+        expect(requirements[0].amount).toBe(testCase.expectedAmount);
+        expect(requirements[0].asset).toBe("0x036CbD53842c5426634e7929541eC2318f3dCF7e"); // Base Sepolia USDC
+      }
+    });
+
+    it("should use registerMoneyParser for custom conversion", async () => {
+      exactServer.registerMoneyParser(async (amount, _network) => {
+        if (Number(amount) > 100) {
+          return {
+            amount: (Number(amount) * 1e18).toString(),
+            asset: "0x6B175474E89094C44Da98b954EedeAC495271d0F", // DAI on mainnet (test value)
+            extra: { token: "DAI", tier: "large" },
+          };
+        }
+        return null; // Use default for small amounts
+      });
+
+      const largeRequirements = await server.buildPaymentRequirements({
+        scheme: "exact",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        price: 150,
+        network: "eip155:84532" as Network,
+      });
+
+      expect(largeRequirements[0].asset).toBe("0x6B175474E89094C44Da98b954EedeAC495271d0F");
+      expect(largeRequirements[0].extra?.tier).toBe("large");
+
+      const smallRequirements = await server.buildPaymentRequirements({
+        scheme: "exact",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        price: 50,
+        network: "eip155:84532" as Network,
+      });
+
+      expect(smallRequirements[0].amount).toBe("50000000"); // 50 * 1e6 (USDC)
+      expect(smallRequirements[0].asset).toBe("0x036CbD53842c5426634e7929541eC2318f3dCF7e"); // Base Sepolia USDC
+    });
+  });
+});

--- a/typescript/packages/mechanisms/base/test/integrations/upto-eoa-evm.test.ts
+++ b/typescript/packages/mechanisms/base/test/integrations/upto-eoa-evm.test.ts
@@ -1,0 +1,313 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { x402Client } from "@x402/core/client";
+import { x402Facilitator } from "@x402/core/facilitator";
+import { x402ResourceServer, FacilitatorClient } from "@x402/core/server";
+import {
+  Network,
+  PaymentPayload,
+  PaymentRequirements,
+  VerifyResponse,
+  SettleResponse,
+  SupportedResponse,
+} from "@x402/core/types";
+import { toFacilitatorEvmSigner } from "@x402/evm";
+import type { UptoPermit2Payload } from "@x402/evm";
+import { BaseScheme as BaseUptoClient } from "../../src/upto/client/scheme";
+import { BaseScheme as BaseUptoServer } from "../../src/upto/server/scheme";
+import { BaseScheme as BaseUptoFacilitator } from "../../src/upto/facilitator/scheme";
+import { privateKeyToAccount } from "viem/accounts";
+import { createWalletClient, createPublicClient, http } from "viem";
+import { baseSepolia } from "viem/chains";
+
+const CLIENT_PRIVATE_KEY = process.env.CLIENT_PRIVATE_KEY as `0x${string}` | undefined;
+const FACILITATOR_PRIVATE_KEY = process.env.FACILITATOR_PRIVATE_KEY as `0x${string}` | undefined;
+
+const HAS_KEYS = Boolean(CLIENT_PRIVATE_KEY && FACILITATOR_PRIVATE_KEY);
+const describeOnChain = HAS_KEYS ? describe : describe.skip;
+
+if (!HAS_KEYS) {
+  console.warn(
+    "[upto-eoa-evm.test.ts] Skipping on-chain tests: CLIENT_PRIVATE_KEY and FACILITATOR_PRIVATE_KEY env vars are required.",
+  );
+}
+
+/**
+ * Base Upto Facilitator Client wrapper
+ * Wraps the x402Facilitator for use with x402ResourceServer
+ */
+class BaseUptoFacilitatorClient implements FacilitatorClient {
+  readonly scheme = "upto";
+  readonly network = "eip155:84532"; // Base Sepolia
+  readonly x402Version = 2;
+
+  /**
+   * Creates a new BaseUptoFacilitatorClient instance
+   *
+   * @param facilitator - The x402 facilitator to wrap
+   */
+  constructor(private readonly facilitator: x402Facilitator) {}
+
+  /**
+   * Verifies a payment payload
+   *
+   * @param paymentPayload - The payment payload to verify
+   * @param paymentRequirements - The payment requirements
+   * @returns Promise resolving to verification response
+   */
+  verify(
+    paymentPayload: PaymentPayload,
+    paymentRequirements: PaymentRequirements,
+  ): Promise<VerifyResponse> {
+    return this.facilitator.verify(paymentPayload, paymentRequirements);
+  }
+
+  /**
+   * Settles a payment
+   *
+   * @param paymentPayload - The payment payload to settle
+   * @param paymentRequirements - The payment requirements
+   * @returns Promise resolving to settlement response
+   */
+  settle(
+    paymentPayload: PaymentPayload,
+    paymentRequirements: PaymentRequirements,
+  ): Promise<SettleResponse> {
+    return this.facilitator.settle(paymentPayload, paymentRequirements);
+  }
+
+  /**
+   * Gets supported payment kinds
+   *
+   * @returns Promise resolving to supported response
+   */
+  getSupported(): Promise<SupportedResponse> {
+    return Promise.resolve(this.facilitator.getSupported() as unknown as SupportedResponse);
+  }
+}
+
+describeOnChain("Base Upto Integration Tests", () => {
+  describe("x402Client / x402ResourceServer / x402Facilitator - Upto Flow", () => {
+    let client: x402Client;
+    let server: x402ResourceServer;
+    let clientAddress: `0x${string}`;
+
+    beforeEach(async () => {
+      const clientAccount = privateKeyToAccount(CLIENT_PRIVATE_KEY!);
+      clientAddress = clientAccount.address;
+
+      const uptoClient = new BaseUptoClient(clientAccount);
+      client = new x402Client().register("eip155:84532", uptoClient);
+
+      const facilitatorAccount = privateKeyToAccount(FACILITATOR_PRIVATE_KEY!);
+
+      const publicClient = createPublicClient({
+        chain: baseSepolia,
+        transport: http(),
+      });
+
+      const walletClient = createWalletClient({
+        account: facilitatorAccount,
+        chain: baseSepolia,
+        transport: http(),
+      });
+
+      const facilitatorSigner = toFacilitatorEvmSigner({
+        address: facilitatorAccount.address,
+        readContract: args =>
+          publicClient.readContract({
+            ...args,
+            args: args.args || [],
+          } as never),
+        verifyTypedData: args => publicClient.verifyTypedData(args as never),
+        writeContract: args =>
+          walletClient.writeContract({
+            ...args,
+            args: args.args || [],
+          } as never),
+        sendTransaction: args => walletClient.sendTransaction(args),
+        waitForTransactionReceipt: args => publicClient.waitForTransactionReceipt(args),
+        getCode: args => publicClient.getCode(args),
+      });
+
+      const uptoFacilitator = new BaseUptoFacilitator(facilitatorSigner);
+      const facilitator = new x402Facilitator().register("eip155:84532", uptoFacilitator);
+
+      const facilitatorClient = new BaseUptoFacilitatorClient(facilitator);
+      server = new x402ResourceServer(facilitatorClient);
+      server.register("eip155:84532", new BaseUptoServer());
+      await server.initialize();
+    });
+
+    it(
+      "server should successfully verify and settle a Base upto payment from a client",
+      { timeout: 30000 },
+      async () => {
+        const accepts: PaymentRequirements[] = [
+          {
+            scheme: "upto",
+            network: "eip155:84532",
+            asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e", // Base Sepolia USDC
+            amount: "10000", // max 0.01 USDC authorized
+            payTo: "0x9876543210987654321098765432109876543210",
+            maxTimeoutSeconds: 3600,
+            extra: {
+              name: "USDC",
+              version: "2",
+            },
+          },
+        ];
+        const resource = {
+          url: "https://company.co",
+          description: "Company Co. usage-based resource",
+          mimeType: "application/json",
+        };
+        const paymentRequired = await server.createPaymentRequiredResponse(accepts, resource);
+
+        // Facilitator's supported kind enriches extra with facilitatorAddress
+        expect(paymentRequired.accepts[0].extra?.facilitatorAddress).toBeDefined();
+
+        const paymentPayload = await client.createPaymentPayload(paymentRequired);
+
+        expect(paymentPayload).toBeDefined();
+        expect(paymentPayload.x402Version).toBe(2);
+        expect(paymentPayload.accepted.scheme).toBe("upto");
+
+        const uptoPayload = paymentPayload.payload as UptoPermit2Payload;
+        expect(uptoPayload.permit2Authorization).toBeDefined();
+        expect(uptoPayload.permit2Authorization.permitted.token).toBeDefined();
+        expect(uptoPayload.permit2Authorization.from).toBe(clientAddress);
+        expect(uptoPayload.signature).toBeDefined();
+
+        const accepted = server.findMatchingRequirements(accepts, paymentPayload);
+        expect(accepted).toBeDefined();
+
+        const verifyResponse = await server.verifyPayment(paymentPayload, accepted!);
+
+        if (!verifyResponse.isValid) {
+          console.log("❌ Verification failed!");
+          console.log("Invalid reason:", verifyResponse.invalidReason);
+          console.log("Payer:", verifyResponse.payer);
+          console.log("Client address:", clientAddress);
+        }
+
+        expect(verifyResponse.isValid).toBe(true);
+        expect(verifyResponse.payer).toBe(clientAddress);
+
+        // Server settles for less than the authorized max (usage-based billing)
+        const settleResponse = await server.settlePayment(
+          paymentPayload,
+          accepted!,
+          undefined,
+          undefined,
+          { amount: "5000" }, // settle 0.005 USDC of the 0.01 USDC authorized
+        );
+        expect(settleResponse.success).toBe(true);
+        expect(settleResponse.network).toBe("eip155:84532");
+        expect(settleResponse.transaction).toBeDefined();
+        expect(settleResponse.payer).toBe(clientAddress);
+      },
+    );
+  });
+
+  describe("Price Parsing Integration", () => {
+    let server: x402ResourceServer;
+    let uptoServer: BaseUptoServer;
+
+    beforeEach(async () => {
+      const facilitatorAccount = privateKeyToAccount(FACILITATOR_PRIVATE_KEY!);
+      const publicClient = createPublicClient({
+        chain: baseSepolia,
+        transport: http(),
+      });
+      const walletClient = createWalletClient({
+        account: facilitatorAccount,
+        chain: baseSepolia,
+        transport: http(),
+      });
+
+      const facilitatorSigner = toFacilitatorEvmSigner({
+        address: facilitatorAccount.address,
+        readContract: args =>
+          publicClient.readContract({
+            ...args,
+            args: args.args || [],
+          } as never),
+        verifyTypedData: args => publicClient.verifyTypedData(args as never),
+        writeContract: args =>
+          walletClient.writeContract({
+            ...args,
+            args: args.args || [],
+          } as never),
+        sendTransaction: args => walletClient.sendTransaction(args),
+        waitForTransactionReceipt: args => publicClient.waitForTransactionReceipt(args),
+        getCode: args => publicClient.getCode(args),
+      });
+      const facilitator = new x402Facilitator().register(
+        "eip155:84532",
+        new BaseUptoFacilitator(facilitatorSigner),
+      );
+
+      const facilitatorClient = new BaseUptoFacilitatorClient(facilitator);
+      server = new x402ResourceServer(facilitatorClient);
+
+      uptoServer = new BaseUptoServer();
+      server.register("eip155:84532", uptoServer);
+      await server.initialize();
+    });
+
+    it("should parse Money formats and build payment requirements with the max authorized amount", async () => {
+      const testCases = [
+        { input: "$0.10", expectedAmount: "100000" },
+        { input: "1.50", expectedAmount: "1500000" },
+        { input: 2.5, expectedAmount: "2500000" },
+      ];
+
+      for (const testCase of testCases) {
+        const requirements = await server.buildPaymentRequirements({
+          scheme: "upto",
+          payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+          price: testCase.input,
+          network: "eip155:84532" as Network,
+        });
+
+        expect(requirements).toHaveLength(1);
+        expect(requirements[0].amount).toBe(testCase.expectedAmount);
+        expect(requirements[0].asset).toBe("0x036CbD53842c5426634e7929541eC2318f3dCF7e"); // Base Sepolia USDC
+        expect(requirements[0].extra?.assetTransferMethod).toBe("permit2");
+      }
+    });
+
+    it("should use registerMoneyParser for custom conversion", async () => {
+      uptoServer.registerMoneyParser(async (amount, _network) => {
+        if (Number(amount) > 100) {
+          return {
+            amount: (Number(amount) * 1e18).toString(),
+            asset: "0x6B175474E89094C44Da98b954EedeAC495271d0F", // DAI on mainnet (test value)
+            extra: { token: "DAI", tier: "large" },
+          };
+        }
+        return null; // Use default for small amounts
+      });
+
+      const largeRequirements = await server.buildPaymentRequirements({
+        scheme: "upto",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        price: 150,
+        network: "eip155:84532" as Network,
+      });
+
+      expect(largeRequirements[0].asset).toBe("0x6B175474E89094C44Da98b954EedeAC495271d0F");
+      expect(largeRequirements[0].extra?.tier).toBe("large");
+
+      const smallRequirements = await server.buildPaymentRequirements({
+        scheme: "upto",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        price: 50,
+        network: "eip155:84532" as Network,
+      });
+
+      expect(smallRequirements[0].amount).toBe("50000000"); // 50 * 1e6 (USDC)
+      expect(smallRequirements[0].asset).toBe("0x036CbD53842c5426634e7929541eC2318f3dCF7e"); // Base Sepolia USDC
+    });
+  });
+});

--- a/typescript/packages/mechanisms/base/test/unit/auth-capture/client.test.ts
+++ b/typescript/packages/mechanisms/base/test/unit/auth-capture/client.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from "vitest";
+import { isAuthCapturePayload } from "@x402/evm";
+import type { PaymentRequirements } from "@x402/core/types";
+import { BaseScheme, type BaseClientSigner } from "../../../src/auth-capture/client/scheme";
+
+/**
+ * `BaseScheme` (auth-capture client) is a thin pass-through wrapper around
+ * `@x402/evm`'s `AuthCaptureEvmScheme`. PaymentInfo hashing, salt derivation,
+ * and signing details are covered by `@x402/evm`'s own test suite - these
+ * tests only verify that the wrapper actually delegates (including its
+ * validation behavior) and doesn't diverge from the underlying implementation.
+ */
+describe("BaseScheme (AuthCapture Client)", () => {
+  const requirements: PaymentRequirements = {
+    scheme: "auth-capture",
+    network: "eip155:8453",
+    amount: "1000000",
+    asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    payTo: "0x1234567890123456789012345678901234567890",
+    maxTimeoutSeconds: 300,
+    extra: {
+      name: "USD Coin",
+      version: "2",
+      captureAuthorizer: "0x9876543210987654321098765432109876543210",
+      feeRecipient: "0x9876543210987654321098765432109876543210",
+      captureDeadline: Math.floor(Date.now() / 1000) + 3600,
+      refundDeadline: Math.floor(Date.now() / 1000) + 7200,
+      minFeeBps: 0,
+      maxFeeBps: 100,
+    },
+  };
+
+  it("exposes scheme = 'auth-capture'", () => {
+    const mockSigner: BaseClientSigner = {
+      address: "0x1234567890123456789012345678901234567890",
+      signTypedData: vi.fn().mockResolvedValue("0xmocksignature"),
+    };
+    const client = new BaseScheme(mockSigner);
+    expect(client.scheme).toBe("auth-capture");
+  });
+
+  it("delegates createPaymentPayload to the underlying AuthCaptureEvmScheme (EIP-3009)", async () => {
+    const mockSigner: BaseClientSigner = {
+      address: "0x1234567890123456789012345678901234567890",
+      signTypedData: vi.fn().mockResolvedValue("0xmocksignature"),
+    };
+    const client = new BaseScheme(mockSigner);
+
+    const result = await client.createPaymentPayload(2, requirements);
+
+    expect(isAuthCapturePayload(result.payload)).toBe(true);
+    expect(result.payload).toHaveProperty("authorization");
+    expect(mockSigner.signTypedData).toHaveBeenCalled();
+  });
+
+  it("delegates createPaymentPayload to the underlying AuthCaptureEvmScheme (Permit2)", async () => {
+    const mockSigner: BaseClientSigner = {
+      address: "0x1234567890123456789012345678901234567890",
+      signTypedData: vi.fn().mockResolvedValue("0xmocksignature"),
+    };
+    const client = new BaseScheme(mockSigner);
+
+    const result = await client.createPaymentPayload(2, {
+      ...requirements,
+      extra: { ...requirements.extra, assetTransferMethod: "permit2" },
+    });
+
+    expect(isAuthCapturePayload(result.payload)).toBe(true);
+    expect(result.payload).toHaveProperty("permit2Authorization");
+  });
+
+  it("propagates the underlying AuthCaptureEvmScheme's required `extra` field validation", async () => {
+    const mockSigner: BaseClientSigner = {
+      address: "0x1234567890123456789012345678901234567890",
+      signTypedData: vi.fn().mockResolvedValue("0xmocksignature"),
+    };
+    const client = new BaseScheme(mockSigner);
+
+    await expect(client.createPaymentPayload(2, { ...requirements, extra: {} })).rejects.toThrow(
+      /name/,
+    );
+  });
+
+  it("propagates the underlying AuthCaptureEvmScheme's x402Version validation", async () => {
+    const mockSigner: BaseClientSigner = {
+      address: "0x1234567890123456789012345678901234567890",
+      signTypedData: vi.fn().mockResolvedValue("0xmocksignature"),
+    };
+    const client = new BaseScheme(mockSigner);
+
+    await expect(client.createPaymentPayload(1, requirements)).rejects.toThrow(
+      /Unsupported x402Version/,
+    );
+  });
+
+  it("rejects createPaymentPayload for a network outside Base's scope", async () => {
+    const mockSigner: BaseClientSigner = {
+      address: "0x1234567890123456789012345678901234567890",
+      signTypedData: vi.fn().mockResolvedValue("0xmocksignature"),
+    };
+    const client = new BaseScheme(mockSigner);
+
+    await expect(
+      client.createPaymentPayload(2, { ...requirements, network: "eip155:1" }),
+    ).rejects.toThrow(/eip155:1/);
+  });
+});

--- a/typescript/packages/mechanisms/base/test/unit/batch-settlement/client.test.ts
+++ b/typescript/packages/mechanisms/base/test/unit/batch-settlement/client.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from "vitest";
+import type { PaymentRequirements } from "@x402/core/types";
+import { BaseScheme, type BaseClientSigner } from "../../../src/batch-settlement/client/scheme";
+
+/**
+ * `BaseScheme` (batch-settlement client) is a thin pass-through wrapper around
+ * `@x402/evm`'s `BatchSettlementEvmScheme`. Deposit sizing, voucher signing, channel
+ * recovery, and refund mechanics are covered by `@x402/evm`'s own test suite - these
+ * tests only verify that the wrapper actually delegates and doesn't diverge from the
+ * underlying implementation.
+ */
+describe("BaseScheme (Batch-Settlement Client)", () => {
+  const requirements: PaymentRequirements = {
+    scheme: "batch-settlement",
+    network: "eip155:84532",
+    amount: "1000000",
+    asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+    payTo: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+    maxTimeoutSeconds: 3600,
+    extra: {
+      name: "USDC",
+      version: "2",
+      receiverAuthorizer: "0x9876543210987654321098765432109876543210",
+    },
+  };
+
+  function buildMockSigner(): BaseClientSigner {
+    return {
+      address: "0x1234567890123456789012345678901234567890",
+      signTypedData: vi.fn().mockResolvedValue("0xmocksignature"),
+    };
+  }
+
+  it("exposes scheme = 'batch-settlement'", () => {
+    const client = new BaseScheme(buildMockSigner());
+    expect(client.scheme).toBe("batch-settlement");
+  });
+
+  it("exposes schemeHooks from the underlying BatchSettlementEvmScheme", () => {
+    const client = new BaseScheme(buildMockSigner());
+    expect(client.schemeHooks).toBeDefined();
+  });
+
+  it("delegates buildChannelConfig to the underlying BatchSettlementEvmScheme", () => {
+    const signer = buildMockSigner();
+    const client = new BaseScheme(signer);
+
+    const config = client.buildChannelConfig(requirements);
+
+    expect(config.payer).toBe(signer.address);
+    expect(config.receiver).toBe(requirements.payTo);
+    expect(config.token).toBe(requirements.asset);
+  });
+
+  it("delegates createPaymentPayload to the underlying BatchSettlementEvmScheme (initial deposit + voucher bundle)", async () => {
+    const signer = buildMockSigner();
+    const client = new BaseScheme(signer);
+
+    const result = await client.createPaymentPayload(2, requirements);
+
+    const payload = result.payload as { type: string; deposit?: unknown; voucher?: unknown };
+    expect(payload.type).toBe("deposit");
+    expect(payload.deposit).toBeDefined();
+    expect(payload.voucher).toBeDefined();
+    expect(signer.signTypedData).toHaveBeenCalled();
+  });
+
+  it("propagates the underlying BatchSettlementEvmScheme's required EIP-712 domain validation", async () => {
+    const client = new BaseScheme(buildMockSigner());
+
+    await expect(
+      client.createPaymentPayload(2, {
+        ...requirements,
+        extra: { receiverAuthorizer: "0x9876543210987654321098765432109876543210" },
+      }),
+    ).rejects.toThrow(/name, version/);
+  });
+
+  it("rejects createPaymentPayload for a network outside Base's scope", async () => {
+    const client = new BaseScheme(buildMockSigner());
+
+    await expect(
+      client.createPaymentPayload(2, { ...requirements, network: "eip155:1" }),
+    ).rejects.toThrow(/eip155:1/);
+  });
+
+  it("rejects buildChannelConfig for a network outside Base's scope", () => {
+    const client = new BaseScheme(buildMockSigner());
+
+    expect(() => client.buildChannelConfig({ ...requirements, network: "eip155:1" })).toThrow(
+      /eip155:1/,
+    );
+  });
+});

--- a/typescript/packages/mechanisms/base/test/unit/batch-settlement/facilitator.test.ts
+++ b/typescript/packages/mechanisms/base/test/unit/batch-settlement/facilitator.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  BaseScheme,
+  type BaseAuthorizerSigner,
+  type BaseFacilitatorSigner,
+} from "../../../src/batch-settlement/facilitator/scheme";
+
+/**
+ * `BaseScheme` (batch-settlement facilitator) is a thin pass-through wrapper
+ * around `@x402/evm`'s `BatchSettlementEvmScheme`. Deposit/voucher verification and
+ * onchain settlement details are covered by `@x402/evm`'s own test suite - these
+ * tests only verify that the wrapper actually delegates and doesn't diverge from
+ * the underlying implementation.
+ */
+describe("BaseScheme (Batch-Settlement Facilitator)", () => {
+  const mockSigner: BaseFacilitatorSigner = {
+    getAddresses: vi.fn().mockReturnValue(["0x1234567890123456789012345678901234567890"]),
+    readContract: vi.fn(),
+    verifyTypedData: vi.fn(),
+    writeContract: vi.fn(),
+    sendTransaction: vi.fn(),
+    waitForTransactionReceipt: vi.fn(),
+    getCode: vi.fn(),
+  };
+
+  it("exposes scheme = 'batch-settlement' and caipFamily = 'eip155:*'", () => {
+    const facilitator = new BaseScheme(mockSigner);
+    expect(facilitator.scheme).toBe("batch-settlement");
+    expect(facilitator.caipFamily).toBe("eip155:*");
+  });
+
+  it("delegates getSigners to the underlying BatchSettlementEvmScheme", () => {
+    const facilitator = new BaseScheme(mockSigner);
+    expect(facilitator.getSigners("eip155:84532")).toEqual([
+      "0x1234567890123456789012345678901234567890",
+    ]);
+  });
+
+  it("delegates getExtra to the underlying BatchSettlementEvmScheme (undefined with no authorizerSigner)", () => {
+    const facilitator = new BaseScheme(mockSigner);
+    expect(facilitator.getExtra("eip155:84532")).toBeUndefined();
+  });
+
+  it("delegates getExtra to the underlying BatchSettlementEvmScheme (receiverAuthorizer when configured)", () => {
+    const authorizerSigner: BaseAuthorizerSigner = {
+      address: "0x9876543210987654321098765432109876543210",
+      signTypedData: vi.fn().mockResolvedValue("0xmocksignature"),
+    };
+    const facilitator = new BaseScheme(mockSigner, authorizerSigner);
+    expect(facilitator.getExtra("eip155:84532")).toEqual({
+      receiverAuthorizer: "0x9876543210987654321098765432109876543210",
+    });
+  });
+
+  it("returns [] from getSigners and undefined from getExtra for a network outside Base's scope", () => {
+    const facilitator = new BaseScheme(mockSigner);
+    expect(facilitator.getSigners("eip155:1")).toEqual([]);
+    expect(facilitator.getExtra("eip155:1")).toBeUndefined();
+  });
+
+  const requirements = {
+    scheme: "batch-settlement",
+    network: "eip155:1" as const,
+    amount: "1000000",
+    asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+    payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+    maxTimeoutSeconds: 3600,
+    extra: {},
+  };
+
+  it("rejects verify for a network outside Base's scope", async () => {
+    const facilitator = new BaseScheme(mockSigner);
+    await expect(facilitator.verify({ x402Version: 2 } as never, requirements)).rejects.toThrow(
+      /eip155:1/,
+    );
+  });
+
+  it("rejects settle for a network outside Base's scope", async () => {
+    const facilitator = new BaseScheme(mockSigner);
+    await expect(facilitator.settle({ x402Version: 2 } as never, requirements)).rejects.toThrow(
+      /eip155:1/,
+    );
+  });
+});

--- a/typescript/packages/mechanisms/base/test/unit/batch-settlement/server.test.ts
+++ b/typescript/packages/mechanisms/base/test/unit/batch-settlement/server.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from "vitest";
+import type { SupportedKind } from "@x402/core/types";
+import { BaseScheme } from "../../../src/batch-settlement/server/scheme";
+
+/**
+ * `BaseScheme` (batch-settlement server) is a thin pass-through wrapper around
+ * `@x402/evm`'s `BatchSettlementEvmScheme`. Channel/voucher storage and settlement
+ * enrichment details are covered by `@x402/evm`'s own test suite - these tests only
+ * verify that the wrapper actually delegates and doesn't diverge from the
+ * underlying implementation.
+ */
+describe("BaseScheme (Batch-Settlement Server)", () => {
+  const receiverAddress = "0x1234567890123456789012345678901234567890" as const;
+
+  it("exposes scheme = 'batch-settlement' and eip3009/permit2 as supported transfer methods", () => {
+    const server = new BaseScheme(receiverAddress);
+    expect(server.scheme).toBe("batch-settlement");
+    expect(server.defaultAssetTransferMethod).toBe("eip3009");
+    expect(server.paymentFlows.eip3009.default).toBe("authorization");
+    expect(server.paymentFlows.permit2.default).toBe("authorization");
+  });
+
+  it("delegates getReceiverAddress and getWithdrawDelay to the underlying BatchSettlementEvmScheme", () => {
+    const server = new BaseScheme(receiverAddress, { withdrawDelay: 1800 });
+    expect(server.getReceiverAddress()).toBe(receiverAddress);
+    expect(server.getWithdrawDelay()).toBe(1800);
+  });
+
+  it("delegates parsePrice to the underlying BatchSettlementEvmScheme (Base Sepolia USDC)", async () => {
+    const server = new BaseScheme(receiverAddress);
+    const result = await server.parsePrice("$1.00", "eip155:84532");
+    expect(result.asset).toBe("0x036CbD53842c5426634e7929541eC2318f3dCF7e");
+    expect(result.amount).toBe("1000000");
+  });
+
+  it("delegates registerMoneyParser to the underlying BatchSettlementEvmScheme and returns `this` for chaining", async () => {
+    const server = new BaseScheme(receiverAddress);
+    const returned = server.registerMoneyParser(async () => ({
+      amount: "42",
+      asset: "0xCustomToken",
+    }));
+    expect(returned).toBe(server);
+
+    const result = await server.parsePrice("$1.00", "eip155:84532");
+    expect(result).toEqual({ amount: "42", asset: "0xCustomToken" });
+  });
+
+  it("delegates enhancePaymentRequirements to the underlying BatchSettlementEvmScheme (receiverAuthorizer + withdrawDelay)", async () => {
+    const authorizerSigner = {
+      address: "0x9876543210987654321098765432109876543210" as const,
+      signTypedData: vi.fn().mockResolvedValue("0xmocksignature" as const),
+    };
+    const server = new BaseScheme(receiverAddress, {
+      receiverAuthorizerSigner: authorizerSigner,
+      withdrawDelay: 900,
+    });
+
+    const enhanced = await server.enhancePaymentRequirements(
+      {
+        scheme: "batch-settlement",
+        network: "eip155:84532",
+        amount: "1000000",
+        asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+        payTo: receiverAddress,
+        maxTimeoutSeconds: 3600,
+        extra: { name: "USDC", version: "2" },
+      },
+      { x402Version: 2, scheme: "batch-settlement", network: "eip155:84532" },
+      [],
+    );
+
+    expect(enhanced.extra?.receiverAuthorizer).toBe("0x9876543210987654321098765432109876543210");
+    expect(enhanced.extra?.withdrawDelay).toBe(900);
+  });
+
+  it("propagates the underlying BatchSettlementEvmScheme's non-zero receiverAuthorizer requirement", async () => {
+    const server = new BaseScheme(receiverAddress);
+
+    await expect(
+      server.enhancePaymentRequirements(
+        {
+          scheme: "batch-settlement",
+          network: "eip155:84532",
+          amount: "1000000",
+          asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+          payTo: receiverAddress,
+          maxTimeoutSeconds: 3600,
+          extra: { name: "USDC", version: "2" },
+        },
+        { x402Version: 2, scheme: "batch-settlement", network: "eip155:84532" },
+        [],
+      ),
+    ).rejects.toThrow(/receiverAuthorizer/);
+  });
+
+  it("rejects parsePrice for a network outside Base's scope", async () => {
+    const server = new BaseScheme(receiverAddress);
+    await expect(server.parsePrice("$1.00", "eip155:1")).rejects.toThrow(/eip155:1/);
+  });
+
+  it("rejects enhancePaymentRequirements for a network outside Base's scope", async () => {
+    const server = new BaseScheme(receiverAddress);
+    await expect(
+      server.enhancePaymentRequirements(
+        {
+          scheme: "batch-settlement",
+          network: "eip155:1",
+          amount: "1000000",
+          asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+          payTo: receiverAddress,
+          maxTimeoutSeconds: 3600,
+          extra: { name: "USDC", version: "2" },
+        },
+        { x402Version: 2, scheme: "batch-settlement", network: "eip155:1" },
+        [],
+      ),
+    ).rejects.toThrow(/eip155:1/);
+  });
+
+  it("rejects createChannelManager for a network outside Base's scope", () => {
+    const server = new BaseScheme(receiverAddress);
+    expect(() => server.createChannelManager({} as never, "eip155:1")).toThrow(/eip155:1/);
+  });
+
+  it("returns undefined from getAssetDecimals for a network outside Base's scope", () => {
+    const server = new BaseScheme(receiverAddress);
+    expect(
+      server.getAssetDecimals("0x036CbD53842c5426634e7929541eC2318f3dCF7e", "eip155:1"),
+    ).toBeUndefined();
+  });
+
+  it("returns a problem string from validateFacilitatorSupport for a network outside Base's scope", () => {
+    const server = new BaseScheme(receiverAddress);
+    const supportedKind: SupportedKind = {
+      x402Version: 2,
+      scheme: "batch-settlement",
+      network: "eip155:1",
+    };
+    expect(server.validateFacilitatorSupport("eip155:1", supportedKind, [])).toMatch(/eip155:1/);
+  });
+
+  it("still composes the underlying BatchSettlementEvmScheme's receiverAuthorizer check on Base", () => {
+    const server = new BaseScheme(receiverAddress);
+    const supportedKind: SupportedKind = {
+      x402Version: 2,
+      scheme: "batch-settlement",
+      network: "eip155:84532",
+    };
+    // No receiverAuthorizerSigner configured and no facilitator-advertised
+    // receiverAuthorizer - the underlying BatchSettlementEvmScheme's own check fires.
+    expect(server.validateFacilitatorSupport("eip155:84532", supportedKind, [])).toMatch(
+      /receiverAuthorizer/,
+    );
+  });
+});

--- a/typescript/packages/mechanisms/base/test/unit/delegation-parity.test.ts
+++ b/typescript/packages/mechanisms/base/test/unit/delegation-parity.test.ts
@@ -1,0 +1,95 @@
+import { describe, it } from "vitest";
+import { ExactEvmScheme as ExactEvmClient } from "@x402/evm/exact/client";
+import { ExactEvmScheme as ExactEvmServer } from "@x402/evm/exact/server";
+import { ExactEvmScheme as ExactEvmFacilitator } from "@x402/evm/exact/facilitator";
+import { UptoEvmScheme as UptoEvmClient } from "@x402/evm/upto/client";
+import { UptoEvmScheme as UptoEvmServer } from "@x402/evm/upto/server";
+import { UptoEvmScheme as UptoEvmFacilitator } from "@x402/evm/upto/facilitator";
+import { AuthCaptureEvmScheme } from "@x402/evm/auth-capture/client";
+import { BatchSettlementEvmScheme as BatchSettlementEvmClient } from "@x402/evm/batch-settlement/client";
+import { BatchSettlementEvmScheme as BatchSettlementEvmServer } from "@x402/evm/batch-settlement/server";
+import { BatchSettlementEvmScheme as BatchSettlementEvmFacilitator } from "@x402/evm/batch-settlement/facilitator";
+import { BaseScheme as BaseExactClient } from "../../src/exact/client/scheme";
+import { BaseScheme as BaseExactServer } from "../../src/exact/server/scheme";
+import { BaseScheme as BaseExactFacilitator } from "../../src/exact/facilitator/scheme";
+import { BaseScheme as BaseUptoClient } from "../../src/upto/client/scheme";
+import { BaseScheme as BaseUptoServer } from "../../src/upto/server/scheme";
+import { BaseScheme as BaseUptoFacilitator } from "../../src/upto/facilitator/scheme";
+import { BaseScheme as BaseAuthCaptureClient } from "../../src/auth-capture/client/scheme";
+import { BaseScheme as BaseBatchSettlementClient } from "../../src/batch-settlement/client/scheme";
+import { BaseScheme as BaseBatchSettlementServer } from "../../src/batch-settlement/server/scheme";
+import { BaseScheme as BaseBatchSettlementFacilitator } from "../../src/batch-settlement/facilitator/scheme";
+
+/**
+ * For each `@x402/evm` scheme class `@x402/base` wraps, reflects over its
+ * prototype and asserts every public method also exists on the corresponding
+ * `BaseScheme` wrapper's prototype. Catches a future `@x402/evm` method
+ * getting added without a matching `@x402/base` delegation.
+ *
+ * Only covers prototype methods, not instance-field hooks (`schemeHooks`,
+ * `findDefaultAsset`, etc.) assigned in constructors - those are covered by
+ * the per-scheme unit tests instead. `ignore` excludes `@x402/evm`-internal
+ * helpers that are `private` at the type level but still visible on the
+ * runtime prototype.
+ */
+function assertPrototypeDelegation(
+  label: string,
+  EvmClass: { readonly prototype: object },
+  BaseClass: { readonly prototype: object },
+  ignore: readonly string[] = [],
+): void {
+  const evmMembers = Object.getOwnPropertyNames(EvmClass.prototype).filter(
+    name => name !== "constructor" && !ignore.includes(name),
+  );
+  const baseProto = BaseClass.prototype as Record<string, unknown>;
+
+  for (const member of evmMembers) {
+    it(`${label}: forwards "${member}"`, () => {
+      if (typeof baseProto[member] !== "function") {
+        throw new Error(
+          `${label}: "${member}" exists on the @x402/evm class prototype but is not a ` +
+            `function on the @x402/base wrapper's prototype - it looks like a delegation gap.`,
+        );
+      }
+    });
+  }
+}
+
+describe("delegation parity (@x402/evm -> @x402/base)", () => {
+  describe("exact", () => {
+    assertPrototypeDelegation("client", ExactEvmClient, BaseExactClient);
+    assertPrototypeDelegation("server", ExactEvmServer, BaseExactServer, [
+      "defaultMoneyConversion", // private helper, not part of the public SchemeNetworkServer surface
+    ]);
+    assertPrototypeDelegation("facilitator", ExactEvmFacilitator, BaseExactFacilitator);
+  });
+
+  describe("upto", () => {
+    assertPrototypeDelegation("client", UptoEvmClient, BaseUptoClient);
+    assertPrototypeDelegation("server", UptoEvmServer, BaseUptoServer, [
+      "defaultMoneyConversion", // private helper, not part of the public SchemeNetworkServer surface
+    ]);
+    assertPrototypeDelegation("facilitator", UptoEvmFacilitator, BaseUptoFacilitator);
+  });
+
+  describe("auth-capture", () => {
+    assertPrototypeDelegation("client", AuthCaptureEvmScheme, BaseAuthCaptureClient);
+  });
+
+  describe("batch-settlement", () => {
+    assertPrototypeDelegation("client", BatchSettlementEvmClient, BaseBatchSettlementClient, [
+      "normalizeStrategyDepositAmount", // private helper, not part of the public SchemeNetworkClient surface
+      "deps", // private helper, not part of the public SchemeNetworkClient surface
+      "resolveDepositAmount", // private helper, not part of the public SchemeNetworkClient surface
+      "createVoucherPayload", // private helper, not part of the public SchemeNetworkClient surface
+    ]);
+    assertPrototypeDelegation("server", BatchSettlementEvmServer, BaseBatchSettlementServer, [
+      "defaultMoneyConversion", // private helper, not part of the public SchemeNetworkServer surface
+    ]);
+    assertPrototypeDelegation(
+      "facilitator",
+      BatchSettlementEvmFacilitator,
+      BaseBatchSettlementFacilitator,
+    );
+  });
+});

--- a/typescript/packages/mechanisms/base/test/unit/exact/client.test.ts
+++ b/typescript/packages/mechanisms/base/test/unit/exact/client.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest";
+import { isEIP3009Payload, isPermit2Payload, type ExactEvmPayloadV2 } from "@x402/evm";
+import type { PaymentRequirements } from "@x402/core/types";
+import { BaseScheme, type BaseClientSigner } from "../../../src/exact/client/scheme";
+
+/**
+ * `BaseScheme` (client) is a thin pass-through wrapper around `@x402/evm`'s
+ * `ExactEvmScheme`. EIP-3009 / Permit2 signing details, extension enrichment, etc.
+ * are covered by `@x402/evm`'s own test suite - these tests only verify that the
+ * wrapper actually delegates and doesn't diverge from the underlying implementation.
+ */
+describe("BaseScheme (Client)", () => {
+  const requirements: PaymentRequirements = {
+    scheme: "exact",
+    network: "eip155:8453",
+    amount: "1000000",
+    asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+    maxTimeoutSeconds: 300,
+    extra: { name: "USD Coin", version: "2" },
+  };
+
+  it("exposes scheme = 'exact'", () => {
+    const mockSigner: BaseClientSigner = {
+      address: "0x1234567890123456789012345678901234567890",
+      signTypedData: vi.fn().mockResolvedValue("0xmocksignature"),
+    };
+    const client = new BaseScheme(mockSigner);
+    expect(client.scheme).toBe("exact");
+  });
+
+  it("delegates createPaymentPayload to the underlying ExactEvmScheme (EIP-3009)", async () => {
+    const mockSigner: BaseClientSigner = {
+      address: "0x1234567890123456789012345678901234567890",
+      signTypedData: vi.fn().mockResolvedValue("0xmocksignature"),
+    };
+    const client = new BaseScheme(mockSigner);
+
+    const result = await client.createPaymentPayload(2, requirements);
+    const payload = result.payload as unknown as ExactEvmPayloadV2;
+
+    expect(isEIP3009Payload(payload)).toBe(true);
+    if (isEIP3009Payload(payload)) {
+      expect(payload.authorization.from).toBe(mockSigner.address);
+    }
+    expect(mockSigner.signTypedData).toHaveBeenCalled();
+  });
+
+  it("delegates createPaymentPayload to the underlying ExactEvmScheme (Permit2)", async () => {
+    const mockSigner: BaseClientSigner = {
+      address: "0x1234567890123456789012345678901234567890",
+      signTypedData: vi.fn().mockResolvedValue("0xmocksignature"),
+    };
+    const client = new BaseScheme(mockSigner);
+
+    const result = await client.createPaymentPayload(2, {
+      ...requirements,
+      extra: { ...requirements.extra, assetTransferMethod: "permit2" },
+    });
+
+    expect(isPermit2Payload(result.payload as unknown as ExactEvmPayloadV2)).toBe(true);
+  });
+
+  it("rejects createPaymentPayload for a network outside Base's scope", async () => {
+    const mockSigner: BaseClientSigner = {
+      address: "0x1234567890123456789012345678901234567890",
+      signTypedData: vi.fn().mockResolvedValue("0xmocksignature"),
+    };
+    const client = new BaseScheme(mockSigner);
+
+    await expect(
+      client.createPaymentPayload(2, { ...requirements, network: "eip155:1" }),
+    ).rejects.toThrow(/eip155:1/);
+  });
+});

--- a/typescript/packages/mechanisms/base/test/unit/exact/facilitator.test.ts
+++ b/typescript/packages/mechanisms/base/test/unit/exact/facilitator.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { BaseScheme, type BaseFacilitatorSigner } from "../../../src/exact/facilitator/scheme";
+
+/**
+ * `BaseScheme` (facilitator) is a thin pass-through wrapper around `@x402/evm`'s
+ * `ExactEvmScheme`. Verify/settle logic (EIP-3009, Permit2, gas sponsoring, etc.) is
+ * covered by `@x402/evm`'s own test suite - these tests only verify that the wrapper
+ * actually delegates and doesn't diverge from the underlying implementation.
+ */
+describe("BaseScheme (Facilitator)", () => {
+  const mockSigner: BaseFacilitatorSigner = {
+    getAddresses: vi.fn().mockReturnValue(["0x1234567890123456789012345678901234567890"]),
+    readContract: vi.fn(),
+    verifyTypedData: vi.fn(),
+    writeContract: vi.fn(),
+    sendTransaction: vi.fn(),
+    waitForTransactionReceipt: vi.fn(),
+    getCode: vi.fn(),
+  };
+
+  it("exposes scheme = 'exact' and caipFamily = 'eip155:*'", () => {
+    const facilitator = new BaseScheme(mockSigner);
+    expect(facilitator.scheme).toBe("exact");
+    expect(facilitator.caipFamily).toBe("eip155:*");
+  });
+
+  it("delegates getSigners to the underlying ExactEvmScheme", () => {
+    const facilitator = new BaseScheme(mockSigner);
+    expect(facilitator.getSigners("eip155:8453")).toEqual([
+      "0x1234567890123456789012345678901234567890",
+    ]);
+  });
+
+  it("delegates getExtra to the underlying ExactEvmScheme (undefined for EVM)", () => {
+    const facilitator = new BaseScheme(mockSigner);
+    expect(facilitator.getExtra("eip155:8453")).toBeUndefined();
+  });
+
+  it("returns [] from getSigners and undefined from getExtra for a network outside Base's scope", () => {
+    const facilitator = new BaseScheme(mockSigner);
+    expect(facilitator.getSigners("eip155:1")).toEqual([]);
+    expect(facilitator.getExtra("eip155:1")).toBeUndefined();
+  });
+
+  const requirements = {
+    scheme: "exact",
+    network: "eip155:1" as const,
+    amount: "1000000",
+    asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+    maxTimeoutSeconds: 300,
+    extra: {},
+  };
+
+  it("rejects verify for a network outside Base's scope", async () => {
+    const facilitator = new BaseScheme(mockSigner);
+    await expect(facilitator.verify({ x402Version: 2 } as never, requirements)).rejects.toThrow(
+      /eip155:1/,
+    );
+  });
+
+  it("rejects settle for a network outside Base's scope", async () => {
+    const facilitator = new BaseScheme(mockSigner);
+    await expect(facilitator.settle({ x402Version: 2 } as never, requirements)).rejects.toThrow(
+      /eip155:1/,
+    );
+  });
+});

--- a/typescript/packages/mechanisms/base/test/unit/exact/server.test.ts
+++ b/typescript/packages/mechanisms/base/test/unit/exact/server.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import type { SupportedKind } from "@x402/core/types";
+import { BaseScheme } from "../../../src/exact/server/scheme";
+
+/**
+ * `BaseScheme` (server) is a thin pass-through wrapper around `@x402/evm`'s
+ * `ExactEvmScheme`. Pricing/asset conversion details are covered by `@x402/evm`'s
+ * own test suite - these tests only verify that the wrapper actually delegates
+ * and doesn't diverge from the underlying implementation.
+ */
+describe("BaseScheme (Server)", () => {
+  it("exposes scheme = 'exact' and eip3009 as the default transfer method", () => {
+    const server = new BaseScheme();
+    expect(server.scheme).toBe("exact");
+    expect(server.defaultAssetTransferMethod).toBe("eip3009");
+    expect(server.paymentFlows.eip3009.default).toBe("authorization");
+  });
+
+  it("delegates parsePrice to the underlying ExactEvmScheme (Base mainnet USDC)", async () => {
+    const server = new BaseScheme();
+    const result = await server.parsePrice("$1.00", "eip155:8453");
+    expect(result.asset).toBe("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+    expect(result.amount).toBe("1000000");
+  });
+
+  it("delegates parsePrice to the underlying ExactEvmScheme (Base Sepolia USDC)", async () => {
+    const server = new BaseScheme();
+    const result = await server.parsePrice("$0.10", "eip155:84532");
+    expect(result.asset).toBe("0x036CbD53842c5426634e7929541eC2318f3dCF7e");
+    expect(result.amount).toBe("100000");
+  });
+
+  it("delegates registerMoneyParser to the underlying ExactEvmScheme", async () => {
+    const server = new BaseScheme();
+    server.registerMoneyParser(async () => ({ amount: "42", asset: "0xCustomToken" }));
+
+    const result = await server.parsePrice("$1.00", "eip155:8453");
+    expect(result).toEqual({ amount: "42", asset: "0xCustomToken" });
+  });
+
+  it("rejects parsePrice for a network outside Base's scope", async () => {
+    const server = new BaseScheme();
+    await expect(server.parsePrice("$1.00", "eip155:1")).rejects.toThrow(/eip155:1/);
+  });
+
+  it("rejects enhancePaymentRequirements for a network outside Base's scope", async () => {
+    const server = new BaseScheme();
+    await expect(
+      server.enhancePaymentRequirements(
+        {
+          scheme: "exact",
+          network: "eip155:1",
+          amount: "1000000",
+          asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+          maxTimeoutSeconds: 300,
+          extra: {},
+        },
+        { x402Version: 2, scheme: "exact", network: "eip155:1" },
+        [],
+      ),
+    ).rejects.toThrow(/eip155:1/);
+  });
+
+  it("returns undefined from getAssetDecimals for a network outside Base's scope", () => {
+    const server = new BaseScheme();
+    expect(
+      server.getAssetDecimals("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", "eip155:1"),
+    ).toBeUndefined();
+  });
+
+  it("returns a problem string from validateFacilitatorSupport for a network outside Base's scope", () => {
+    const server = new BaseScheme();
+    const supportedKind: SupportedKind = { x402Version: 2, scheme: "exact", network: "eip155:1" };
+    expect(server.validateFacilitatorSupport?.("eip155:1", supportedKind, [])).toMatch(/eip155:1/);
+  });
+
+  it("returns void from validateFacilitatorSupport for a Base network", () => {
+    const server = new BaseScheme();
+    const supportedKind: SupportedKind = {
+      x402Version: 2,
+      scheme: "exact",
+      network: "eip155:8453",
+    };
+    expect(server.validateFacilitatorSupport?.("eip155:8453", supportedKind, [])).toBeUndefined();
+  });
+});

--- a/typescript/packages/mechanisms/base/test/unit/index.test.ts
+++ b/typescript/packages/mechanisms/base/test/unit/index.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import type { BaseClientSigner, BaseFacilitatorSigner } from "../../src";
+import {
+  BaseScheme,
+  BaseUptoScheme,
+  BaseAuthCaptureScheme,
+  BaseBatchSettlementScheme,
+} from "../../src";
+import { BaseScheme as ClientBaseScheme } from "../../src/exact/client";
+import { BaseScheme as ServerBaseScheme } from "../../src/exact/server";
+import { BaseScheme as FacilitatorBaseScheme } from "../../src/exact/facilitator";
+import { BaseScheme as ClientBaseUptoScheme } from "../../src/upto/client";
+import { BaseScheme as ClientBaseAuthCaptureScheme } from "../../src/auth-capture/client";
+import { BaseScheme as ClientBaseBatchSettlementScheme } from "../../src/batch-settlement/client";
+
+describe("@x402/base", () => {
+  it("should export BaseScheme (exact client) from the package root", () => {
+    expect(BaseScheme).toBeDefined();
+    expect(BaseScheme).toBe(ClientBaseScheme);
+  });
+
+  it("should export BaseUptoScheme (upto client) from the package root", () => {
+    expect(BaseUptoScheme).toBeDefined();
+    expect(BaseUptoScheme).toBe(ClientBaseUptoScheme);
+  });
+
+  it("should export BaseAuthCaptureScheme (auth-capture client) from the package root", () => {
+    expect(BaseAuthCaptureScheme).toBeDefined();
+    expect(BaseAuthCaptureScheme).toBe(ClientBaseAuthCaptureScheme);
+  });
+
+  it("should export BaseBatchSettlementScheme (batch-settlement client) from the package root", () => {
+    expect(BaseBatchSettlementScheme).toBeDefined();
+    expect(BaseBatchSettlementScheme).toBe(ClientBaseBatchSettlementScheme);
+  });
+
+  it("should create a client instance", () => {
+    const mockSigner: BaseClientSigner = {
+      address: "0x1234567890123456789012345678901234567890",
+      signTypedData: async () => "0xmocksignature",
+    };
+    const client = new ClientBaseScheme(mockSigner);
+    expect(client.scheme).toBe("exact");
+  });
+
+  it("should create a server instance", () => {
+    const server = new ServerBaseScheme();
+    expect(server.scheme).toBe("exact");
+  });
+
+  it("should create a facilitator instance", () => {
+    const mockSigner: Pick<BaseFacilitatorSigner, "getAddresses"> = {
+      getAddresses: () => ["0x1234567890123456789012345678901234567890"],
+    };
+    const facilitator = new FacilitatorBaseScheme(mockSigner as BaseFacilitatorSigner);
+    expect(facilitator.scheme).toBe("exact");
+  });
+});

--- a/typescript/packages/mechanisms/base/test/unit/networks.test.ts
+++ b/typescript/packages/mechanisms/base/test/unit/networks.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import {
+  BASE_MAINNET,
+  BASE_SEPOLIA,
+  BASE_NETWORKS,
+  isBaseNetwork,
+  assertBaseNetwork,
+  findBaseDefaultAsset,
+} from "../../src/networks";
+
+describe("networks", () => {
+  describe("BASE_NETWORKS", () => {
+    it("contains exactly Base mainnet and Base Sepolia", () => {
+      expect(BASE_MAINNET).toBe("eip155:8453");
+      expect(BASE_SEPOLIA).toBe("eip155:84532");
+      expect(BASE_NETWORKS).toEqual(["eip155:8453", "eip155:84532"]);
+    });
+  });
+
+  describe("isBaseNetwork", () => {
+    it("accepts Base mainnet and Base Sepolia", () => {
+      expect(isBaseNetwork("eip155:8453")).toBe(true);
+      expect(isBaseNetwork("eip155:84532")).toBe(true);
+    });
+
+    it("rejects other EVM networks", () => {
+      expect(isBaseNetwork("eip155:1")).toBe(false);
+      expect(isBaseNetwork("eip155:137")).toBe(false);
+      expect(isBaseNetwork("eip155:42161")).toBe(false);
+    });
+
+    it("rejects non-EVM networks", () => {
+      expect(isBaseNetwork("solana:mainnet")).toBe(false);
+      expect(isBaseNetwork("solana:*")).toBe(false);
+    });
+
+    it("rejects wildcards and garbage input", () => {
+      expect(isBaseNetwork("eip155:*")).toBe(false);
+      expect(isBaseNetwork("")).toBe(false);
+      expect(isBaseNetwork("not-a-network")).toBe(false);
+    });
+  });
+
+  describe("assertBaseNetwork", () => {
+    it("does not throw for Base mainnet or Base Sepolia", () => {
+      expect(() => assertBaseNetwork("eip155:8453", "test")).not.toThrow();
+      expect(() => assertBaseNetwork("eip155:84532", "test")).not.toThrow();
+    });
+
+    it("throws with the offending network and operation name for off-Base networks", () => {
+      expect(() => assertBaseNetwork("eip155:1", "BaseScheme.createPaymentPayload")).toThrow(
+        /BaseScheme\.createPaymentPayload/,
+      );
+      expect(() => assertBaseNetwork("eip155:1", "BaseScheme.createPaymentPayload")).toThrow(
+        /eip155:1/,
+      );
+    });
+
+    it("throws for non-EVM networks", () => {
+      expect(() => assertBaseNetwork("solana:mainnet", "test")).toThrow(/solana:mainnet/);
+    });
+  });
+
+  describe("findBaseDefaultAsset", () => {
+    const usdcMainnet = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+    const usdcSepolia = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
+
+    it("resolves known default assets on Base mainnet", () => {
+      const asset = findBaseDefaultAsset(usdcMainnet, "eip155:8453");
+      expect(asset).toBeDefined();
+      expect(asset?.symbol).toBe("USDC");
+    });
+
+    it("resolves known default assets on Base Sepolia", () => {
+      const asset = findBaseDefaultAsset(usdcSepolia, "eip155:84532");
+      expect(asset).toBeDefined();
+      expect(asset?.symbol).toBe("USDC");
+    });
+
+    it("returns undefined for an unrecognized asset on a Base network", () => {
+      expect(
+        findBaseDefaultAsset("0x0000000000000000000000000000000000dEaD", "eip155:8453"),
+      ).toBeUndefined();
+    });
+
+    it("returns undefined off-Base even for an asset address that is a known default elsewhere", () => {
+      // Same USDC address, but on a network @x402/base is not scoped to.
+      expect(findBaseDefaultAsset(usdcMainnet, "eip155:1")).toBeUndefined();
+    });
+  });
+});

--- a/typescript/packages/mechanisms/base/test/unit/upto/client.test.ts
+++ b/typescript/packages/mechanisms/base/test/unit/upto/client.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { isUptoPermit2Payload } from "@x402/evm";
+import type { PaymentRequirements } from "@x402/core/types";
+import { BaseScheme, type BaseClientSigner } from "../../../src/upto/client/scheme";
+
+/**
+ * `BaseScheme` (upto client) is a thin pass-through wrapper around `@x402/evm`'s
+ * `UptoEvmScheme`. Permit2 signing details, extension enrichment, etc. are covered
+ * by `@x402/evm`'s own test suite - these tests only verify that the wrapper actually
+ * delegates and doesn't diverge from the underlying implementation.
+ */
+describe("BaseScheme (Upto Client)", () => {
+  const requirements: PaymentRequirements = {
+    scheme: "upto",
+    network: "eip155:8453",
+    amount: "1000000",
+    asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+    maxTimeoutSeconds: 300,
+    extra: { facilitatorAddress: "0x8135968F909911fA035BCbbdd5458811820E2abd" },
+  };
+
+  it("exposes scheme = 'upto'", () => {
+    const mockSigner: BaseClientSigner = {
+      address: "0x1234567890123456789012345678901234567890",
+      signTypedData: vi.fn().mockResolvedValue("0xmocksignature"),
+    };
+    const client = new BaseScheme(mockSigner);
+    expect(client.scheme).toBe("upto");
+  });
+
+  it("delegates createPaymentPayload to the underlying UptoEvmScheme (Permit2)", async () => {
+    const mockSigner: BaseClientSigner = {
+      address: "0x1234567890123456789012345678901234567890",
+      signTypedData: vi.fn().mockResolvedValue("0xmocksignature"),
+    };
+    const client = new BaseScheme(mockSigner);
+
+    const result = await client.createPaymentPayload(2, requirements);
+
+    expect(isUptoPermit2Payload(result.payload)).toBe(true);
+    expect(mockSigner.signTypedData).toHaveBeenCalled();
+  });
+
+  it("propagates the underlying UptoEvmScheme's facilitatorAddress requirement", async () => {
+    const mockSigner: BaseClientSigner = {
+      address: "0x1234567890123456789012345678901234567890",
+      signTypedData: vi.fn().mockResolvedValue("0xmocksignature"),
+    };
+    const client = new BaseScheme(mockSigner);
+
+    await expect(client.createPaymentPayload(2, { ...requirements, extra: {} })).rejects.toThrow(
+      /facilitatorAddress/,
+    );
+  });
+
+  it("rejects createPaymentPayload for a network outside Base's scope", async () => {
+    const mockSigner: BaseClientSigner = {
+      address: "0x1234567890123456789012345678901234567890",
+      signTypedData: vi.fn().mockResolvedValue("0xmocksignature"),
+    };
+    const client = new BaseScheme(mockSigner);
+
+    await expect(
+      client.createPaymentPayload(2, { ...requirements, network: "eip155:1" }),
+    ).rejects.toThrow(/eip155:1/);
+  });
+});

--- a/typescript/packages/mechanisms/base/test/unit/upto/facilitator.test.ts
+++ b/typescript/packages/mechanisms/base/test/unit/upto/facilitator.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { BaseScheme, type BaseFacilitatorSigner } from "../../../src/upto/facilitator/scheme";
+
+/**
+ * `BaseScheme` (upto facilitator) is a thin pass-through wrapper around `@x402/evm`'s
+ * `UptoEvmScheme`. Verify/settle logic (Permit2, gas sponsoring, etc.) is covered by
+ * `@x402/evm`'s own test suite - these tests only verify that the wrapper actually
+ * delegates and doesn't diverge from the underlying implementation.
+ */
+describe("BaseScheme (Upto Facilitator)", () => {
+  const mockSigner: BaseFacilitatorSigner = {
+    getAddresses: vi.fn().mockReturnValue(["0x1234567890123456789012345678901234567890"]),
+    readContract: vi.fn(),
+    verifyTypedData: vi.fn(),
+    writeContract: vi.fn(),
+    sendTransaction: vi.fn(),
+    waitForTransactionReceipt: vi.fn(),
+    getCode: vi.fn(),
+  };
+
+  it("exposes scheme = 'upto' and caipFamily = 'eip155:*'", () => {
+    const facilitator = new BaseScheme(mockSigner);
+    expect(facilitator.scheme).toBe("upto");
+    expect(facilitator.caipFamily).toBe("eip155:*");
+  });
+
+  it("delegates getSigners to the underlying UptoEvmScheme", () => {
+    const facilitator = new BaseScheme(mockSigner);
+    expect(facilitator.getSigners("eip155:8453")).toEqual([
+      "0x1234567890123456789012345678901234567890",
+    ]);
+  });
+
+  it("delegates getExtra to the underlying UptoEvmScheme (facilitatorAddress)", () => {
+    const facilitator = new BaseScheme(mockSigner);
+    expect(facilitator.getExtra("eip155:8453")).toEqual({
+      facilitatorAddress: "0x1234567890123456789012345678901234567890",
+    });
+  });
+
+  it("returns [] from getSigners and undefined from getExtra for a network outside Base's scope", () => {
+    const facilitator = new BaseScheme(mockSigner);
+    expect(facilitator.getSigners("eip155:1")).toEqual([]);
+    expect(facilitator.getExtra("eip155:1")).toBeUndefined();
+  });
+
+  const requirements = {
+    scheme: "upto",
+    network: "eip155:1" as const,
+    amount: "1000000",
+    asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+    maxTimeoutSeconds: 300,
+    extra: {},
+  };
+
+  it("rejects verify for a network outside Base's scope", async () => {
+    const facilitator = new BaseScheme(mockSigner);
+    await expect(facilitator.verify({ x402Version: 2 } as never, requirements)).rejects.toThrow(
+      /eip155:1/,
+    );
+  });
+
+  it("rejects settle for a network outside Base's scope", async () => {
+    const facilitator = new BaseScheme(mockSigner);
+    await expect(facilitator.settle({ x402Version: 2 } as never, requirements)).rejects.toThrow(
+      /eip155:1/,
+    );
+  });
+});

--- a/typescript/packages/mechanisms/base/test/unit/upto/server.test.ts
+++ b/typescript/packages/mechanisms/base/test/unit/upto/server.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import type { SupportedKind } from "@x402/core/types";
+import { BaseScheme } from "../../../src/upto/server/scheme";
+
+/**
+ * `BaseScheme` (upto server) is a thin pass-through wrapper around `@x402/evm`'s
+ * `UptoEvmScheme`. Pricing/asset conversion details are covered by `@x402/evm`'s own
+ * test suite - these tests only verify that the wrapper actually delegates and
+ * doesn't diverge from the underlying implementation.
+ */
+describe("BaseScheme (Upto Server)", () => {
+  it("exposes scheme = 'upto' and permit2 as the (only) transfer method", () => {
+    const server = new BaseScheme();
+    expect(server.scheme).toBe("upto");
+    expect(server.defaultAssetTransferMethod).toBe("permit2");
+    expect(server.paymentFlows.permit2.default).toBe("authorization");
+  });
+
+  it("delegates parsePrice to the underlying UptoEvmScheme (Base mainnet USDC)", async () => {
+    const server = new BaseScheme();
+    const result = await server.parsePrice("$1.00", "eip155:8453");
+    expect(result.asset).toBe("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+    expect(result.amount).toBe("1000000");
+    expect(result.extra?.assetTransferMethod).toBe("permit2");
+  });
+
+  it("delegates enhancePaymentRequirements to the underlying UptoEvmScheme (facilitatorAddress)", async () => {
+    const server = new BaseScheme();
+    const enhanced = await server.enhancePaymentRequirements(
+      {
+        scheme: "upto",
+        network: "eip155:8453",
+        amount: "1000000",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: {},
+      },
+      {
+        x402Version: 2,
+        scheme: "upto",
+        network: "eip155:8453",
+        // Already EIP-55 checksummed, so the underlying getAddress() call is a no-op.
+        extra: { facilitatorAddress: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" },
+      },
+      [],
+    );
+    expect(enhanced.extra?.facilitatorAddress).toBe("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+    expect(enhanced.extra?.assetTransferMethod).toBe("permit2");
+  });
+
+  it("delegates registerMoneyParser to the underlying UptoEvmScheme", async () => {
+    const server = new BaseScheme();
+    server.registerMoneyParser(async () => ({ amount: "42", asset: "0xCustomToken" }));
+
+    const result = await server.parsePrice("$1.00", "eip155:8453");
+    expect(result).toEqual({ amount: "42", asset: "0xCustomToken" });
+  });
+
+  it("rejects parsePrice for a network outside Base's scope", async () => {
+    const server = new BaseScheme();
+    await expect(server.parsePrice("$1.00", "eip155:1")).rejects.toThrow(/eip155:1/);
+  });
+
+  it("rejects enhancePaymentRequirements for a network outside Base's scope", async () => {
+    const server = new BaseScheme();
+    await expect(
+      server.enhancePaymentRequirements(
+        {
+          scheme: "upto",
+          network: "eip155:1",
+          amount: "1000000",
+          asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+          maxTimeoutSeconds: 300,
+          extra: {},
+        },
+        { x402Version: 2, scheme: "upto", network: "eip155:1" },
+        [],
+      ),
+    ).rejects.toThrow(/eip155:1/);
+  });
+
+  it("returns undefined from getAssetDecimals for a network outside Base's scope", () => {
+    const server = new BaseScheme();
+    expect(
+      server.getAssetDecimals("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", "eip155:1"),
+    ).toBeUndefined();
+  });
+
+  it("returns a problem string from validateFacilitatorSupport for a network outside Base's scope", () => {
+    const server = new BaseScheme();
+    const supportedKind: SupportedKind = { x402Version: 2, scheme: "upto", network: "eip155:1" };
+    expect(server.validateFacilitatorSupport?.("eip155:1", supportedKind, [])).toMatch(/eip155:1/);
+  });
+
+  it("returns void from validateFacilitatorSupport for a Base network", () => {
+    const server = new BaseScheme();
+    const supportedKind: SupportedKind = {
+      x402Version: 2,
+      scheme: "upto",
+      network: "eip155:8453",
+    };
+    expect(server.validateFacilitatorSupport?.("eip155:8453", supportedKind, [])).toBeUndefined();
+  });
+});

--- a/typescript/packages/mechanisms/base/tsconfig.json
+++ b/typescript/packages/mechanisms/base/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2020"],
+    "allowJs": false,
+    "checkJs": false
+  },
+  "include": ["src", "test"]
+}

--- a/typescript/packages/mechanisms/base/tsup.config.ts
+++ b/typescript/packages/mechanisms/base/tsup.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from "tsup";
+
+const baseConfig = {
+  entry: {
+    index: "src/index.ts",
+    "exact/client/index": "src/exact/client/index.ts",
+    "exact/server/index": "src/exact/server/index.ts",
+    "exact/facilitator/index": "src/exact/facilitator/index.ts",
+    "upto/client/index": "src/upto/client/index.ts",
+    "upto/server/index": "src/upto/server/index.ts",
+    "upto/facilitator/index": "src/upto/facilitator/index.ts",
+    "auth-capture/client/index": "src/auth-capture/client/index.ts",
+    "batch-settlement/client/index": "src/batch-settlement/client/index.ts",
+    "batch-settlement/server/index": "src/batch-settlement/server/index.ts",
+    "batch-settlement/facilitator/index": "src/batch-settlement/facilitator/index.ts",
+  },
+  dts: {
+    resolve: true,
+  },
+  sourcemap: true,
+  target: "es2020",
+};
+
+export default defineConfig([
+  {
+    ...baseConfig,
+    format: "esm",
+    outDir: "dist/esm",
+    clean: true,
+  },
+  {
+    ...baseConfig,
+    format: "cjs",
+    outDir: "dist/cjs",
+    clean: false,
+  },
+]);

--- a/typescript/packages/mechanisms/base/vitest.config.ts
+++ b/typescript/packages/mechanisms/base/vitest.config.ts
@@ -1,0 +1,15 @@
+import { loadEnv } from "vite";
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig(({ mode }) => ({
+  test: {
+    env: loadEnv(mode, process.cwd(), ""),
+    exclude: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/test/integrations/**", // Exclude integration tests from default run
+    ],
+  },
+  plugins: [tsconfigPaths({ projects: ["."] })],
+}));

--- a/typescript/packages/mechanisms/base/vitest.integration.config.ts
+++ b/typescript/packages/mechanisms/base/vitest.integration.config.ts
@@ -1,0 +1,12 @@
+import { loadEnv } from "vite";
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig(({ mode }) => ({
+  test: {
+    env: loadEnv(mode, process.cwd(), ""),
+    include: ["test/integrations/**/*.test.ts"], // Only include integration tests
+    fileParallelism: false, // Prevent race conditions on tx nonces
+  },
+  plugins: [tsconfigPaths({ projects: ["."] })],
+}));

--- a/typescript/packages/mechanisms/evm/src/exact/client/index.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/index.ts
@@ -2,6 +2,9 @@ export { ExactEvmScheme } from "./scheme";
 export { registerExactEvmScheme } from "./register";
 export type { EvmClientConfig } from "./register";
 export type {
+  EvmSchemeConfig,
+  EvmSchemeConfigByChainId,
+  EvmSchemeOptions,
   ExactEvmSchemeConfig,
   ExactEvmSchemeConfigByChainId,
   ExactEvmSchemeOptions,

--- a/typescript/packages/mechanisms/evm/src/upto/facilitator/index.ts
+++ b/typescript/packages/mechanisms/evm/src/upto/facilitator/index.ts
@@ -1,3 +1,4 @@
 // Note: No register.ts helper — V1 backward compatibility is not needed for upto.
 // Use direct class instantiation: facilitator.register("eip155:*", new UptoEvmScheme(signer))
 export { UptoEvmScheme } from "./scheme";
+export type { UptoEvmSchemeConfig } from "./scheme";

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -1277,6 +1277,61 @@ importers:
         specifier: ^3.0.5
         version: 3.2.4(@types/debug@4.1.13)(@types/node@22.18.0)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
 
+  packages/mechanisms/base:
+    dependencies:
+      '@x402/core':
+        specifier: workspace:~
+        version: link:../../core
+      '@x402/evm':
+        specifier: workspace:~
+        version: link:../evm
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.24.0
+        version: 9.34.0
+      '@types/node':
+        specifier: ^22.13.4
+        version: 22.19.17
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.29.1
+        version: 8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.34.0)(typescript@5.9.2))(eslint@9.34.0)(typescript@5.9.2)
+      '@typescript-eslint/parser':
+        specifier: ^8.29.1
+        version: 8.49.0(eslint@9.34.0)(typescript@5.9.2)
+      eslint:
+        specifier: ^9.24.0
+        version: 9.34.0
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.34.0)(typescript@5.9.2))(eslint@9.34.0)
+      eslint-plugin-jsdoc:
+        specifier: ^50.6.9
+        version: 50.8.0(eslint@9.34.0)
+      eslint-plugin-prettier:
+        specifier: ^5.2.6
+        version: 5.5.4(eslint@9.34.0)(prettier@3.5.2)
+      prettier:
+        specifier: 3.5.2
+        version: 3.5.2
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.0(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.2)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.2
+      viem:
+        specifier: ^2.48.11
+        version: 2.48.11(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.1.13)
+      vite:
+        specifier: ^6.2.6
+        version: 6.3.5(@types/node@22.19.17)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.9.2)(vite@6.3.5(@types/node@22.19.17)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
+
   packages/mechanisms/concordium:
     dependencies:
       '@concordium/web-sdk':


### PR DESCRIPTION
### What

Adds `@x402/base`, a new TypeScript mechanism package scoped to Base
(`eip155:8453`) and Base Sepolia (`eip155:84532`) that implements the `exact`,
`upto`, `auth-capture`, and `batch-settlement` schemes as thin pass-through
wrappers around `@x402/evm`. Each `BaseScheme` client/server/facilitator class
takes the exact same constructor arguments as its `@x402/evm` counterpart and
delegates every method to it — Base is fully EVM-compatible today, so there is
no behavioral difference from generic EVM yet.

### Why

`@x402/evm` is generic across the entire `eip155:*` family. Registering
`@x402/base`'s schemes against `eip155:8453` / `eip155:84532` instead of (or
alongside) `@x402/evm`'s wildcard gives Base a dedicated seam to diverge later
— e.g. a different gas-sponsoring strategy or default asset transfer method —
without a breaking API change or requiring consumers to switch schemes.

### Design decisions

- **Pass-through over registry fallback.** Considered letting network-specific
  and network-family mechanisms both register and fall back to each other at
  the `@x402/core` registry level. Went with intra-mechanism delegation
  instead (`BaseScheme` holds an `EvmScheme` instance and forwards to it) —
  it keeps `@x402/core`'s resolution model simple (one scheme per network key,
  no fallback semantics to reason about) and gives `@x402/base` full control
  to override individual methods later without changing how it's registered.
- **Runtime network scoping, not just registration-time.** Because the
  underlying `@x402/evm` schemes are generic across all EVM chains, a
  `BaseScheme` reached via a wildcard registration or called directly would
  otherwise silently process payments for any `eip155:*` chain. `src/networks.ts`
  adds `assertBaseNetwork` (throws) and `isBaseNetwork`/`findBaseDefaultAsset`
  (fail closed) so this is caught immediately instead. Value-affecting methods
  (`createPaymentPayload`, `verify`, `settle`, `parsePrice`,
  `enhancePaymentRequirements`, `buildChannelConfig`, `createChannelManager`)
  throw; metadata reads (`getAssetDecimals`, `getExtra`, `getSigners`,
  `findDefaultAsset`) return `undefined`/`[]`; `validateFacilitatorSupport`
  reports a problem string so a mis-registered network fails server startup
  instead of surfacing at first payment.
- **`Base`-prefixed type aliases, not `Evm` re-exports.** All public types
  (`BaseClientSigner`, `BaseSchemeOptions`, etc.) are redeclared as aliases of
  their `@x402/evm` equivalents so nothing `Evm`-named leaks through
  `@x402/base`'s public API, even though the implementation is 1:1 today.
- **`auth-capture` is client-only**, mirroring `@x402/evm`, which has no
  server/facilitator implementation for this scheme yet.

### Testing

- Unit tests per scheme/role verify construction, delegation, and network
  scoping (off-Base networks rejected/fail closed).
- `test/unit/delegation-parity.test.ts` reflects over each wrapped
  `@x402/evm` class's prototype and asserts every public method is also
  forwarded by the corresponding `BaseScheme`, so a future `@x402/evm` method
  added without a matching `@x402/base` delegation fails loudly.
- Integration tests (skipped without `CLIENT_PRIVATE_KEY` /
  `FACILITATOR_PRIVATE_KEY` env vars) exercise real signing against Base
  Sepolia for all four schemes.
- `pnpm format && pnpm lint && pnpm build && pnpm test` pass for
  `@x402/base` and the two touched `@x402/evm` export files.

### Release

- New dedicated `publish_npm_scoped_x402_base.yml` workflow, wired into the
  `publish_npm_scoped_x402_all.yml` ordering after `@x402/evm`.
- `@x402/base` added to the `fixed` changeset group (versions alongside
  `@x402/evm`) with an initial-release changeset fragment.
- Both root and `typescript/` READMEs updated to list the new package.