### PR TITLE
examples(typescript): add who-lookup client example against a live mainnet endpoint

### DIFF
--- a/examples/typescript/clients/README.md
+++ b/examples/typescript/clients/README.md
@@ -10,6 +10,7 @@ This directory contains TypeScript client examples demonstrating how to make HTT
 | [`axios/`](./axios/) | Using `@x402/axios` with Axios |
 | [`advanced/`](./advanced/) | Advanced patterns: lifecycle hooks, network preferences |
 | [`custom/`](./custom/) | Manual implementation using only `@x402/core` |
+| [`who-lookup/`](./who-lookup/) | The only mainnet example; opt-in — pays a real, live endpoint on Base mainnet so you can try the flow with no local server |
 
 ## Framework Examples
 
@@ -39,9 +40,21 @@ The **custom** directory shows how to implement x402 payment handling manually u
 - You're integrating with an HTTP client we don't have a package for
 - You want to understand how x402 works under the hood
 
+## Try It Against a Live Endpoint
+
+Every example above defaults to `http://localhost:4021` and expects you to
+run a [server](../servers/) yourself. If you'd rather see a real payment go
+through first, [`who-lookup/`](./who-lookup/) points at a live, cheap
+($0.05 USDC on Base mainnet) third-party endpoint instead — no local server,
+no signup, just a funded EVM wallet.
+
+**It's the only mainnet example here, and it's opt-in.** It spends real
+money and has no testnet twin, so it refuses to run unless you set
+`X402_ALLOW_MAINNET=1` — see its README before running it.
+
 ## Getting Started
 
 1. Pick an example directory
 2. Follow the README in that directory
-3. Make sure you have a [server](../servers/) running to test against
+3. Make sure you have a [server](../servers/) running to test against (or use [`who-lookup/`](./who-lookup/) to try a live endpoint instead)
 

--- a/examples/typescript/clients/who-lookup/.env-local
+++ b/examples/typescript/clients/who-lookup/.env-local
@@ -1,0 +1,5 @@
+EVM_PRIVATE_KEY=
+RESOURCE_SERVER_URL=https://lookups.alienprobe.ai
+ENDPOINT_PATH=/v1/lookup/who/apple.com
+MAX_PAYMENT_ATOMIC=100000
+X402_ALLOW_MAINNET=

--- a/examples/typescript/clients/who-lookup/.prettierignore
+++ b/examples/typescript/clients/who-lookup/.prettierignore
@@ -1,0 +1,8 @@
+docs/
+dist/
+node_modules/
+coverage/
+.github/
+src/client
+**/**/*.json
+*.md

--- a/examples/typescript/clients/who-lookup/.prettierrc
+++ b/examples/typescript/clients/who-lookup/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "avoid",
+  "printWidth": 100,
+  "proseWrap": "never"
+}

--- a/examples/typescript/clients/who-lookup/README.md
+++ b/examples/typescript/clients/who-lookup/README.md
@@ -1,0 +1,89 @@
+# Who-Lookup Client Example
+
+Example client demonstrating `@x402/fetch` against a real, live x402-protected
+endpoint on Base mainnet, so you can try the full 402 → pay → 200 flow without
+standing up your own server first.
+
+The endpoint is [`lookups.alienprobe.ai`](https://lookups.alienprobe.ai), a
+third-party "who" lookup that resolves a company name, domain, or LEI to a
+GLEIF legal-entity record for a fixed **$0.05 in USDC on Base mainnet**. It is
+operated by a contributor to this repo, not by Coinbase or the x402
+Foundation — see [DISCLAIMER](#disclaimer) below.
+
+> **This example pays $0.05 USDC on Base MAINNET from the key in your `.env`.**
+> It is the only example in this repo that spends real money by default —
+> there is no testnet twin for this endpoint. It refuses to run unless you
+> set `X402_ALLOW_MAINNET=1`. Never fund a mainnet key you would not lose.
+
+```typescript
+import { x402Client, wrapFetchWithPayment } from "@x402/fetch";
+import { ExactEvmScheme } from "@x402/evm/exact/client";
+import { privateKeyToAccount } from "viem/accounts";
+
+const client = new x402Client();
+client.register("eip155:*", new ExactEvmScheme(privateKeyToAccount(process.env.EVM_PRIVATE_KEY)));
+
+const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+
+const response = await fetchWithPayment("https://lookups.alienprobe.ai/v1/lookup/who/apple.com");
+console.log(await response.json());
+```
+
+## Prerequisites
+
+- Node.js v20+ (install via [nvm](https://github.com/nvm-sh/nvm))
+- pnpm v10 (install via [pnpm.io/installation](https://pnpm.io/installation))
+- An EVM wallet funded with a small amount of USDC on **Base mainnet**
+  (`eip155:8453`) — this example spends real money, capped at $0.05 per run
+
+## Setup
+
+1. Install and build all packages from the typescript examples root:
+
+```bash
+cd ../../
+pnpm install && pnpm build
+cd clients/who-lookup
+```
+
+2. Copy `.env-local` to `.env` and add your private key:
+
+```bash
+cp .env-local .env
+```
+
+Required environment variables:
+
+- `EVM_PRIVATE_KEY` - Ethereum private key funded with USDC on Base mainnet
+- `X402_ALLOW_MAINNET` - Must be set to `1`. This example refuses to run
+  without it, since it spends real money and has no testnet equivalent.
+
+Optional environment variables:
+
+- `RESOURCE_SERVER_URL` - Overrides the resource server (default: this example's live endpoint)
+- `ENDPOINT_PATH` - Overrides the endpoint path (default: `/v1/lookup/who/apple.com`)
+- `MAX_PAYMENT_ATOMIC` - Spend cap in atomic units of the priced asset (default: `"100000"`, i.e. $0.10 USDC).
+  The example aborts via `onBeforePaymentCreation` rather than pay more than this, no matter what the server asks for.
+
+3. Run the client:
+
+```bash
+pnpm start
+```
+
+## What to expect
+
+- `GET /v1/lookup/who/apple.com` → 402, then a signed payment, then 200 with the resolved GLEIF record.
+- `GET /v1/lookup/who/Acme` (ambiguous name) → 409, free, with up to five candidates and a hint to re-ask with a jurisdiction suffix. Try it by setting `ENDPOINT_PATH=/v1/lookup/who/Acme`.
+- A malformed, unknown, or unreadable subject returns 400/404/503 — all free, before any payment is created.
+
+## Disclaimer
+
+`lookups.alienprobe.ai` is a third-party service run by a contributor to this
+repository. It is not affiliated with, endorsed by, or operated by Coinbase
+or the x402 Foundation. It is included here only as a cheap, real endpoint
+newcomers can try the payment flow against.
+
+## Next Steps
+
+See [Advanced Examples](../advanced/) for builder pattern registration, payment lifecycle hooks, and network preferences.

--- a/examples/typescript/clients/who-lookup/eslint.config.js
+++ b/examples/typescript/clients/who-lookup/eslint.config.js
@@ -1,0 +1,72 @@
+import js from "@eslint/js";
+import ts from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+import prettier from "eslint-plugin-prettier";
+import jsdoc from "eslint-plugin-jsdoc";
+import importPlugin from "eslint-plugin-import";
+
+export default [
+  {
+    ignores: ["dist/**", "node_modules/**"],
+  },
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      sourceType: "module",
+      ecmaVersion: 2020,
+      globals: {
+        process: "readonly",
+        __dirname: "readonly",
+        module: "readonly",
+        require: "readonly",
+        Buffer: "readonly",
+        exports: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly",
+      },
+    },
+    plugins: {
+      "@typescript-eslint": ts,
+      prettier: prettier,
+      jsdoc: jsdoc,
+      import: importPlugin,
+    },
+    rules: {
+      ...ts.configs.recommended.rules,
+      "import/first": "error",
+      "prettier/prettier": "error",
+      "@typescript-eslint/member-ordering": "error",
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_$" }],
+      "jsdoc/tag-lines": ["error", "any", { startLines: 1 }],
+      "jsdoc/check-alignment": "error",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/check-param-names": "error",
+      "jsdoc/check-tag-names": "error",
+      "jsdoc/check-types": "error",
+      "jsdoc/implements-on-classes": "error",
+      "jsdoc/require-description": "error",
+      "jsdoc/require-jsdoc": [
+        "error",
+        {
+          require: {
+            FunctionDeclaration: true,
+            MethodDefinition: true,
+            ClassDeclaration: true,
+            ArrowFunctionExpression: false,
+            FunctionExpression: false,
+          },
+        },
+      ],
+      "jsdoc/require-param": "error",
+      "jsdoc/require-param-description": "error",
+      "jsdoc/require-param-type": "off",
+      "jsdoc/require-returns": "error",
+      "jsdoc/require-returns-description": "error",
+      "jsdoc/require-returns-type": "off",
+      "jsdoc/require-hyphen-before-param-description": ["error", "always"],
+    },
+  },
+];

--- a/examples/typescript/clients/who-lookup/index.ts
+++ b/examples/typescript/clients/who-lookup/index.ts
@@ -1,0 +1,99 @@
+import { config } from "dotenv";
+import { x402Client, wrapFetchWithPayment, x402HTTPClient } from "@x402/fetch";
+import { ExactEvmScheme } from "@x402/evm/exact/client";
+import { privateKeyToAccount } from "viem/accounts";
+
+config();
+
+const evmPrivateKey = process.env.EVM_PRIVATE_KEY as `0x${string}`;
+if (!evmPrivateKey) {
+  console.error("❌ EVM_PRIVATE_KEY environment variable is required");
+  process.exit(1);
+}
+
+const baseURL = process.env.RESOURCE_SERVER_URL || "https://lookups.alienprobe.ai";
+const endpointPath = process.env.ENDPOINT_PATH || "/v1/lookup/who/apple.com";
+// Spend cap, in the asset's atomic units (USDC has 6 decimals: "100000" == $0.10,
+// double the endpoint's $0.05 price). The hook below refuses to pay anything above
+// this, no matter what the server asks for.
+const maxPaymentAtomic = BigInt(process.env.MAX_PAYMENT_ATOMIC || "100000");
+const url = `${baseURL}${endpointPath}`;
+
+// This is the only example in this repo that spends real money on mainnet by
+// default. Everything else here targets a local server or Base Sepolia
+// testnet. Require an explicit opt-in before it can run at all.
+if (process.env.X402_ALLOW_MAINNET !== "1") {
+  console.error("This example pays $0.05 USDC on Base MAINNET from the key in .env.");
+  console.error(
+    "Set X402_ALLOW_MAINNET=1 to proceed; never fund a mainnet key you would not lose.",
+  );
+  process.exit(1);
+}
+
+/**
+ * Example demonstrating a real, live x402-protected endpoint on Base mainnet.
+ *
+ * This hits lookups.alienprobe.ai, a third-party "who" lookup (resolves a
+ * company name, domain, or LEI to a GLEIF legal-entity record) priced at a
+ * fixed $0.05 in USDC on Base mainnet. It is not affiliated with Coinbase or
+ * the x402 Foundation; it exists here to give newcomers something real to pay
+ * for the "free 402 -> pay -> 200" flow without standing up a local server.
+ *
+ * The endpoint refuses malformed/missing/ambiguous/unreadable subjects for
+ * free, before the payment boundary:
+ * - 400 malformed input
+ * - 404 no match in the snapshot
+ * - 409 ambiguous name match (names only; re-ask with a jurisdiction suffix)
+ * - 503 source shard unreadable
+ * Only a 402 challenge costs anything, and only once you pay it.
+ *
+ * Required environment variables:
+ * - EVM_PRIVATE_KEY: The private key of the EVM signer, funded with a small
+ *   amount of USDC on Base mainnet (eip155:8453)
+ *
+ * Optional environment variables:
+ * - RESOURCE_SERVER_URL: Overrides the resource server (default: this example's live endpoint)
+ * - ENDPOINT_PATH: Overrides the endpoint path (default: /v1/lookup/who/apple.com)
+ * - MAX_PAYMENT_ATOMIC: Spend cap in atomic units of the priced asset (default: "100000", i.e. $0.10 USDC)
+ * - X402_ALLOW_MAINNET: Must be set to "1" to run at all. This is the only
+ *   example in the repo that spends real money by default; there is no
+ *   testnet twin, so the opt-in is the safety gate instead.
+ */
+async function main(): Promise<void> {
+  const evmSigner = privateKeyToAccount(evmPrivateKey);
+
+  const client = new x402Client();
+  client.register("eip155:*", new ExactEvmScheme(evmSigner));
+  client.onBeforePaymentCreation(async context => {
+    const { amount } = context.selectedRequirements;
+    if (BigInt(amount) > maxPaymentAtomic) {
+      return {
+        abort: true,
+        reason: `Refusing to pay ${amount} — exceeds spend cap of ${maxPaymentAtomic}`,
+      };
+    }
+  });
+
+  const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+
+  console.log(`Making request to: ${url}\n`);
+  const response = await fetchWithPayment(url, { method: "GET" });
+  const body = await response.json();
+
+  if (!response.ok) {
+    console.log(`Refused with ${response.status}:`, body);
+    return;
+  }
+
+  console.log("Response body:", body);
+
+  const paymentResponse = new x402HTTPClient(client).getPaymentSettleResponse(name =>
+    response.headers.get(name),
+  );
+  console.log("\nPayment response:", JSON.stringify(paymentResponse, null, 2));
+}
+
+main().catch(error => {
+  console.error(error?.response?.data?.error ?? error);
+  process.exit(1);
+});

--- a/examples/typescript/clients/who-lookup/package.json
+++ b/examples/typescript/clients/who-lookup/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@x402/who-lookup-client-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts",
+    "dev": "tsx index.ts",
+    "format": "prettier -c .prettierrc --write \"**/*.{ts,js,cjs,json,md}\"",
+    "format:check": "prettier -c .prettierrc --check \"**/*.{ts,js,cjs,json,md}\"",
+    "lint": "eslint . --ext .ts --fix",
+    "lint:check": "eslint . --ext .ts"
+  },
+  "dependencies": {
+    "@x402/evm": "workspace:*",
+    "@x402/fetch": "workspace:*",
+    "dotenv": "^16.4.7",
+    "viem": "^2.39.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.24.0",
+    "@typescript-eslint/eslint-plugin": "^8.29.1",
+    "@typescript-eslint/parser": "^8.29.1",
+    "eslint": "^9.24.0",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-jsdoc": "^50.6.9",
+    "eslint-plugin-prettier": "^5.2.6",
+    "prettier": "3.5.2",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/examples/typescript/clients/who-lookup/tsconfig.json
+++ b/examples/typescript/clients/who-lookup/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "types": ["node"]
+  },
+  "include": ["index.ts"]
+}


### PR DESCRIPTION
Adds `examples/typescript/clients/who-lookup/`, a client example that pays a
real, live x402-protected endpoint on Base mainnet instead of a local server.

**Why:** every existing client example points at `http://localhost:4021` and
requires the reader to first stand up one of the `servers/` examples. That's
the right default, but it means a newcomer can't see a real 402 → pay → 200
round-trip without writing a server first. This adds an opt-in path to try
the flow against a real endpoint in under a minute: install deps, add a
funded private key, `pnpm start`.

**The endpoint:** `GET https://lookups.alienprobe.ai/v1/lookup/who/{q}`
resolves a company name, domain, or LEI to a GLEIF legal-entity record.
Fixed price: $0.05 in USDC on Base mainnet (`eip155:8453`). No signup. Free
refusals before the payment boundary: 400 malformed, 404 miss, 409 ambiguous
name (with candidates), 503 source unreadable.

**Disclosure:** this endpoint is operated by me (a contributor to this repo),
not by Coinbase or the x402 Foundation. It's included purely as a cheap, real
example to pay against — the example's `onBeforePaymentCreation` hook also
enforces a spend cap (`MAX_PAYMENT_ATOMIC`, default `100000` = $0.10) so it
never pays more than double what the example claims to, regardless of what
any server (this one or another `RESOURCE_SERVER_URL`) asks for.

**Opt-in, not default-on:** every other client example in this repo targets
`http://localhost:4021` or Base Sepolia testnet. This is the first and only
client example that spends real money by default, and there's no testnet
twin for this endpoint to fall back to — GLEIF entity data doesn't have a
faucet-funded sandbox equivalent. To keep that from being a surprise, the
example refuses to run at all unless `X402_ALLOW_MAINNET=1` is set, printing
a two-line warning first. Happy to gate this further (e.g. move it out of
`examples/` entirely into a Bazaar/ecosystem listing) if maintainers would
rather not carry a mainnet-spending example in this directory.

Also adds a short "Try It Against a Live Endpoint" note to
`examples/typescript/clients/README.md` pointing at the new example.

No changes to any package under `typescript/packages/`.

**Note on AI assistance:** this PR was drafted with AI assistance per
`CONTRIBUTING.md`; the code was written by matching the existing
`clients/fetch` and `clients/payment-identifier` examples line-for-line in
structure, and I've verified the target endpoint's 402/409/200 behavior
against `curl` before writing this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2BujkiGfTPuEv29WvNG4x